### PR TITLE
Centralize env vars with Viper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         run: make test-integration
         env:
           CREATE_JUNIT_REPORT: "true"
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          LSTK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v6

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 test-integration: $(BUILD_DIR)/$(BINARY_NAME)
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
 	if [ "$$(uname)" = "Darwin" ]; then \
-		cd test/integration && KEYRING=file go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...; \
+		cd test/integration && LOCALSTACK_KEYRING=file go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...; \
 	else \
 		cd test/integration && go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 test-integration: $(BUILD_DIR)/$(BINARY_NAME)
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
 	if [ "$$(uname)" = "Darwin" ]; then \
-		cd test/integration && LOCALSTACK_KEYRING=file go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...; \
+		cd test/integration && LSTK_KEYRING=file go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...; \
 	else \
 		cd test/integration && go run gotest.tools/gotestsum@latest --format testdox $$JUNIT -- -count=1 ./...; \
 	fi

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/localstack/lstk/internal/ui"
@@ -27,6 +28,7 @@ var rootCmd = &cobra.Command{
 		if cmd.Name() == "version" {
 			return nil
 		}
+		env.Init()
 		return config.Init()
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/env.example
+++ b/env.example
@@ -1,11 +1,11 @@
 # Authentication token (optional - will trigger device flow login if not set)
-export LOCALSTACK_AUTH_TOKEN=ls-...
+export LSTK_AUTH_TOKEN=ls-...
 
 # API endpoint (defaults to https://api.localstack.cloud)
-export LOCALSTACK_API_ENDPOINT=https://api.staging.aws.localstack.cloud
+export LSTK_API_ENDPOINT=https://api.staging.aws.localstack.cloud
 
 # Web app URL (defaults to https://app.localstack.cloud)
-export LOCALSTACK_WEB_APP_URL=https://app.staging.aws.localstack.cloud
+export LSTK_WEB_APP_URL=https://app.staging.aws.localstack.cloud
 
 # Force file-based keyring backend instead of system keychain (optional)
-# export LOCALSTACK_KEYRING=file
+# export LSTK_KEYRING=file

--- a/env.example
+++ b/env.example
@@ -8,4 +8,4 @@ export LOCALSTACK_API_ENDPOINT=https://api.staging.aws.localstack.cloud
 export LOCALSTACK_WEB_APP_URL=https://app.staging.aws.localstack.cloud
 
 # Force file-based keyring backend instead of system keychain (optional)
-# export KEYRING=file
+# export LOCALSTACK_KEYRING=file

--- a/env.example
+++ b/env.example
@@ -1,7 +1,11 @@
+# Authentication token (optional - will trigger device flow login if not set)
 export LOCALSTACK_AUTH_TOKEN=ls-...
 
-# Force file-based keyring backend (instead of system keychain)
-# export KEYRING=file
-#
+# API endpoint (defaults to https://api.localstack.cloud)
 export LOCALSTACK_API_ENDPOINT=https://api.staging.aws.localstack.cloud
+
+# Web app URL (defaults to https://app.localstack.cloud)
 export LOCALSTACK_WEB_APP_URL=https://app.staging.aws.localstack.cloud
+
+# Force file-based keyring backend instead of system keychain (optional)
+# export KEYRING=file

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"time"
+
+	"github.com/localstack/lstk/internal/env"
 )
 
 type PlatformAPI interface {
@@ -65,12 +66,8 @@ type PlatformClient struct {
 }
 
 func NewPlatformClient() *PlatformClient {
-	baseURL := os.Getenv("LOCALSTACK_API_ENDPOINT")
-	if baseURL == "" {
-		baseURL = "https://api.localstack.cloud"
-	}
 	return &PlatformClient{
-		baseURL:    baseURL,
+		baseURL:    env.Vars.APIEndpoint,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/99designs/keyring"
 	"github.com/localstack/lstk/internal/api"
+	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 )
 
@@ -33,7 +33,7 @@ func (a *Auth) GetToken(ctx context.Context) (string, error) {
 		return token, nil
 	}
 
-	if token := os.Getenv("LOCALSTACK_AUTH_TOKEN"); token != "" {
+	if token := env.Vars.AuthToken; token != "" {
 		return token, nil
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -27,7 +27,7 @@ func New(sink output.Sink, platform api.PlatformAPI, storage AuthTokenStorage, a
 	}
 }
 
-// GetToken tries in order: 1) keyring 2) LOCALSTACK_AUTH_TOKEN env var 3) device flow login
+// GetToken tries in order: 1) keyring 2) LSTK_AUTH_TOKEN env var 3) device flow login
 func (a *Auth) GetToken(ctx context.Context) (string, error) {
 	if token, err := a.tokenStorage.GetAuthToken(); err == nil && token != "" {
 		return token, nil
@@ -38,7 +38,7 @@ func (a *Auth) GetToken(ctx context.Context) (string, error) {
 	}
 
 	if !a.allowLogin {
-		return "", fmt.Errorf("authentication required: set LOCALSTACK_AUTH_TOKEN or run in interactive mode")
+		return "", fmt.Errorf("authentication required: set LSTK_AUTH_TOKEN or run in interactive mode")
 	}
 
 	output.EmitLog(a.sink, "No existing credentials found. Please log in:")

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -15,7 +14,6 @@ import (
 
 func TestMain(m *testing.M) {
 	_ = os.Unsetenv("LOCALSTACK_AUTH_TOKEN")
-	env.Init()
 	m.Run()
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -14,6 +15,7 @@ import (
 
 func TestMain(m *testing.M) {
 	_ = os.Unsetenv("LOCALSTACK_AUTH_TOKEN")
+	env.Init()
 	m.Run()
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	_ = os.Unsetenv("LOCALSTACK_AUTH_TOKEN")
+	_ = os.Unsetenv("LSTK_AUTH_TOKEN")
 	m.Run()
 }
 

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -5,14 +5,12 @@ package auth
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/localstack/lstk/internal/api"
+	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/pkg/browser"
 )
-
-const webAppURL = "https://app.localstack.cloud"
 
 type LoginProvider interface {
 	Login(ctx context.Context) (string, error)
@@ -82,11 +80,7 @@ func (l *loginProvider) Login(ctx context.Context) (string, error) {
 }
 
 func getWebAppURL() string {
-	// allows overriding the URL for testing
-	if url := os.Getenv("LOCALSTACK_WEB_APP_URL"); url != "" {
-		return url
-	}
-	return webAppURL
+	return env.Vars.WebAppURL
 }
 
 func (l *loginProvider) completeAuth(ctx context.Context, authReq *api.AuthRequest) (string, error) {

--- a/internal/auth/token_storage.go
+++ b/internal/auth/token_storage.go
@@ -45,7 +45,7 @@ func NewTokenStorage() (AuthTokenStorage, error) {
 		},
 	}
 
-	// Force file backend if KEYRING env var is set to "file"
+	// Force file backend if LOCALSTACK_KEYRING env var is set to "file"
 	if env.Vars.Keyring == "file" {
 		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}
 	}

--- a/internal/auth/token_storage.go
+++ b/internal/auth/token_storage.go
@@ -45,7 +45,7 @@ func NewTokenStorage() (AuthTokenStorage, error) {
 		},
 	}
 
-	// Force file backend if LOCALSTACK_KEYRING env var is set to "file"
+	// Force file backend if LSTK_KEYRING env var is set to "file"
 	if env.Vars.Keyring == "file" {
 		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}
 	}

--- a/internal/auth/token_storage.go
+++ b/internal/auth/token_storage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/99designs/keyring"
 	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/env"
 )
 
 const (
@@ -45,7 +46,7 @@ func NewTokenStorage() (AuthTokenStorage, error) {
 	}
 
 	// Force file backend if KEYRING env var is set to "file"
-	if os.Getenv("KEYRING") == "file" {
+	if env.Vars.Keyring == "file" {
 		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}
 	}
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -13,7 +13,7 @@ type Env struct {
 	Keyring     string
 }
 
-var Vars *Env
+var Vars = &Env{}
 
 // Init initializes environment variable configuration
 func Init() {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,0 +1,33 @@
+package env
+
+import (
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+type Env struct {
+	AuthToken   string
+	APIEndpoint string
+	WebAppURL   string
+	Keyring     string
+}
+
+var Vars *Env
+
+// Init initializes environment variable configuration
+func Init() {
+	viper.SetEnvPrefix("LOCALSTACK")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+
+	viper.SetDefault("api_endpoint", "https://api.localstack.cloud")
+	viper.SetDefault("web_app_url", "https://app.localstack.cloud")
+
+	Vars = &Env{
+		AuthToken:   viper.GetString("auth_token"),
+		APIEndpoint: viper.GetString("api_endpoint"),
+		WebAppURL:   viper.GetString("web_app_url"),
+		Keyring:     viper.GetString("keyring"),
+	}
+}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -17,7 +17,7 @@ var Vars = &Env{}
 
 // Init initializes environment variable configuration
 func Init() {
-	viper.SetEnvPrefix("LOCALSTACK")
+	viper.SetEnvPrefix("LSTK")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 

--- a/internal/ui/run_login_test.go
+++ b/internal/ui/run_login_test.go
@@ -84,8 +84,8 @@ func TestLoginFlow_DeviceFlowSuccess(t *testing.T) {
 	mockServer := createMockAPIServer(t, "test-license-token", true)
 	defer mockServer.Close()
 
-	t.Setenv("LOCALSTACK_API_ENDPOINT", mockServer.URL)
-	t.Setenv("LOCALSTACK_AUTH_TOKEN", "")
+	t.Setenv("LSTK_API_ENDPOINT", mockServer.URL)
+	t.Setenv("LSTK_AUTH_TOKEN", "")
 	env.Init()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -142,8 +142,8 @@ func TestLoginFlow_DeviceFlowFailure_NotConfirmed(t *testing.T) {
 	mockServer := createMockAPIServer(t, "", false)
 	defer mockServer.Close()
 
-	t.Setenv("LOCALSTACK_API_ENDPOINT", mockServer.URL)
-	t.Setenv("LOCALSTACK_AUTH_TOKEN", "")
+	t.Setenv("LSTK_API_ENDPOINT", mockServer.URL)
+	t.Setenv("LSTK_AUTH_TOKEN", "")
 	env.Init()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/ui/run_login_test.go
+++ b/internal/ui/run_login_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/auth"
+	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,6 +85,8 @@ func TestLoginFlow_DeviceFlowSuccess(t *testing.T) {
 	defer mockServer.Close()
 
 	t.Setenv("LOCALSTACK_API_ENDPOINT", mockServer.URL)
+	t.Setenv("LOCALSTACK_AUTH_TOKEN", "")
+	env.Init()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -140,6 +143,8 @@ func TestLoginFlow_DeviceFlowFailure_NotConfirmed(t *testing.T) {
 	defer mockServer.Close()
 
 	t.Setenv("LOCALSTACK_API_ENDPOINT", mockServer.URL)
+	t.Setenv("LOCALSTACK_AUTH_TOKEN", "")
+	env.Init()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -9,9 +9,9 @@ import (
 type Key string
 
 const (
-	AuthToken   Key = "LOCALSTACK_AUTH_TOKEN"
-	APIEndpoint Key = "LOCALSTACK_API_ENDPOINT"
-	Keyring     Key = "LOCALSTACK_KEYRING"
+	AuthToken   Key = "LSTK_AUTH_TOKEN"
+	APIEndpoint Key = "LSTK_API_ENDPOINT"
+	Keyring     Key = "LSTK_KEYRING"
 	CI          Key = "CI"
 )
 

--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -1,0 +1,68 @@
+package env
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Key is a declared environment variable name.
+type Key string
+
+const (
+	AuthToken   Key = "LOCALSTACK_AUTH_TOKEN"
+	APIEndpoint Key = "LOCALSTACK_API_ENDPOINT"
+	Keyring     Key = "LOCALSTACK_KEYRING"
+	CI          Key = "CI"
+)
+
+// Get returns the value of the given environment variable.
+func Get(key Key) string {
+	return os.Getenv(string(key))
+}
+
+// Require returns the value of the given environment variable, failing the test if it is not set.
+func Require(t testing.TB, key Key) string {
+	t.Helper()
+	v := os.Getenv(string(key))
+	if v == "" {
+		t.Fatalf("%s must be set to run this test", key)
+	}
+	return v
+}
+
+// Environ is a slice of "KEY=value" environment variable strings.
+type Environ []string
+
+// Without returns the current process environment excluding the given keys.
+func Without(keys ...Key) Environ {
+	return Environ(os.Environ()).Without(keys...)
+}
+
+// With returns the current process environment with key=value appended.
+func With(key Key, value string) Environ {
+	return Environ(os.Environ()).With(key, value)
+}
+
+// Without returns a copy of e excluding any variable whose key matches one of the given keys.
+func (e Environ) Without(keys ...Key) Environ {
+	var result Environ
+	for _, entry := range e {
+		excluded := false
+		for _, key := range keys {
+			if strings.HasPrefix(entry, string(key)+"=") {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+// With returns a copy of e with key=value appended.
+func (e Environ) With(key Key, value string) Environ {
+	return append(e, string(key)+"="+value)
+}

--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 )
 
-// Key is a declared environment variable name.
 type Key string
 
 const (
@@ -16,12 +15,10 @@ const (
 	CI          Key = "CI"
 )
 
-// Get returns the value of the given environment variable.
 func Get(key Key) string {
 	return os.Getenv(string(key))
 }
 
-// Require returns the value of the given environment variable, failing the test if it is not set.
 func Require(t testing.TB, key Key) string {
 	t.Helper()
 	v := os.Getenv(string(key))
@@ -31,20 +28,16 @@ func Require(t testing.TB, key Key) string {
 	return v
 }
 
-// Environ is a slice of "KEY=value" environment variable strings.
 type Environ []string
 
-// Without returns the current process environment excluding the given keys.
 func Without(keys ...Key) Environ {
 	return Environ(os.Environ()).Without(keys...)
 }
 
-// With returns the current process environment with key=value appended.
 func With(key Key, value string) Environ {
 	return Environ(os.Environ()).With(key, value)
 }
 
-// Without returns a copy of e excluding any variable whose key matches one of the given keys.
 func (e Environ) Without(keys ...Key) Environ {
 	var result Environ
 	for _, entry := range e {
@@ -62,7 +55,6 @@ func (e Environ) Without(keys ...Key) Environ {
 	return result
 }
 
-// With returns a copy of e with key=value appended.
 func (e Environ) With(key Key, value string) Environ {
 	return append(e, string(key)+"="+value)
 }

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 		},
 	}
 
-	// Force file backend if LOCALSTACK_KEYRING env var is set to "file"
+	// Force file backend if LSTK_KEYRING env var is set to "file"
 	if env.Get(env.Keyring) == "file" {
 		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}
 	}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 		},
 	}
 
-	// Force file backend if KEYRING env var is set to "file"
+	// Force file backend if LOCALSTACK_KEYRING env var is set to "file"
 	if env.Get(env.Keyring) == "file" {
 		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}
 	}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -107,6 +107,7 @@ func requireDocker(t *testing.T) {
 		t.Skip("Docker is not available")
 	}
 	// Skip Docker tests on Windows (GitHub Actions doesn't support Linux containers)
+	// Note: CI env var is not in config.GetEnv() as it's a standard CI environment variable
 	if runtime.GOOS == "windows" && os.Getenv("CI") != "" {
 		t.Skip("Docker tests not supported on Windows CI (nested virtualization not available)")
 	}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -10,12 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 
 	"github.com/99designs/keyring"
 	"github.com/docker/docker/client"
+	"github.com/localstack/lstk/test/integration/env"
 )
 
 // syncBuffer is a thread-safe buffer for concurrent read/write access.
@@ -88,7 +88,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Force file backend if KEYRING env var is set to "file"
-	if os.Getenv("KEYRING") == "file" {
+	if env.Get(env.Keyring) == "file" {
 		keyringConfig.AllowedBackends = []keyring.BackendType{keyring.FileBackend}
 	}
 
@@ -108,26 +108,9 @@ func requireDocker(t *testing.T) {
 	}
 	// Skip Docker tests on Windows (GitHub Actions doesn't support Linux containers)
 	// Note: CI env var is not in config.GetEnv() as it's a standard CI environment variable
-	if runtime.GOOS == "windows" && os.Getenv("CI") != "" {
+	if runtime.GOOS == "windows" && env.Get(env.CI) != "" {
 		t.Skip("Docker tests not supported on Windows CI (nested virtualization not available)")
 	}
-}
-
-func envWithout(keys ...string) []string {
-	var env []string
-	for _, e := range os.Environ() {
-		excluded := false
-		for _, key := range keys {
-			if strings.HasPrefix(e, key+"=") {
-				excluded = true
-				break
-			}
-		}
-		if !excluded {
-			env = append(env, e)
-		}
-	}
-	return env
 }
 
 func GetAuthTokenFromKeyring() (string, error) {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -54,7 +54,7 @@ func TestStartCommandSucceedsWithKeyringToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	// Run without LOCALSTACK_AUTH_TOKEN should use keyring
+	// Run without LSTK_AUTH_TOKEN should use keyring
 	cmd := exec.CommandContext(ctx, binaryPath(), "start")
 	cmd.Env = env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL)
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
- Introduces centralized environment variable management using Viper, replacing scattered `os.Getenv()` calls throughout the codebase, eliminating raw string env var names.
- Introduces `test/integration/env` to do the same for integration tests.

