### PR TITLE
Browser authentication flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.6
 require (
 	github.com/docker/docker v28.2.2+incompatible
 	github.com/docker/go-connections v0.5.0
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -116,6 +118,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,16 +1,25 @@
 package auth
 
 import (
-	"errors"
+	"context"
+	"log"
 	"os"
 )
 
-// GetToken returns the auth token from keyring or environment variable.
-func GetToken() (string, error) {
-	// TODO: try keyring first
+// GetToken tries in order: 1) keychain 2) LOCALSTACK_AUTH_TOKEN env var 3) browser login
+func GetToken(ctx context.Context) (string, error) {
+	// TODO: try keychain first
 
 	if token := os.Getenv("LOCALSTACK_AUTH_TOKEN"); token != "" {
 		return token, nil
 	}
-	return "", errors.New("auth token not found, please set LOCALSTACK_AUTH_TOKEN")
+
+	log.Println("Authentication required. Opening browser...")
+	token, err := Login(ctx)
+	if err != nil {
+		log.Println("Authentication failed.")
+		return "", err
+	}
+	log.Println("Login successful.")
+	return token, nil
 }

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/pkg/browser"
+)
+
+func getWebAppURL() string {
+	// allows overriding the URL for testing
+	if url := os.Getenv("LOCALSTACK_WEB_APP_URL"); url != "" {
+		return url
+	}
+	return "https://app.localstack.cloud"
+}
+
+func Login(ctx context.Context) (string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:45678")
+	if err != nil {
+		return "", fmt.Errorf("failed to start callback server: %w", err)
+	}
+	defer listener.Close()
+
+	tokenCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/success", func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		if token == "" {
+			errCh <- fmt.Errorf("no token in callback")
+			http.Error(w, "No token received", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		tokenCh <- token
+	})
+	server := &http.Server{Handler: mux}
+	go server.Serve(listener)
+	defer server.Shutdown(ctx)
+
+	loginURL := fmt.Sprintf("%s/redirect?name=CLI", getWebAppURL())
+	if err := browser.OpenURL(loginURL); err != nil {
+		log.Printf("Could not open browser. Please visit: %s", loginURL)
+	}
+
+	select {
+	case token := <-tokenCh:
+		return token, nil
+	case err := <-errCh:
+		return "", err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Start(ctx context.Context, rt runtime.Runtime, onProgress func(string)) error {
-	token, err := auth.GetToken()
+	token, err := auth.GetToken(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Changes
- Implements browser-based login when no auth token is saved or set in env var (CLI opens browser to LocalStack webapp, receives token via local callback server)
- Starts an HTTP server in order to receive the callback from the webapp (the call will be implemented in the webapp in a subsequent PR)
- Falls back gracefully by printing the URL if browser cannot be opened
**Dependencies**
- Added `github.com/pkg/browser` for cross-platform browser opening

### Integration test
- `TestStartCommandTriggersLoginWithoutToken`: simulates browser callback to verify that the login flow works  (`LOCALSTACK_WEB_APP_URL` env var allows overriding webapp URL for testing)

### TODO
- handle `/redirect?name=CLI` in webapp and execute CLI callback
- save the received auth token
