### PR TITLE
Add event sink system instead of plain CLI printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin/
 *.test
+
+.idea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Note: Integration tests require `LOCALSTACK_AUTH_TOKEN` environment variable for
   - `container/` - Handling different emulator containers
   - `runtime/` - Abstraction for container runtimes (Docker, Kubernetes, etc.) - currently only Docker implemented
   - `auth/` - Authentication (env var token or browser-based login)
+  - `output/` - Generic event and sink abstractions for CLI/TUI/non-interactive rendering
 
 # Configuration
 
@@ -46,6 +47,13 @@ Environment variables:
 # Testing
 
 - Prefer integration tests to cover most cases. Use unit tests when integration tests are not practical.
+
+# Output Routing
+
+- Emit progress/events through `internal/output` sinks instead of printing directly from command handlers.
+- Use `output.NewPlainSink(...)` for CLI text output.
+- Prefer typed `output.Sink` dependencies over raw callback functions like `func(string)`.
+- Keep reusable output primitives in `internal/output`; command-specific orchestration can live in `cmd/`.
 
 # Maintaining This File
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/localstack/lstk/internal/auth"
+	"github.com/localstack/lstk/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -12,7 +14,8 @@ var loginCmd = &cobra.Command{
 	Short: "Authenticate with LocalStack",
 	Long:  "Authenticate with LocalStack and store credentials in system keyring",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		a, err := auth.New()
+		sink := output.NewPlainSink(os.Stdout)
+		a, err := auth.New(sink)
 		if err != nil {
 			return fmt.Errorf("failed to initialize auth: %w", err)
 		}
@@ -22,7 +25,7 @@ var loginCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Println("Login successful.")
+		output.EmitLog(sink, "Login successful.")
 		return nil
 	},
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -25,7 +25,6 @@ var loginCmd = &cobra.Command{
 			return err
 		}
 
-		output.EmitLog(sink, "Login successful.")
 		return nil
 	},
 }

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/localstack/lstk/internal/auth"
+	"github.com/localstack/lstk/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +13,8 @@ var logoutCmd = &cobra.Command{
 	Use:   "logout",
 	Short: "Remove stored authentication token",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		a, err := auth.New()
