### PR TITLE
Fix binary path in integration tests for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,15 +82,7 @@ jobs:
             go.sum
             test/integration/go.sum
 
-      - name: Debug - List bin directory after build
-        shell: bash
-        run: |
-          make build
-          echo "Contents of bin directory:"
-          ls -la bin/
-
       - name: Run integration tests
-        shell: bash
         run: make test-integration
         env:
           CREATE_JUNIT_REPORT: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           ls -la bin/
 
       - name: Run integration tests
+        shell: bash
         run: make test-integration
         env:
           CREATE_JUNIT_REPORT: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,13 @@ jobs:
             go.sum
             test/integration/go.sum
 
+      - name: Debug - List bin directory after build
+        shell: bash
+        run: |
+          make build
+          echo "Contents of bin directory:"
+          ls -la bin/
+
       - name: Run integration tests
         run: make test-integration
         env:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ BUILD_DIR=bin
 
 .PHONY: build clean test test-integration lint mock-generate
 
-build:
+$(BUILD_DIR)/$(BINARY_NAME):
 	go build -o $(BUILD_DIR)/$(BINARY_NAME) .
+
+build: clean $(BUILD_DIR)/$(BINARY_NAME)
 
 clean:
 	rm -rf $(BUILD_DIR)
@@ -13,7 +15,7 @@ test:
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile test-results.xml"; \
 	go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- ./cmd/... ./internal/...
 
-test-integration: build
+test-integration: $(BUILD_DIR)/$(BINARY_NAME)
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
 	cd test/integration && go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 BINARY_NAME=lstk
+ifeq ($(OS),Windows_NT)
+    BINARY_NAME=lstk.exe
+endif
 BUILD_DIR=bin
 
 .PHONY: build clean test test-integration lint mock-generate

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -34,7 +34,7 @@ func TestConfigFileCreatedOnStartup(t *testing.T) {
 
 	configFile := filepath.Join(configDir, "config.toml")
 
-	cmd := exec.Command(binaryPath(), "start")
+	cmd := exec.Command("../../bin/lstk", "start")
 	cmd.Env = env
 	err := cmd.Start()
 	require.NoError(t, err, "failed to start lstk")

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -34,7 +34,7 @@ func TestConfigFileCreatedOnStartup(t *testing.T) {
 
 	configFile := filepath.Join(configDir, "config.toml")
 
-	cmd := exec.Command("../../bin/lstk", "start")
+	cmd := exec.Command(binaryPath(), "start")
 	cmd.Env = env
 	err := cmd.Start()
 	require.NoError(t, err, "failed to start lstk")

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -34,9 +34,10 @@ func TestConfigFileCreatedOnStartup(t *testing.T) {
 
 	configFile := filepath.Join(configDir, "config.toml")
 
-	cmd := exec.Command("../../bin/lstk", "start")
+	cmd := exec.Command(binaryPath(), "start")
 	cmd.Env = env
-	cmd.Start()
+	err := cmd.Start()
+	require.NoError(t, err, "failed to start lstk")
 	defer cmd.Process.Kill()
 
 	// Poll for config file creation - check every 50ms, timeout after 2s

--- a/test/integration/logout_test.go
+++ b/test/integration/logout_test.go
@@ -26,7 +26,7 @@ func TestLogoutCommandRemovesToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "logout")
+	cmd := exec.CommandContext(ctx, "../../bin/lstk", "logout")
 	output, err := cmd.CombinedOutput()
 
 	require.NoError(t, err, "lstk logout failed: %s", output)
@@ -44,7 +44,7 @@ func TestLogoutCommandSucceedsWhenNoToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "logout")
+	cmd := exec.CommandContext(ctx, "../../bin/lstk", "logout")
 	output, err := cmd.CombinedOutput()
 
 	// Should succeed even if no token

--- a/test/integration/logout_test.go
+++ b/test/integration/logout_test.go
@@ -26,7 +26,7 @@ func TestLogoutCommandRemovesToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "../../bin/lstk", "logout")
+	cmd := exec.CommandContext(ctx, binaryPath(), "logout")
 	output, err := cmd.CombinedOutput()
 
 	require.NoError(t, err, "lstk logout failed: %s", output)
