### PR TITLE
Validate license before starting container

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/auth"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/spf13/cobra"
@@ -15,7 +16,8 @@ var loginCmd = &cobra.Command{
 	Long:  "Authenticate with LocalStack and store credentials in system keyring",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sink := output.NewPlainSink(os.Stdout)
-		a, err := auth.New(sink)
+		platformClient := api.NewPlatformClient()
+		a, err := auth.New(sink, platformClient)
 		if err != nil {
 			return fmt.Errorf("failed to initialize auth: %w", err)
 		}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/auth"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/spf13/cobra"
@@ -14,7 +15,8 @@ var logoutCmd = &cobra.Command{
 	Short: "Remove stored authentication token",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sink := output.NewPlainSink(os.Stdout)
-		a, err := auth.New(sink)
+		platformClient := api.NewPlatformClient()
+		a, err := auth.New(sink, platformClient)
 		if err != nil {
 			return fmt.Errorf("failed to initialize auth: %w", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/container"
 	"github.com/localstack/lstk/internal/output"
@@ -42,5 +43,5 @@ func Execute(ctx context.Context) error {
 }
 
 func runStart(ctx context.Context, rt runtime.Runtime) error {
-	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout))
+	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout), api.NewPlatformClient())
 }

--- a/env.example
+++ b/env.example
@@ -2,3 +2,6 @@ export LOCALSTACK_AUTH_TOKEN=ls-...
 
 # Force file-based keyring backend (instead of system keychain)
 # export KEYRING=file
+#
+export LOCALSTACK_API_ENDPOINT=https://api.staging.aws.localstack.cloud
+export LOCALSTACK_WEB_APP_URL=https://app.staging.aws.localstack.cloud

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/99designs/keyring"
+	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/output"
 )
 
@@ -16,14 +17,14 @@ type Auth struct {
 	sink         output.Sink
 }
 
