### PR TITLE
Fix failing integration test on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile test-results.xml"; \
 	go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- ./cmd/... ./internal/...
 
-test-integration: $(BUILD_DIR)/$(BINARY_NAME)
+test-integration: build
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
 	cd test/integration && go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile test-results.xml"; \
 	go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- ./cmd/... ./internal/...
 
-test-integration: build
+test-integration: $(BUILD_DIR)/$(BINARY_NAME)
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
 	if [ "$$(uname)" = "Darwin" ]; then \
 		cd test/integration && KEYRING=file go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...; \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,11 @@ test:
 
 test-integration: build
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
-	cd test/integration && go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...
+	if [ "$$(uname)" = "Darwin" ]; then \
+		cd test/integration && KEYRING=file go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...; \
+	else \
+		cd test/integration && go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...; \
+	fi
 
 mock-generate:
 	go generate ./...

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/localstack/lstk/internal/auth"
+	"github.com/spf13/cobra"
+)
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Authenticate with LocalStack",
+	Long:  "Authenticate with LocalStack and store credentials in system keyring",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		a, err := auth.New()
+		if err != nil {
+			return fmt.Errorf("failed to initialize auth: %w", err)
+		}
+
+		_, err = a.GetToken(cmd.Context())
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("Login successful.")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(loginCmd)
+}

--- a/env.example
+++ b/env.example
@@ -1,1 +1,4 @@
 export LOCALSTACK_AUTH_TOKEN=ls-...
+
+# Force file-based keyring backend (instead of system keychain)
+# export KEYRING=file

--- a/internal/auth/keyring.go
+++ b/internal/auth/keyring.go
@@ -41,6 +41,11 @@ func newSystemKeyring() (*systemKeyring, error) {
 		},
 	}
 
