### PR TITLE
Handle container startup failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 test-integration: build
-	cd test/integration && go test -v .
+	cd test/integration && go test -count=1 -v .

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +15,17 @@ var rootCmd = &cobra.Command{
 	Short: "LocalStack CLI",
 	Long:  "lstk is the command-line interface for LocalStack.",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := runStart(cmd.Context()); err != nil {
+		rt, err := runtime.NewDockerRuntime()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		onProgress := func(msg string) {
+			fmt.Println(msg)
+		}
+
+		if err := container.Start(cmd.Context(), rt, onProgress); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
+	"github.com/localstack/lstk/internal/container"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
@@ -14,61 +14,19 @@ var startCmd = &cobra.Command{
 	Short: "Start LocalStack",
 	Long:  "Start the LocalStack emulator.",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := runStart(cmd.Context()); err != nil {
+		rt, err := runtime.NewDockerRuntime()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		onProgress := func(msg string) {
+			fmt.Println(msg)
+		}
+
+		if err := container.Start(cmd.Context(), rt, onProgress); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 	},
-}
-
-func runStart(ctx context.Context) error {
-	rt, err := runtime.NewDockerRuntime()
-	if err != nil {
-		return fmt.Errorf("failed to create runtime: %w", err)
-	}
-
-	// TODO: hardcoded for now, later should be configurable
-	containers := []runtime.ContainerConfig{
-		{
-			Image: "localstack/localstack-pro:latest",
-			Name:  "localstack-aws",
-			Ports: map[string]string{"4566/tcp": "4566"},
-		},
-	}
-
-	for _, config := range containers {
-		fmt.Printf("Pulling %s...\n", config.Image)
-		progress := make(chan runtime.PullProgress)
-		go func() {
-			for p := range progress {
-				if p.Total > 0 {
-					fmt.Printf("  %s: %s %.1f%%\n", p.LayerID, p.Status, float64(p.Current)/float64(p.Total)*100)
-				} else if p.Status != "" {
-					fmt.Printf("  %s: %s\n", p.LayerID, p.Status)
-				}
-			}
-		}()
-		if err := rt.PullImage(ctx, config.Image, progress); err != nil {
-			return fmt.Errorf("failed to pull image %s: %w", config.Image, err)
-		}
-
-		fmt.Printf("Starting %s...\n", config.Name)
-		containerID, err := rt.Start(ctx, config)
-		if err != nil {
-			return fmt.Errorf("failed to start %s: %w", config.Name, err)
-		}
-
-		running, err := rt.IsRunning(ctx, containerID)
-		if err != nil {
-			return fmt.Errorf("failed to check status of %s: %w", config.Name, err)
-		}
-
-		if !running {
-			return fmt.Errorf("container %s failed to start", config.Name)
-		}
-
-		fmt.Printf("%s running (container: %s)\n", config.Name, containerID[:12])
-	}
-
-	return nil
 }

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -1,0 +1,93 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+func Start(ctx context.Context, rt runtime.Runtime, onProgress func(string)) error {
+	// TODO: hardcoded for now, later should be configurable
+	containers := []runtime.ContainerConfig{
+		{
+			Image:      "localstack/localstack-pro:latest",
+			Name:       "localstack-aws",
+			Port:       "4566",
+			HealthPath: "/_localstack/health",
+		},
+	}
+
+	for _, config := range containers {
+		onProgress(fmt.Sprintf("Pulling %s...", config.Image))
+		progress := make(chan runtime.PullProgress)
+		go func() {
+			for p := range progress {
+				if p.Total > 0 {
+					onProgress(fmt.Sprintf("  %s: %s %.1f%%", p.LayerID, p.Status, float64(p.Current)/float64(p.Total)*100))
+				} else if p.Status != "" {
+					onProgress(fmt.Sprintf("  %s: %s", p.LayerID, p.Status))
+				}
+			}
+		}()
+		if err := rt.PullImage(ctx, config.Image, progress); err != nil {
+			return fmt.Errorf("failed to pull image %s: %w", config.Image, err)
+		}
+
+		onProgress(fmt.Sprintf("Starting %s...", config.Name))
+		containerID, err := rt.Start(ctx, config)
+		if err != nil {
+			return fmt.Errorf("failed to start %s: %w", config.Name, err)
+		}
+
+		onProgress(fmt.Sprintf("Waiting for %s to be ready...", config.Name))
+		healthURL := fmt.Sprintf("http://localhost:%s%s", config.Port, config.HealthPath)
+		if err := awaitStartup(ctx, rt, containerID, config.Name, healthURL); err != nil {
+			return err
+		}
+
+		onProgress(fmt.Sprintf("%s ready (container: %s)", config.Name, containerID[:12]))
+	}
+
+	return nil
+}
+
+// awaitStartup polls until one of two outcomes:
+//   - Success: health endpoint returns 200 (license is valid, LocalStack is ready)
+//   - Failure: container stops running (e.g., license activation failed), returns error with container logs
+//
+// TODO: move to Runtime interface if other runtimes (k8s?) need native readiness probes
+func awaitStartup(ctx context.Context, rt runtime.Runtime, containerID, name, healthURL string) error {
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	for {
+		running, err := rt.IsRunning(ctx, containerID)
+		if err != nil {
+			return fmt.Errorf("failed to check container status: %w", err)
+		}
+		if !running {
+			logs, logsErr := rt.Logs(ctx, containerID, 20)
+			if logsErr != nil || logs == "" {
+				return fmt.Errorf("%s exited unexpectedly", name)
+			}
+			return fmt.Errorf("%s exited unexpectedly:\n%s", name, logs)
+		}
+
+		resp, err := client.Get(healthURL)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -3,9 +3,10 @@ package runtime
 import "context"
 
 type ContainerConfig struct {
-	Image string
-	Name  string
-	Ports map[string]string
+	Image      string
+	Name       string
+	Port       string
+	HealthPath string
 }
 
 type PullProgress struct {
@@ -20,4 +21,5 @@ type Runtime interface {
 	PullImage(ctx context.Context, image string, progress chan<- PullProgress) error
 	Start(ctx context.Context, config ContainerConfig) (string, error)
 	IsRunning(ctx context.Context, containerID string) (bool, error)
+	Logs(ctx context.Context, containerID string, tail int) (string, error)
 }

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -13,7 +13,7 @@ import (
 
 const containerName = "localstack-aws"
 
-func TestStartCommand(t *testing.T) {
+func TestStartCommandFailsWithoutAuth(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
@@ -22,12 +22,9 @@ func TestStartCommand(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, "../../bin/lstk", "start")
 	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, "lstk start failed: %s", output)
 
-	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
-	require.NoError(t, err, "failed to inspect container")
-
-	assert.True(t, inspect.State.Running, "container is not running, state: %s", inspect.State.Status)
+	require.Error(t, err, "expected lstk start to fail without auth")
+	assert.Contains(t, string(output), "License activation failed")
 }
 
 func cleanup() {


### PR DESCRIPTION
- Retrieve container logs when startup fails, and output the actual error instead of generic "container exited unexpectedly". We should make it look prettier in the future with bubbletea. For now we just output the raw docker logs.
- Moved business logic from `cmd/` to `internal/container/` 
- Transformed the one integration test to a failure case since auth token handling is not yet implemented. It will come together with a success test case in a subsequent PR.

### How to test
- `make test-integration` passes
- `./bin/lstk start` shows license error

Sample output:

 ```
❯ make build && ./bin/lstk
go build -o bin/lstk .
Pulling localstack/localstack-pro:latest...
  latest: Pulling from localstack/localstack-pro
  : Digest: sha256:47b0373bc10996b5333e5e116dd5d788f58d6035c75fb73376833abe62d2b16a
  : Status: Image is up to date for localstack/localstack-pro:latest
Starting localstack-aws...
Waiting for localstack-aws to be ready...
Error: localstack-aws exited unexpectedly:

 LocalStack version: 4.13.1.dev3
"LocalStack build date: 2026-01-30
%LocalStack build git hash: 6cb59848d

1Localstack returning with exit code 55. Reason:
0===============================================
#License activation failed! 🔑❌

�Reason: No credentials were found in the environment. Please make sure to either set the LOCALSTACK_AUTH_TOKEN variable to a valid auth token. If you are using the CLI, you can also run `localstack auth set-token`.

gDue to this error, Localstack has quit. LocalStack pro features can only be used with a valid license.

_- Please check that your credentials are set up correctly and that you have an active license.
O  You can find your credentials in our webapp at https://app.localstack.cloud.
^- If you want to continue using LocalStack without pro features you can set `ACTIVATE_PRO=0`.
```

toward DRG-352