-func New(sink output.Sink) (*Auth, error) {
+func New(sink output.Sink, platformClient api.PlatformAPI) (*Auth, error) {
 	kr, err := newSystemKeyring()
 	if err != nil {
 		return nil, err
 	}
 	return &Auth{
 		keyring:      kr,
-		browserLogin: newBrowserLogin(sink),
+		browserLogin: newBrowserLogin(sink, platformClient),
 		sink:         sink,
 	}, nil
 }

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -27,9 +27,9 @@ type browserLogin struct {
 	sink           output.Sink
 }
 
-func newBrowserLogin(sink output.Sink) *browserLogin {
+func newBrowserLogin(sink output.Sink, platformClient api.PlatformAPI) *browserLogin {
 	return &browserLogin{
-		platformClient: api.NewPlatformClient(),
+		platformClient: platformClient,
 		sink:           sink,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,8 @@ const (
 	EmulatorAWS       EmulatorType = "aws"
 	EmulatorSnowflake EmulatorType = "snowflake"
 	EmulatorAzure     EmulatorType = "azure"
+
+	dockerRegistry = "localstack"
 )
 
 var emulatorImages = map[EmulatorType]string{
@@ -44,7 +46,7 @@ func (c *ContainerConfig) Image() (string, error) {
 	if tag == "" {
 		tag = "latest"
 	}
-	return fmt.Sprintf("localstack/%s:%s", productName, tag), nil
+	return fmt.Sprintf("%s/%s:%s", dockerRegistry, productName, tag), nil
 }
 
 // Name returns the container name: "localstack-{type}" or "localstack-{type}-{tag}" if tag != latest

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ const (
 )
 
 var emulatorImages = map[EmulatorType]string{
-	EmulatorAWS: "localstack/localstack-pro",
+	EmulatorAWS: "localstack-pro",
 }
 
 var emulatorHealthPaths = map[EmulatorType]string{
@@ -36,15 +36,15 @@ type ContainerConfig struct {
 }
 
 func (c *ContainerConfig) Image() (string, error) {
-	baseImage, ok := emulatorImages[c.Type]
-	if !ok {
-		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
+	productName, err := c.ProductName()
+	if err != nil {
+		return "", err
 	}
 	tag := c.Tag
 	if tag == "" {
 		tag = "latest"
 	}
-	return fmt.Sprintf("%s:%s", baseImage, tag), nil
+	return fmt.Sprintf("localstack/%s:%s", productName, tag), nil
 }
 
 // Name returns the container name: "localstack-{type}" or "localstack-{type}-{tag}" if tag != latest
@@ -62,6 +62,14 @@ func (c *ContainerConfig) HealthPath() (string, error) {
 		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
 	}
 	return path, nil
+}
+
+func (c *ContainerConfig) ProductName() (string, error) {
+	productName, ok := emulatorImages[c.Type]
+	if !ok {
+		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
+	}
+	return productName, nil
 }
 
 func ConfigDir() (string, error) {

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -3,7 +3,6 @@ package container
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	stdruntime "runtime"
@@ -106,14 +105,9 @@ func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, 
 	if version == "" || version == "latest" {
 		actualVersion, err := rt.GetImageVersion(ctx, containerConfig.Image)
 		if err != nil {
-			log.Printf("Could not resolve version from image %s: %v", containerConfig.Image, err)
-			if version == "" {
-				version = "latest"
-			}
-		} else {
-			log.Printf("Resolved version for %s: %s", containerConfig.Image, actualVersion)
-			version = actualVersion
+			return fmt.Errorf("could not resolve version from image %s: %w", containerConfig.Image, err)
 		}
+		version = actualVersion
 	}
 
 	productName, err := cfgContainer.ProductName()

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -3,18 +3,22 @@ package container
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
+	"os"
+	stdruntime "runtime"
 	"time"
 
 	"github.com/containerd/errdefs"
+	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/auth"
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 )
 
-func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink) error {
-	a, err := auth.New(sink)
+func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, platformClient api.PlatformAPI) error {
+	a, err := auth.New(sink, platformClient)
 	if err != nil {
 		return fmt.Errorf("failed to initialize auth: %w", err)
 	}
@@ -50,6 +54,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink) error {
 		}
 	}
 
+	// Pull all images first
 	for _, config := range containers {
 		// Remove any existing stopped container with the same name
 		if err := rt.Remove(ctx, config.Name); err != nil && !errdefs.IsNotFound(err) {
@@ -66,7 +71,18 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink) error {
 		if err := rt.PullImage(ctx, config.Image, progress); err != nil {
 			return fmt.Errorf("failed to pull image %s: %w", config.Image, err)
 		}
+	}
 
+	// TODO validate license for tag "latest" without resolving the actual image version,
+	// and avoid pulling all images first
+	for i, c := range cfg.Containers {
+		if err := validateLicense(ctx, rt, sink, platformClient, containers[i], &c, token); err != nil {
+			return err
+		}
+	}
+
+	// Start containers
+	for _, config := range containers {
 		output.EmitStatus(sink, "starting", config.Name, "")
 		containerID, err := rt.Start(ctx, config)
 		if err != nil {
@@ -80,6 +96,50 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink) error {
 		}
 
 		output.EmitStatus(sink, "ready", config.Name, fmt.Sprintf("containerId: %s", containerID[:12]))
+	}
+
+	return nil
+}
+
+func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, platformClient api.PlatformAPI, containerConfig runtime.ContainerConfig, cfgContainer *config.ContainerConfig, token string) error {
+	version := cfgContainer.Tag
+	if version == "" || version == "latest" {
+		actualVersion, err := rt.GetImageVersion(ctx, containerConfig.Image)
+		if err != nil {
+			log.Printf("Could not resolve version from image %s: %v", containerConfig.Image, err)
+			if version == "" {
+				version = "latest"
+			}
+		} else {
+			log.Printf("Resolved version for %s: %s", containerConfig.Image, actualVersion)
+			version = actualVersion
+		}
+	}
+
+	productName, err := cfgContainer.ProductName()
+	if err != nil {
+		return err
+	}
+	output.EmitStatus(sink, "validating license", containerConfig.Name, version)
+
+	hostname, _ := os.Hostname()
+	licenseReq := &api.LicenseRequest{
+		Product: api.ProductInfo{
+			Name:    productName,
+			Version: version,
+		},
+		Credentials: api.CredentialsInfo{
+			Token: token,
+		},
+		Machine: api.MachineInfo{
+			Hostname:        hostname,
+			Platform:        stdruntime.GOOS,
+			PlatformRelease: stdruntime.GOARCH,
+		},
+	}
+
+	if err := platformClient.GetLicense(ctx, licenseReq); err != nil {
+		return fmt.Errorf("license validation failed for %s:%s: %w", productName, version, err)
 	}
 
 	return nil

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -25,4 +25,5 @@ type Runtime interface {
 	Remove(ctx context.Context, containerName string) error
 	IsRunning(ctx context.Context, containerID string) (bool, error)
 	Logs(ctx context.Context, containerID string, tail int) (string, error)
+	GetImageVersion(ctx context.Context, imageName string) (string, error)
 }

--- a/test/integration/license_test.go
+++ b/test/integration/license_test.go
@@ -1,0 +1,117 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const licenseContainerName = "localstack-aws"
+
+func TestLicenseValidationSuccess(t *testing.T) {
+	requireDocker(t)
+	authToken := os.Getenv("LOCALSTACK_AUTH_TOKEN")
+	require.NotEmpty(t, authToken, "LOCALSTACK_AUTH_TOKEN must be set to run this test")
+
+	cleanupLicense()
+	t.Cleanup(cleanupLicense)
+
+	validationErrors := make(chan error, 1)
+
+	// Mock platform API that returns success
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/license/request" && r.Method == http.MethodPost {
+			var req map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "invalid request", http.StatusBadRequest)
+				return
+			}
+
+			// Validate with safe type assertions
+			product, ok := req["product"].(map[string]interface{})
+			if !ok || product["name"] != "localstack-pro" {
+				validationErrors <- fmt.Errorf("invalid product field")
+				http.Error(w, "invalid product", http.StatusBadRequest)
+				return
+			}
+
+			credentials, ok := req["credentials"].(map[string]interface{})
+			if !ok || credentials["token"] != authToken {
+				validationErrors <- fmt.Errorf("invalid credentials field")
+				http.Error(w, "invalid credentials", http.StatusBadRequest)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mockServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd.Env = append(
+		os.Environ(),
+		"LOCALSTACK_API_ENDPOINT="+mockServer.URL,
+	)
+	output, err := cmd.CombinedOutput()
+
+	// Check for validation errors from handler
+	select {
+	case validationErr := <-validationErrors:
+		t.Fatalf("request validation failed: %v", validationErr)
+	default:
+	}
+
+	require.NoError(t, err, "lstk start failed: %s", output)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, licenseContainerName)
+	require.NoError(t, err, "failed to inspect container")
+	assert.True(t, inspect.State.Running, "container should be running")
+}
+
+func TestLicenseValidationFailure(t *testing.T) {
+	requireDocker(t)
+	cleanupLicense()
+	t.Cleanup(cleanupLicense)
+
+	mockServer := createMockLicenseServer(false)
+	defer mockServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd.Env = append(
+		os.Environ(),
+		"LOCALSTACK_API_ENDPOINT="+mockServer.URL,
+	)
+	output, err := cmd.CombinedOutput()
+
+	require.Error(t, err, "expected lstk start to fail with forbidden license")
+	assert.Contains(t, string(output), "license validation failed")
+	assert.Contains(t, string(output), "invalid, inactive, or expired")
+
+	// Verify container was not started
+	_, err = dockerClient.ContainerInspect(ctx, licenseContainerName)
+	assert.Error(t, err, "container should not exist after license failure")
+}
+
+func cleanupLicense() {
+	ctx := context.Background()
+	_ = dockerClient.ContainerStop(ctx, licenseContainerName, container.StopOptions{})
+	_ = dockerClient.ContainerRemove(ctx, licenseContainerName, container.RemoveOptions{Force: true})
+}


### PR DESCRIPTION
The CLI now validates licenses upfront via the platform API, providing clear error messages if validation fails, rather than waiting for the container to fail during startup.
This should be further improved in the future by resolving the version for the `latest` tag without having to pull the images (DRG-504, DRG-508).