### PR TITLE
Fix upgrade workflow

### DIFF
--- a/.github/workflows/weekly-go-upgrade.yml
+++ b/.github/workflows/weekly-go-upgrade.yml
@@ -43,4 +43,3 @@ jobs:
             - Runs `go mod tidy` to keep module files consistent.
           labels: dependencies
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
-          reviewers: silv-io,carole-lavillonniere

--- a/.github/workflows/weekly-go-upgrade.yml
+++ b/.github/workflows/weekly-go-upgrade.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: stable
+          check-latest: true
 
       - name: Upgrade Go version
         run: |

--- a/.github/workflows/weekly-go-upgrade.yml
+++ b/.github/workflows/weekly-go-upgrade.yml
@@ -32,6 +32,8 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           branch: chore/weekly-go-upgrade
+          author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
+          committer: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
           commit-message: "chore(go): weekly Go upgrade"
           title: "chore(go): weekly Go upgrade"
           body: |
@@ -40,4 +42,5 @@ jobs:
             - Updates the `go` directive to the latest released Go version.
             - Runs `go mod tidy` to keep module files consistent.
           labels: dependencies
-          delete-branch: true
+          token: ${{ secrets.PRO_ACCESS_TOKEN }}
+          reviewers: silv-io,carole-lavillonniere


### PR DESCRIPTION
The new upgrade workflow installed the current go version to upgrade the go version, which doesn't work in CI by the looks of it (works locally though).

Should've done a test run before merging. Fixed it now and confirmed with test runs that it will work in #32 and #33