@@ -44,7 +44,7 @@ func TestLogoutCommandSucceedsWhenNoToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "../../bin/lstk", "logout")
+	cmd := exec.CommandContext(ctx, binaryPath(), "logout")
 	output, err := cmd.CombinedOutput()
 
 	// Should succeed even if no token

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -2,18 +2,10 @@ package integration_test
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	"github.com/docker/docker/client"
 )
-
-func binaryPath() string {
-	if runtime.GOOS == "windows" {
-		return "../../bin/lstk.exe"
-	}
-	return "../../bin/lstk"
-}
 
 var dockerClient *client.Client
 var dockerAvailable bool

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -2,10 +2,18 @@ package integration_test
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/docker/docker/client"
 )
+
+func binaryPath() string {
+	if runtime.GOOS == "windows" {
+		return "../../bin/lstk.exe"
+	}
+	return "../../bin/lstk"
+}
 
 var dockerClient *client.Client
 var dockerAvailable bool

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -44,7 +44,7 @@ func TestStartCommandSucceedsWithValidToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "../../bin/lstk", "start")
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
 	cmd.Env = append(os.Environ(), "LOCALSTACK_AUTH_TOKEN="+authToken)
 	output, err := cmd.CombinedOutput()
 
@@ -63,7 +63,7 @@ func TestStartCommandTriggersLoginWithoutToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "../../bin/lstk", "start")
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
 	cmd.Env = envWithoutAuthToken()
 
 	// Capture output asynchronously
@@ -108,7 +108,7 @@ func TestStartCommandSucceedsWithKeyringToken(t *testing.T) {
 	defer cancel()
 
 	// Run without LOCALSTACK_AUTH_TOKEN should use keyring
-	cmd := exec.CommandContext(ctx, "../../bin/lstk", "start")
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
 	cmd.Env = envWithoutAuthToken()
 	output, err := cmd.CombinedOutput()
 
@@ -127,7 +127,7 @@ func TestStartCommandFailsWithInvalidToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "../../bin/lstk", "start")
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
 	cmd.Env = append(os.Environ(), "LOCALSTACK_AUTH_TOKEN=invalid-token")
 	output, err := cmd.CombinedOutput()
 

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -44,7 +44,7 @@ func TestStartCommandSucceedsWithValidToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd := exec.CommandContext(ctx, "../../bin/lstk", "start")
 	cmd.Env = append(os.Environ(), "LOCALSTACK_AUTH_TOKEN="+authToken)
 	output, err := cmd.CombinedOutput()
 
@@ -63,7 +63,7 @@ func TestStartCommandTriggersLoginWithoutToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd := exec.CommandContext(ctx, "../../bin/lstk", "start")
 	cmd.Env = envWithoutAuthToken()
 
 	// Capture output asynchronously
@@ -108,7 +108,7 @@ func TestStartCommandSucceedsWithKeyringToken(t *testing.T) {
 	defer cancel()
 
 	// Run without LOCALSTACK_AUTH_TOKEN should use keyring
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd := exec.CommandContext(ctx, "../../bin/lstk", "start")
 	cmd.Env = envWithoutAuthToken()
 	output, err := cmd.CombinedOutput()
 
@@ -127,7 +127,7 @@ func TestStartCommandFailsWithInvalidToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd := exec.CommandContext(ctx, "../../bin/lstk", "start")
 	cmd.Env = append(os.Environ(), "LOCALSTACK_AUTH_TOKEN=invalid-token")
 	output, err := cmd.CombinedOutput()
 


### PR DESCRIPTION
- Change to build a file ending with .exe for windows
- Add a `binaryPath` helper to the integration tests which returns a different path for windows.

This should fix the config test on windows.

Also:
- Adapt the Makefile so that `make integration` depends on the build artifact itself, not the build target

What's missing still is that `docker` apparently is available on windows but it doesn't work properly because it can't pull the image? Should be a follow-up fix.