### PR TITLE
Add Unit/Integration testing jobs to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint/Test
+name: LSTK CI
 
 on:
   push:
@@ -82,6 +82,7 @@ jobs:
         run: make test-integration
         env:
           CREATE_JUNIT_REPORT: "true"
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,36 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version-file: .tool-versions
+
+  test-unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run unit tests
+        run: make test
+
+  test-integration:
+    name: Integration Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run integration tests
+        run: make test-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache-dependency-path: go.sum
 
       - name: Run unit tests
         run: make test
@@ -77,6 +78,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            test/integration/go.sum
 
       - name: Run integration tests
         run: make test-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Lint/Test
 
 on:
   push:
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
+  checks: write
 
 jobs:
   lint:
@@ -33,15 +35,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run unit tests
         run: make test
+        env:
+          CREATE_JUNIT_REPORT: "true"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-test-results
+          path: test-results.xml
+
+      - name: Test report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Unit Test Results
+          path: test-results.xml
+          reporter: java-junit
 
   test-integration:
     name: Integration Tests (${{ matrix.os }})
@@ -51,12 +70,29 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run integration tests
         run: make test-integration
+        env:
+          CREATE_JUNIT_REPORT: "true"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: integration-test-results-${{ matrix.os }}
+          path: test-integration-results.xml
+
+      - name: Test report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Integration Test Results (${{ matrix.os }})
+          path: test-integration-results.xml
+          reporter: java-junit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     name: Integration Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,12 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 test:
-	go test ./cmd/... ./internal/...
+	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile test-results.xml"; \
+	go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- ./cmd/... ./internal/...
 
 test-integration: build
-	cd test/integration && go test -count=1 -v .
+	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
+	cd test/integration && go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...
 
 mock-generate:
 	go generate ./...

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 test:
-	go test ./internal/...
+	go test ./cmd/... ./internal/...
 
 test-integration: build
 	cd test/integration && go test -count=1 -v .

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -1,18 +1,28 @@
 package integration_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/docker/client"
 )
 
 var dockerClient *client.Client
+var dockerAvailable bool
 
 func TestMain(m *testing.M) {
 	var err error
 	dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	if err != nil {
-		panic(err)
+	if err == nil {
+		_, err = dockerClient.Ping(context.Background())
+		dockerAvailable = err == nil
 	}
 	m.Run()
+}
+
+func requireDocker(t *testing.T) {
+	t.Helper()
+	if !dockerAvailable {
+		t.Skip("Docker is not available")
+	}
 }

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -22,6 +22,7 @@ const (
 const containerName = "localstack-aws"
 
 func TestStartCommandSucceedsWithValidToken(t *testing.T) {
+	requireDocker(t)
 	authToken := os.Getenv("LOCALSTACK_AUTH_TOKEN")
 	require.NotEmpty(t, authToken, "LOCALSTACK_AUTH_TOKEN must be set to run this test")
 
@@ -43,6 +44,7 @@ func TestStartCommandSucceedsWithValidToken(t *testing.T) {
 }
 
 func TestStartCommandTriggersLoginWithoutToken(t *testing.T) {
+	requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
 
@@ -80,6 +82,7 @@ func TestStartCommandTriggersLoginWithoutToken(t *testing.T) {
 }
 
 func TestStartCommandSucceedsWithKeyringToken(t *testing.T) {
+	requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
 
@@ -105,6 +108,7 @@ func TestStartCommandSucceedsWithKeyringToken(t *testing.T) {
 }
 
 func TestStartCommandFailsWithInvalidToken(t *testing.T) {
+	requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
 


### PR DESCRIPTION
* Add pipelines for integration and unit tests
* Integration tests run for Linux, macOS and Windows
* Results are available in a nice format when clicking on the "results" check


Note: the integration tests are failing currently for different reasons. Most of it is connected to macOS and windows runners not having docker. I've added a skipping mechanism for this. 

However, for the other ones it might make sense to solve it in separate PRs.