+	// Force file backend if KEYRING env var is set to "file"
+	if os.Getenv("KEYRING") == "file" {
+		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}
+	}
+
 	ring, err := keyring.Open(keyringConfig)
 	if err != nil {
 		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"strconv"
@@ -46,6 +47,7 @@ func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progres
 		var msg struct {
 			Status         string `json:"status"`
 			ID             string `json:"id"`
+			Error          string `json:"error"`
 			ProgressDetail struct {
 				Current int64 `json:"current"`
 				Total   int64 `json:"total"`
@@ -55,6 +57,10 @@ func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progres
 			break
 		} else if err != nil {
 			return err
+		}
+
+		if msg.Error != "" {
+			return fmt.Errorf("image pull failed: %s", msg.Error)
 		}
 
 		if progress != nil {

--- a/test/integration/login_browser_flow_test.go
+++ b/test/integration/login_browser_flow_test.go
@@ -12,14 +12,13 @@ import (
 )
 
 func TestBrowserFlowStoresToken(t *testing.T) {
-	// requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd := exec.CommandContext(ctx, binaryPath(), "login")
 	cmd.Env = envWithoutAuthToken()
 
 	// Keep stdin open so ENTER listener doesn't trigger immediately
@@ -44,9 +43,8 @@ func TestBrowserFlowStoresToken(t *testing.T) {
 
 	out := <-output
 
-	// Login should succeed, but container will fail with invalid token
+	// Login should succeed
 	assert.Contains(t, string(out), "Login successful")
-	assert.Contains(t, string(out), "License activation failed")
 
 	// Verify token was stored in keyring
 	storedToken, err := keyringGet(keyringService, keyringUser)

--- a/test/integration/login_browser_flow_test.go
+++ b/test/integration/login_browser_flow_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBrowserFlowStoresToken(t *testing.T) {
-	requireDocker(t)
+	// requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
 

--- a/test/integration/login_device_flow_test.go
+++ b/test/integration/login_device_flow_test.go
@@ -62,7 +62,6 @@ func createMockAPIServer(t *testing.T, licenseToken string) *httptest.Server {
 }
 
 func TestDeviceFlowSuccess(t *testing.T) {
-	requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
 
@@ -74,10 +73,10 @@ func TestDeviceFlowSuccess(t *testing.T) {
 	mockServer := createMockAPIServer(t, licenseToken)
 	defer mockServer.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd := exec.CommandContext(ctx, binaryPath(), "login")
 	env := envWithoutAuthToken()
 	env = append(env, "LOCALSTACK_API_ENDPOINT="+mockServer.URL)
 	cmd.Env = env
@@ -111,37 +110,26 @@ func TestDeviceFlowSuccess(t *testing.T) {
 		assert.Contains(t, output, "Auth request confirmed")
 		assert.Contains(t, output, "Fetching license token")
 		assert.Contains(t, output, "Login successful")
-		// Container should start successfully with valid token
-		assert.NotContains(t, output, "License activation failed")
 
 		// Verify token was stored in keyring
 		storedToken, err := keyringGet(keyringService, keyringUser)
 		require.NoError(t, err)
 		assert.Equal(t, licenseToken, storedToken)
 
-		// Verify container is running
-		inspect, err := dockerClient.ContainerInspect(ctx, containerName)
-		if err != nil {
-			t.Logf("Command output:\n%s", output)
-		}
-		require.NoError(t, err, "failed to inspect container")
-		assert.True(t, inspect.State.Running, "container should be running")
-
-	case <-time.After(2 * time.Minute):
+	case <-time.After(30 * time.Second):
 		cancel()
 		t.Fatal("timeout waiting for command output")
 	}
 }
 
 func TestDeviceFlowFailure_RequestNotConfirmed(t *testing.T) {
-	requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd := exec.CommandContext(ctx, binaryPath(), "login")
 	cmd.Env = envWithoutAuthToken()
 
 	// Keep stdin open and get the pipe to simulate ENTER
@@ -175,14 +163,6 @@ func TestDeviceFlowFailure_RequestNotConfirmed(t *testing.T) {
 		// Verify no token was stored in keyring
 		_, err := keyringGet(keyringService, keyringUser)
 		assert.Error(t, err, "no token should be stored when login fails")
-
-		// Verify container was not started
-		inspect, err := dockerClient.ContainerInspect(ctx, containerName)
-		if err == nil {
-			// Container exists but should not be running
-			assert.False(t, inspect.State.Running, "container should not be running when login fails")
-		}
-		// If err != nil, container doesn't exist which is also acceptable
 
 	case <-time.After(10 * time.Second):
 		cancel()

--- a/test/integration/login_device_flow_test.go
+++ b/test/integration/login_device_flow_test.go
@@ -121,7 +121,10 @@ func TestDeviceFlowSuccess(t *testing.T) {
 
 		// Verify container is running
 		inspect, err := dockerClient.ContainerInspect(ctx, containerName)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("Command output:\n%s", output)
+		}
+		require.NoError(t, err, "failed to inspect container")
 		assert.True(t, inspect.State.Running, "container should be running")
 
 	case <-time.After(2 * time.Minute):

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -51,6 +51,11 @@ func TestMain(m *testing.M) {
 		},
 	}
 
+	// Force file backend if KEYRING env var is set to "file"
+	if os.Getenv("KEYRING") == "file" {
+		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}
+	}
+
 	ring, err = keyring.Open(keyringConfig)
 	if err != nil {
 		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -65,6 +65,10 @@ func requireDocker(t *testing.T) {
 	if !dockerAvailable {
 		t.Skip("Docker is not available")
 	}
+	// Skip Docker tests on Windows (GitHub Actions doesn't support Linux containers)
+	if runtime.GOOS == "windows" && os.Getenv("CI") != "" {
+		t.Skip("Docker tests not supported on Windows CI (nested virtualization not available)")
+	}
 }
 
 func envWithoutAuthToken() []string {


### PR DESCRIPTION
## Problem
GitHub Actions Windows runners don't support nested virtualization, which is required to run Linux containers on Windows. From [GitHub discussion](https://github.com/orgs/community/discussions/25491):

> "The Windows VMs are not enabled for nested virtualization so you won't be able to run a linux container on the Windows VM."

## Solution
- New `login` command that performs authentication without starting containers. Use this new command in authentication integration tests
- Docker-based tests are now skipped on windows on CI, while login/logout tests run successfully (Login/authentication doesn't need containers)
- Added an env var `KEYRING=file` to force saving token to file instead of keychain. Only enable when running tests on macOS. With the changes of this PR we now run the login command on macOS, but it would without the var stay stuck because of user interaction expected with the keychain pop-up.

Integration tests now run on all platforms:
- **Linux/macOS**: All tests run (login + docker tests). Keychain is disabled for macOS.
- **Windows CI**: Login tests run, docker tests skip automatically
- **Windows local**: All tests run if docker desktop is available (with linux containers)

## Additional changes
- Makefile `test-integration` target now depends on `build` instead of just the binary, in order to always use latest code
- Fixes docker pull errors on windows where "no matching manifest for windows/amd64" wasn't being caught, causing tests to fail with "No such image" errors.
