### PR TITLE
Add golangci-lint locally and in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.8.0
+          version-file: .tool-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version-file: .tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+golangci-lint 2.8.0

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,9 @@ test-integration: build
 
 mock-generate:
 	go generate ./...
-GOLANGCI_LINT_VERSION := 2.8.0
 
 lint:
-	@which golangci-lint > /dev/null || (echo "golangci-lint not found." && exit 1)
-	@INSTALLED=$$(golangci-lint version --short | sed 's/^v//'); \
-	if [ "$$INSTALLED" != "$(GOLANGCI_LINT_VERSION)" ]; then \
-		echo "golangci-lint version mismatch: installed $$INSTALLED, expected $(GOLANGCI_LINT_VERSION)"; \
-		exit 1; \
-	fi
+	@EXPECTED=$$(awk '/^golangci-lint/ {print $$2}' .tool-versions); \
+	INSTALLED=$$(golangci-lint version --short 2>/dev/null | sed 's/^v//'); \
+	[ "$$INSTALLED" = "$$EXPECTED" ] || { echo "golangci-lint $$EXPECTED required (found: $$INSTALLED)"; exit 1; }
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY_NAME=lstk
 BUILD_DIR=bin
 
-.PHONY: build clean test test-integration mock-generate
+.PHONY: build clean test test-integration lint mock-generate
 
 build:
 	go build -o $(BUILD_DIR)/$(BINARY_NAME) .
@@ -17,3 +17,13 @@ test-integration: build
 
 mock-generate:
 	go generate ./...
+GOLANGCI_LINT_VERSION := 2.8.0
+
+lint:
+	@which golangci-lint > /dev/null || (echo "golangci-lint not found." && exit 1)
+	@INSTALLED=$$(golangci-lint version --short | sed 's/^v//'); \
+	if [ "$$INSTALLED" != "$(GOLANGCI_LINT_VERSION)" ]; then \
+		echo "golangci-lint version mismatch: installed $$INSTALLED, expected $(GOLANGCI_LINT_VERSION)"; \
+		exit 1; \
+	fi
+	golangci-lint run


### PR DESCRIPTION
Adds:
* golangci-lint in default settings to the CI
* make target to run it (and to check that the same version is used as in CI to avoid confusion)