### PR TITLE
Add dependabot config to update go and dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      go-version:
+        patterns:
+          - "go"
+      dependencies:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,15 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-    groups:
-      go-version:
-        patterns:
-          - "go"
-      dependencies:
-        patterns:
-          - "*"
+      interval: "daily"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10

--- a/.github/workflows/weekly-go-upgrade.yml
+++ b/.github/workflows/weekly-go-upgrade.yml
@@ -1,0 +1,42 @@
+name: Weekly Go Upgrade
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade-go:
+    name: Upgrade Go Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Upgrade Go version
+        run: |
+          go get go@latest
+          go mod tidy
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/weekly-go-upgrade
+          commit-message: "chore(go): weekly Go upgrade"
+          title: "chore(go): weekly Go upgrade"
+          body: |
+            Automated weekly Go upgrade.
+
+            - Updates the `go` directive to the latest released Go version.
+            - Runs `go mod tidy` to keep module files consistent.
+          labels: dependencies
+          delete-branch: true


### PR DESCRIPTION
Go 1.26 is out. Would be nice to have an action just upgrading it for us and also our dependencies via dependabot while we're at it.
