### PR TITLE
Add styled CLI output with spinner for logout command

### DIFF
--- a/internal/auth/token_storage.go
+++ b/internal/auth/token_storage.go
@@ -21,6 +21,8 @@ const (
 	keyringAuthTokenLabel = "LocalStack Auth Token"
 )
 
+var ErrTokenNotFound = errors.New("credential not found")
+
 type AuthTokenStorage interface {
 	GetAuthToken() (string, error)
 	SetAuthToken(token string) error
@@ -66,7 +68,7 @@ func (s *authTokenStorage) GetAuthToken() (string, error) {
 	item, err := s.ring.Get(keyringAuthTokenKey)
 	if err != nil {
 		if errors.Is(err, keyring.ErrKeyNotFound) {
-			return "", fmt.Errorf("credential not found")
+			return "", ErrTokenNotFound
 		}
 		return "", err
 	}

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -15,6 +15,8 @@
 //   - Use for errors that need more than a single line
 package output
 
+import "time"
+
 type MessageSeverity int
 
 const (
@@ -30,8 +32,9 @@ type MessageEvent struct {
 }
 
 type SpinnerEvent struct {
-	Active bool
-	Text   string
+	Active      bool
+	Text        string
+	MinDuration time.Duration // Minimum time spinner should display (0 = use default)
 }
 
 type ErrorAction struct {
@@ -144,8 +147,16 @@ func EmitContainerLogLine(sink Sink, line string) {
 	Emit(sink, ContainerLogLineEvent{Line: line})
 }
 
+const DefaultSpinnerMinDuration = 400 * time.Millisecond
+
+// EmitSpinnerStart starts spinner with default min duration (400ms)
 func EmitSpinnerStart(sink Sink, text string) {
-	Emit(sink, SpinnerEvent{Active: true, Text: text})
+	Emit(sink, SpinnerEvent{Active: true, Text: text, MinDuration: DefaultSpinnerMinDuration})
+}
+
+// EmitSpinnerStartWithDuration starts spinner with custom min duration (0 = no minimum)
+func EmitSpinnerStartWithDuration(sink Sink, text string, minDuration time.Duration) {
+	Emit(sink, SpinnerEvent{Active: true, Text: text, MinDuration: minDuration})
 }
 
 func EmitSpinnerStop(sink Sink) {

--- a/internal/ui/components/spinner.go
+++ b/internal/ui/components/spinner.go
@@ -1,15 +1,22 @@
 package components
 
 import (
+	"time"
+
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/localstack/lstk/internal/ui/styles"
 )
 
+type SpinnerMinDurationElapsedMsg struct{}
+
 type Spinner struct {
-	model   spinner.Model
-	text    string
-	visible bool
+	model       spinner.Model
+	text        string
+	visible     bool
+	startedAt   time.Time
+	minDuration time.Duration
+	pendingStop bool
 }
 
 func NewSpinner() Spinner {
@@ -19,14 +26,40 @@ func NewSpinner() Spinner {
 	return Spinner{model: s}
 }
 
-func (s Spinner) Start(text string) Spinner {
+func (s Spinner) Start(text string, minDuration time.Duration) Spinner {
 	s.text = text
 	s.visible = true
+	s.startedAt = time.Now()
+	s.pendingStop = false
+	s.minDuration = minDuration
 	return s
 }
 
-func (s Spinner) Stop() Spinner {
-	s.visible = false
+func (s Spinner) Stop() (Spinner, tea.Cmd) {
+	elapsed := time.Since(s.startedAt)
+	remaining := s.minDuration - elapsed
+
+	if remaining <= 0 {
+		s.visible = false
+		s.pendingStop = false
+		return s, nil
+	}
+
+	s.pendingStop = true
+	return s, tea.Tick(remaining, func(t time.Time) tea.Msg {
+		return SpinnerMinDurationElapsedMsg{}
+	})
+}
+
+func (s Spinner) PendingStop() bool {
+	return s.pendingStop
+}
+
+func (s Spinner) HandleMinDurationElapsed() Spinner {
+	if s.pendingStop {
+		s.visible = false
+		s.pendingStop = false
+	}
 	return s
 }
 

--- a/internal/ui/components/spinner_test.go
+++ b/internal/ui/components/spinner_test.go
@@ -3,6 +3,7 @@ package components
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 )
@@ -15,12 +16,12 @@ func TestSpinner_StartStop(t *testing.T) {
 		t.Fatal("expected spinner to be hidden initially")
 	}
 
-	s = s.Start("Loading")
+	s = s.Start("Loading", 0)
 	if !s.Visible() {
 		t.Fatal("expected spinner to be visible after Start")
 	}
 
-	s = s.Stop()
+	s, _ = s.Stop()
 	if s.Visible() {
 		t.Fatal("expected spinner to be hidden after Stop")
 	}
@@ -35,7 +36,7 @@ func TestSpinner_View(t *testing.T) {
 		t.Fatal("expected empty view when spinner is hidden")
 	}
 
-	s = s.Start("Loading")
+	s = s.Start("Loading", 0)
 	view := s.View()
 	if !strings.Contains(view, "Loading") {
 		t.Fatalf("expected view to contain 'Loading', got: %q", view)
@@ -46,10 +47,66 @@ func TestSpinner_Update(t *testing.T) {
 	t.Parallel()
 
 	s := NewSpinner()
-	s = s.Start("Loading")
+	s = s.Start("Loading", 0)
 
 	_, cmd := s.Update(spinner.TickMsg{})
 	if cmd == nil {
 		t.Fatal("expected non-nil command from spinner update")
+	}
+}
+
+func TestSpinner_MinDuration_ImmediateStop(t *testing.T) {
+	t.Parallel()
+
+	s := NewSpinner()
+	s = s.Start("Loading", 0)
+
+	s, cmd := s.Stop()
+	if s.Visible() {
+		t.Fatal("expected spinner to be hidden immediately with 0 min duration")
+	}
+	if s.PendingStop() {
+		t.Fatal("expected no pending stop with 0 min duration")
+	}
+	if cmd != nil {
+		t.Fatal("expected no command with immediate stop")
+	}
+}
+
+func TestSpinner_MinDuration_DelayedStop(t *testing.T) {
+	t.Parallel()
+
+	s := NewSpinner()
+	s = s.Start("Loading", 500*time.Millisecond)
+
+	s, cmd := s.Stop()
+	if !s.Visible() {
+		t.Fatal("expected spinner to remain visible during min duration")
+	}
+	if !s.PendingStop() {
+		t.Fatal("expected pending stop during min duration")
+	}
+	if cmd == nil {
+		t.Fatal("expected command for delayed stop")
+	}
+}
+
+func TestSpinner_HandleMinDurationElapsed(t *testing.T) {
+	t.Parallel()
+
+	s := NewSpinner()
+	s = s.Start("Loading", 500*time.Millisecond)
+	s, _ = s.Stop()
+
+	if !s.PendingStop() {
+		t.Fatal("expected pending stop before handling elapsed")
+	}
+
+	s = s.HandleMinDurationElapsed()
+	if s.Visible() {
+		t.Fatal("expected spinner to be hidden after min duration elapsed")
+	}
+	if s.PendingStop() {
+		t.Fatal("expected no pending stop after handling elapsed")
 	}
 }

--- a/internal/ui/run_logout.go
+++ b/internal/ui/run_logout.go
@@ -1,0 +1,57 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/localstack/lstk/internal/api"
+	"github.com/localstack/lstk/internal/auth"
+	"github.com/localstack/lstk/internal/output"
+)
+
+func RunLogout(parentCtx context.Context) error {
+	_, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	app := NewApp("", cancel)
+	p := tea.NewProgram(app, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
+	runErrCh := make(chan error, 1)
+
+	go func() {
+		tokenStorage, err := auth.NewTokenStorage()
+		if err != nil {
+			runErrCh <- err
+			p.Send(runErrMsg{err: err})
+			return
+		}
+
+		platformClient := api.NewPlatformClient()
+		a := auth.New(output.NewTUISink(programSender{p: p}), platformClient, tokenStorage, false)
+		err = a.Logout()
+
+		runErrCh <- err
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, auth.ErrNotLoggedIn) {
+			p.Send(runErrMsg{err: err})
+			return
+		}
+		p.Send(runDoneMsg{})
+	}()
+
+	model, err := p.Run()
+	if err != nil {
+		return err
+	}
+
+	if app, ok := model.(App); ok && app.Err() != nil {
+		return app.Err()
+	}
+
+	runErr := <-runErrCh
+	if runErr != nil && !errors.Is(runErr, context.Canceled) && !errors.Is(runErr, auth.ErrNotLoggedIn) {
+		return runErr
+	}
+
+	return nil
+}

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -23,11 +23,10 @@ func TestConfigFileCreatedOnStartup(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, ".config"), 0755))
 
 		e := testEnvWithHome(tmpHome, xdgOverride)
-		stdout, stderr, err := runLstk(t, workDir, e, "logout")
+		_, stderr, err := runLstk(t, workDir, e, "logout")
 		require.NoError(t, err, stderr)
 
 		expectedConfigFile := filepath.Join(tmpHome, ".config", "lstk", "config.toml")
-		assert.Contains(t, stdout, "Logged out successfully.")
 		assert.FileExists(t, expectedConfigFile)
 		assertDefaultConfigContent(t, expectedConfigFile)
 	})
@@ -38,11 +37,10 @@ func TestConfigFileCreatedOnStartup(t *testing.T) {
 		xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
 
 		e := testEnvWithHome(tmpHome, xdgOverride)
-		stdout, stderr, err := runLstk(t, workDir, e, "logout")
+		_, stderr, err := runLstk(t, workDir, e, "logout")
 		require.NoError(t, err, stderr)
 
 		expectedConfigFile := filepath.Join(expectedOSConfigDir(tmpHome, xdgOverride), "config.toml")
-		assert.Contains(t, stdout, "Logged out successfully.")
 		assert.FileExists(t, expectedConfigFile)
 		assertDefaultConfigContent(t, expectedConfigFile)
 	})

--- a/test/integration/logout_test.go
+++ b/test/integration/logout_test.go
@@ -48,4 +48,5 @@ func TestLogoutCommandSucceedsWhenNoToken(t *testing.T) {
 
 	// Should succeed even if no token
 	require.NoError(t, err, "lstk logout should succeed even with no token: %s", output)
+	assert.Contains(t, string(output), "Not currently logged in")
 }


### PR DESCRIPTION
This will add TUI for the logout command.

This will ...
 - Add interactive TUI with loading spinner for the logout command
  - Introduce styled terminal output with colored prefixes for success/note/warning messages
  - Show appropriate feedback: "Success: Logged out successfully." or "Note: Not currently  logged in."

| Loading | Success | Note |
|--------|--------|--------|
| <img width="490" height="304" alt="Frame 480974612" src="https://github.com/user-attachments/assets/8268c22e-0091-4c0b-b099-6d1c50136027" /> | <img width="490" height="304" alt="Frame 480974614" src="https://github.com/user-attachments/assets/66737977-a076-4d77-8635-9ad1d54d7dd6" />  | <img width="490" height="304" alt="Frame 480974613" src="https://github.com/user-attachments/assets/9bffade3-2a6f-4d08-bbff-0cac1c0d7d3f" /> |

Fix DES-113