### PR TITLE
Better context handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,8 +12,8 @@ var rootCmd = &cobra.Command{
 	Use:   "lstk",
 	Short: "LocalStack CLI",
 	Long:  "lstk is the command-line interface for LocalStack.",
-	Run: func(c *cobra.Command, args []string) {
-		if err := runStart(); err != nil {
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runStart(cmd.Context()); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -23,6 +24,6 @@ func init() {
 	rootCmd.AddCommand(startCmd)
 }
 
-func Execute() error {
-	return rootCmd.Execute()
+func Execute(ctx context.Context) error {
+	return rootCmd.ExecuteContext(ctx)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -14,16 +14,14 @@ var startCmd = &cobra.Command{
 	Short: "Start LocalStack",
 	Long:  "Start the LocalStack emulator.",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := runStart(); err != nil {
+		if err := runStart(cmd.Context()); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 	},
 }
 
-func runStart() error {
-	ctx := context.Background()
-
+func runStart(ctx context.Context) error {
 	rt, err := runtime.NewDockerRuntime()
 	if err != nil {
 		return fmt.Errorf("failed to create runtime: %w", err)

--- a/main.go
+++ b/main.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/localstack/lstk/cmd"
 )
 
 func main() {
-	if err := cmd.Execute(); err != nil {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := cmd.Execute(ctx); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This allows gracefully cancel of ongoing runtime (docker) operations instead of killing the process abruptly.

- Create root context with `signal.NotifyContext`. Cancel when signals `SIGINT/Ctrl+C` and `SIGTERM` are received.

- Pass context to cobra and to commands and runtime operations.

towards DRG-352