+		sink := output.NewPlainSink(os.Stdout)
+		a, err := auth.New(sink)
 		if err != nil {
 			return fmt.Errorf("failed to initialize auth: %w", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
@@ -25,11 +26,7 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		onProgress := func(msg string) {
-			fmt.Println(msg)
-		}
-
-		if err := container.Start(cmd.Context(), rt, onProgress); err != nil {
+		if err := runStart(cmd.Context(), rt); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -42,4 +39,8 @@ func init() {
 
 func Execute(ctx context.Context) error {
 	return rootCmd.ExecuteContext(ctx)
+}
+
+func runStart(ctx context.Context, rt runtime.Runtime) error {
+	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout))
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/localstack/lstk/internal/container"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
@@ -20,11 +19,7 @@ var startCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		onProgress := func(msg string) {
-			fmt.Println(msg)
-		}
-
-		if err := container.Start(cmd.Context(), rt, onProgress); err != nil {
+		if err := runStart(cmd.Context(), rt); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,13 +1,13 @@
 package auth
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"log"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/localstack/lstk/internal/output"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -24,9 +24,15 @@ func TestGetToken_ReturnsTokenWhenKeyringStoreFails(t *testing.T) {
 	mockKeyring := NewMockKeyring(ctrl)
 	mockLogin := NewMockLoginProvider(ctrl)
 
+	var events []output.Event
+	sink := output.SinkFunc(func(event output.Event) {
+		events = append(events, event)
+	})
+
 	auth := &Auth{
 		keyring:      mockKeyring,
 		browserLogin: mockLogin,
+		sink:         sink,
 	}
 
 	// Keyring returns empty (no stored token)
@@ -36,14 +42,17 @@ func TestGetToken_ReturnsTokenWhenKeyringStoreFails(t *testing.T) {
 	// Setting token in keyring fails
 	mockKeyring.EXPECT().Set(keyringService, keyringUser, "test-token").Return(errors.New("keyring unavailable"))
 
-	// Capture log output
-	var logBuf bytes.Buffer
-	log.SetOutput(&logBuf)
-	t.Cleanup(func() { log.SetOutput(os.Stderr) })
-
 	token, err := auth.GetToken(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, "test-token", token)
-	assert.Contains(t, logBuf.String(), "Warning: could not store token in keyring")
+	assert.Condition(t, func() bool {
+		for _, event := range events {
+			warningEvent, ok := event.(output.WarningEvent)
+			if ok && strings.Contains(warningEvent.Message, "could not store token in keyring") {
+				return true
+			}
+		}
+		return false
+	})
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -24,8 +24,8 @@ func TestGetToken_ReturnsTokenWhenKeyringStoreFails(t *testing.T) {
 	mockKeyring := NewMockKeyring(ctrl)
 	mockLogin := NewMockLoginProvider(ctrl)
 
-	var events []output.Event
-	sink := output.SinkFunc(func(event output.Event) {
+	var events []any
+	sink := output.SinkFunc(func(event any) {
 		events = append(events, event)
 	})
 

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -1,0 +1,78 @@
+package output
+
+// Event is a marker interface for all event types.
+type Event interface {
+	event()
+}
+
+type Sink interface {
+	Emit(event Event)
+}
+
+type SinkFunc func(event Event)
+
+func (f SinkFunc) Emit(event Event) {
+	if f == nil {
+		return
+	}
+	f(event)
+}
+
+type LogEvent struct {
+	Message string
+}
+
+func (LogEvent) event() {}
+
+type WarningEvent struct {
+	Message string
+}
+
+func (WarningEvent) event() {}
+
+type ContainerStatusEvent struct {
+	Phase     string // e.g., "pulling", "starting", "waiting", "ready"
+	Container string
+	Detail    string // optional extra info (e.g., container ID)
+}
+
+func (ContainerStatusEvent) event() {}
+
+type ProgressEvent struct {
+	Container string
+	LayerID   string
+	Status    string
+	Current   int64
+	Total     int64
+}
+
+func (ProgressEvent) event() {}
+
+func Emit(sink Sink, event Event) {
+	if sink == nil {
+		return
+	}
+	sink.Emit(event)
+}
+
+func EmitLog(sink Sink, message string) {
+	Emit(sink, LogEvent{Message: message})
+}
+
+func EmitWarning(sink Sink, message string) {
+	Emit(sink, WarningEvent{Message: message})
+}
+
+func EmitStatus(sink Sink, phase, container, detail string) {
+	Emit(sink, ContainerStatusEvent{Phase: phase, Container: container, Detail: detail})
+}
+
+func EmitProgress(sink Sink, container, layerID, status string, current, total int64) {
+	Emit(sink, ProgressEvent{
+		Container: container,
+		LayerID:   layerID,
+		Status:    status,
+		Current:   current,
+		Total:     total,
+	})
+}

--- a/internal/output/plain_sink.go
+++ b/internal/output/plain_sink.go
@@ -8,6 +8,7 @@ import (
 
 type PlainSink struct {
 	out io.Writer
+	err error
 }
 
 func NewPlainSink(out io.Writer) *PlainSink {
@@ -17,12 +18,25 @@ func NewPlainSink(out io.Writer) *PlainSink {
 	return &PlainSink{out: out}
 }
 
+// Err returns the first write error encountered, if any.
+func (s *PlainSink) Err() error {
+	return s.err
+}
+
+func (s *PlainSink) setErr(err error) {
+	if s.err == nil && err != nil {
+		s.err = err
+	}
+}
+
 func (s *PlainSink) emit(event any) {
 	switch e := event.(type) {
 	case LogEvent:
-		_, _ = fmt.Fprintln(s.out, e.Message)
+		_, err := fmt.Fprintln(s.out, e.Message)
+		s.setErr(err)
 	case WarningEvent:
-		_, _ = fmt.Fprintf(s.out, "Warning: %s\n", e.Message)
+		_, err := fmt.Fprintf(s.out, "Warning: %s\n", e.Message)
+		s.setErr(err)
 	case ContainerStatusEvent:
 		s.emitStatus(e)
 	case ProgressEvent:
@@ -31,33 +45,37 @@ func (s *PlainSink) emit(event any) {
 }
 
 func (s *PlainSink) emitStatus(e ContainerStatusEvent) {
+	var err error
 	switch e.Phase {
 	case "pulling":
-		_, _ = fmt.Fprintf(s.out, "Pulling %s...\n", e.Container)
+		_, err = fmt.Fprintf(s.out, "Pulling %s...\n", e.Container)
 	case "starting":
-		_, _ = fmt.Fprintf(s.out, "Starting %s...\n", e.Container)
+		_, err = fmt.Fprintf(s.out, "Starting %s...\n", e.Container)
 	case "waiting":
-		_, _ = fmt.Fprintf(s.out, "Waiting for %s to be ready...\n", e.Container)
+		_, err = fmt.Fprintf(s.out, "Waiting for %s to be ready...\n", e.Container)
 	case "ready":
 		if e.Detail != "" {
-			_, _ = fmt.Fprintf(s.out, "%s ready (%s)\n", e.Container, e.Detail)
+			_, err = fmt.Fprintf(s.out, "%s ready (%s)\n", e.Container, e.Detail)
 		} else {
-			_, _ = fmt.Fprintf(s.out, "%s ready\n", e.Container)
+			_, err = fmt.Fprintf(s.out, "%s ready\n", e.Container)
 		}
 	default:
 		if e.Detail != "" {
-			_, _ = fmt.Fprintf(s.out, "%s: %s (%s)\n", e.Container, e.Phase, e.Detail)
+			_, err = fmt.Fprintf(s.out, "%s: %s (%s)\n", e.Container, e.Phase, e.Detail)
 		} else {
-			_, _ = fmt.Fprintf(s.out, "%s: %s\n", e.Container, e.Phase)
+			_, err = fmt.Fprintf(s.out, "%s: %s\n", e.Container, e.Phase)
 		}
 	}
+	s.setErr(err)
 }
 
 func (s *PlainSink) emitProgress(e ProgressEvent) {
+	var err error
 	if e.Total > 0 {
 		pct := float64(e.Current) / float64(e.Total) * 100
-		_, _ = fmt.Fprintf(s.out, "  %s: %s %.1f%%\n", e.LayerID, e.Status, pct)
+		_, err = fmt.Fprintf(s.out, "  %s: %s %.1f%%\n", e.LayerID, e.Status, pct)
 	} else if e.Status != "" {
-		_, _ = fmt.Fprintf(s.out, "  %s: %s\n", e.LayerID, e.Status)
+		_, err = fmt.Fprintf(s.out, "  %s: %s\n", e.LayerID, e.Status)
 	}
+	s.setErr(err)
 }

--- a/internal/output/plain_sink.go
+++ b/internal/output/plain_sink.go
@@ -1,0 +1,63 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+type PlainSink struct {
+	out io.Writer
+}
+
+func NewPlainSink(out io.Writer) *PlainSink {
+	if out == nil {
+		out = os.Stdout
+	}
+	return &PlainSink{out: out}
+}
+
+func (s *PlainSink) Emit(event Event) {
+	switch e := event.(type) {
+	case LogEvent:
+		_, _ = fmt.Fprintln(s.out, e.Message)
+	case WarningEvent:
+		_, _ = fmt.Fprintf(s.out, "Warning: %s\n", e.Message)
+	case ContainerStatusEvent:
+		s.emitStatus(e)
+	case ProgressEvent:
+		s.emitProgress(e)
+	}
+}
+
+func (s *PlainSink) emitStatus(e ContainerStatusEvent) {
+	switch e.Phase {
+	case "pulling":
+		_, _ = fmt.Fprintf(s.out, "Pulling %s...\n", e.Container)
+	case "starting":
+		_, _ = fmt.Fprintf(s.out, "Starting %s...\n", e.Container)
+	case "waiting":
+		_, _ = fmt.Fprintf(s.out, "Waiting for %s to be ready...\n", e.Container)
+	case "ready":
+		if e.Detail != "" {
+			_, _ = fmt.Fprintf(s.out, "%s ready (%s)\n", e.Container, e.Detail)
+		} else {
+			_, _ = fmt.Fprintf(s.out, "%s ready\n", e.Container)
+		}
+	default:
+		if e.Detail != "" {
+			_, _ = fmt.Fprintf(s.out, "%s: %s (%s)\n", e.Container, e.Phase, e.Detail)
+		} else {
+			_, _ = fmt.Fprintf(s.out, "%s: %s\n", e.Container, e.Phase)
+		}
+	}
+}
+
+func (s *PlainSink) emitProgress(e ProgressEvent) {
+	if e.Total > 0 {
+		pct := float64(e.Current) / float64(e.Total) * 100
+		_, _ = fmt.Fprintf(s.out, "  %s: %s %.1f%%\n", e.LayerID, e.Status, pct)
+	} else if e.Status != "" {
+		_, _ = fmt.Fprintf(s.out, "  %s: %s\n", e.LayerID, e.Status)
+	}
+}

--- a/internal/output/plain_sink.go
+++ b/internal/output/plain_sink.go
@@ -17,7 +17,7 @@ func NewPlainSink(out io.Writer) *PlainSink {
 	return &PlainSink{out: out}
 }
 
-func (s *PlainSink) Emit(event Event) {
+func (s *PlainSink) emit(event any) {
 	switch e := event.(type) {
 	case LogEvent:
 		_, _ = fmt.Fprintln(s.out, e.Message)

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -1,0 +1,132 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlainSink_EmitsLogEvent(t *testing.T) {
+	var out bytes.Buffer
+	sink := NewPlainSink(&out)
+
+	sink.Emit(LogEvent{Message: "hello"})
+
+	assert.Equal(t, "hello\n", out.String())
+}
+
+func TestPlainSink_EmitsWarningEvent(t *testing.T) {
+	var out bytes.Buffer
+	sink := NewPlainSink(&out)
+
+	sink.Emit(WarningEvent{Message: "something went wrong"})
+
+	assert.Equal(t, "Warning: something went wrong\n", out.String())
+}
+
+func TestPlainSink_EmitsStatusEvent(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    ContainerStatusEvent
+		expected string
+	}{
+		{
+			name:     "pulling phase",
+			event:    ContainerStatusEvent{Phase: "pulling", Container: "localstack/localstack:latest"},
+			expected: "Pulling localstack/localstack:latest...\n",
+		},
+		{
+			name:     "starting phase",
+			event:    ContainerStatusEvent{Phase: "starting", Container: "localstack"},
+			expected: "Starting localstack...\n",
+		},
+		{
+			name:     "waiting phase",
+			event:    ContainerStatusEvent{Phase: "waiting", Container: "localstack"},
+			expected: "Waiting for localstack to be ready...\n",
+		},
+		{
+			name:     "ready phase with detail",
+			event:    ContainerStatusEvent{Phase: "ready", Container: "localstack", Detail: "abc123"},
+			expected: "localstack ready (abc123)\n",
+		},
+		{
+			name:     "ready phase without detail",
+			event:    ContainerStatusEvent{Phase: "ready", Container: "localstack"},
+			expected: "localstack ready\n",
+		},
+		{
+			name:     "unknown phase with detail",
+			event:    ContainerStatusEvent{Phase: "custom", Container: "localstack", Detail: "info"},
+			expected: "localstack: custom (info)\n",
+		},
+		{
+			name:     "unknown phase without detail",
+			event:    ContainerStatusEvent{Phase: "custom", Container: "localstack"},
+			expected: "localstack: custom\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			sink := NewPlainSink(&out)
+
+			sink.Emit(tt.event)
+
+			assert.Equal(t, tt.expected, out.String())
+		})
+	}
+}
+
+func TestPlainSink_EmitsProgressEvent(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    ProgressEvent
+		expected string
+	}{
+		{
+			name: "with total (percentage)",
+			event: ProgressEvent{
+				Container: "localstack",
+				LayerID:   "abc123",
+				Status:    "Downloading",
+				Current:   50,
+				Total:     100,
+			},
+			expected: "  abc123: Downloading 50.0%\n",
+		},
+		{
+			name: "without total (status only)",
+			event: ProgressEvent{
+				Container: "localstack",
+				LayerID:   "abc123",
+				Status:    "Pull complete",
+				Current:   0,
+				Total:     0,
+			},
+			expected: "  abc123: Pull complete\n",
+		},
+		{
+			name: "no status and no total",
+			event: ProgressEvent{
+				Container: "localstack",
+				LayerID:   "abc123",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			sink := NewPlainSink(&out)
+
+			sink.Emit(tt.event)
+
+			assert.Equal(t, tt.expected, out.String())
+		})
+	}
+}
+

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -11,7 +11,7 @@ func TestPlainSink_EmitsLogEvent(t *testing.T) {
 	var out bytes.Buffer
 	sink := NewPlainSink(&out)
 
-	sink.Emit(LogEvent{Message: "hello"})
+	Emit(sink, LogEvent{Message: "hello"})
 
 	assert.Equal(t, "hello\n", out.String())
 }
@@ -20,7 +20,7 @@ func TestPlainSink_EmitsWarningEvent(t *testing.T) {
 	var out bytes.Buffer
 	sink := NewPlainSink(&out)
 
-	sink.Emit(WarningEvent{Message: "something went wrong"})
+	Emit(sink, WarningEvent{Message: "something went wrong"})
 
 	assert.Equal(t, "Warning: something went wrong\n", out.String())
 }
@@ -73,7 +73,7 @@ func TestPlainSink_EmitsStatusEvent(t *testing.T) {
 			var out bytes.Buffer
 			sink := NewPlainSink(&out)
 
-			sink.Emit(tt.event)
+			Emit(sink, tt.event)
 
 			assert.Equal(t, tt.expected, out.String())
 		})
@@ -123,10 +123,9 @@ func TestPlainSink_EmitsProgressEvent(t *testing.T) {
 			var out bytes.Buffer
 			sink := NewPlainSink(&out)
 
-			sink.Emit(tt.event)
+			Emit(sink, tt.event)
 
 			assert.Equal(t, tt.expected, out.String())
 		})
 	}
 }
-


### PR DESCRIPTION
## Motivation

Currently, the CLI prints directly to stdout throughout the codebase. This becomes problematic when integrating with bubbletea for TUI rendering, since bubbletea owns stdout and you can't print to it while the TUI is running.

By routing all output through a `Sink` interface, we can:
- Use `PlainSink` for non-interactive CLI mode (writes to stdout)
- Swap in a future `TUISink` that sends events to bubbletea's message loop via `Program.Send()`

The event types (`LogEvent`, `ProgressEvent`, etc.) map naturally to bubbletea's `tea.Msg` types, making the future integration straightforward.

## Changes

- Added `internal/output` package with typed events (`LogEvent`, `WarningEvent`, `ContainerStatusEvent`, `ProgressEvent`) and a `Sink` interface
- Used Go generics with union type constraints for compile-time event type safety
- Replaced direct `fmt.Print`/`log.Printf` calls in `container/start.go`, `auth/auth.go`, `auth/login.go`, and command handlers with sink-based emission
- Updated all commands (`start`, `login`, `logout`) to create and pass a `PlainSink`

## Tests

- Added unit tests for `PlainSink` covering all event types and formatting variations
- Updated existing `auth_test.go` to use `SinkFunc` for capturing emitted events and asserting on them
- All existing tests pass; the sink abstraction is transparent to test behavior