### PR TITLE
Handle already-running containers and port conflicts

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -3,7 +3,6 @@ package container
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	stdruntime "runtime"
@@ -14,6 +13,7 @@ import (
 	"github.com/localstack/lstk/internal/auth"
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/ports"
 	"github.com/localstack/lstk/internal/runtime"
 )
 
@@ -142,7 +142,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			output.EmitLog(sink, fmt.Sprintf("%s is already running", c.Name))
 			continue
 		}
-		if err := checkPortAvailable(c.Port); err != nil {
+		if err := ports.CheckAvailable(c.Port); err != nil {
 			configPath, pathErr := config.ConfigFilePath()
 			if pathErr != nil {
 				return nil, err
@@ -152,18 +152,6 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 		filtered = append(filtered, c)
 	}
 	return filtered, nil
-}
-
-func checkPortAvailable(port string) error {
-	conn, err := net.DialTimeout("tcp", "localhost:"+port, time.Second)
-	if err != nil {
-		return nil
-	}
-	err = conn.Close()
-	if err != nil {
-		return nil
-	}
-	return fmt.Errorf("port %s already in use", port)
 }
 
 func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, platformClient api.PlatformAPI, containerConfig runtime.ContainerConfig, token string) error {

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -1,0 +1,16 @@
+package ports
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+func CheckAvailable(port string) error {
+	conn, err := net.DialTimeout("tcp", "localhost:"+port, time.Second)
+	if err != nil {
+		return nil
+	}
+	_ = conn.Close()
+	return fmt.Errorf("port %s already in use", port)
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -6,11 +6,13 @@ import (
 )
 
 type ContainerConfig struct {
-	Image      string
-	Name       string
-	Port       string
-	HealthPath string
-	Env        []string // e.g., ["KEY=value", "FOO=bar"]
+	Image       string
+	Name        string
+	Port        string
+	HealthPath  string
+	Env         []string // e.g., ["KEY=value", "FOO=bar"]
+	Tag         string
+	ProductName string
 }
 
 type PullProgress struct {

--- a/test/integration/license_test.go
+++ b/test/integration/license_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const licenseContainerName = "localstack-aws"
-
 func TestLicenseValidationSuccess(t *testing.T) {
 	requireDocker(t)
 	authToken := env.Require(t, env.AuthToken)
@@ -74,7 +72,7 @@ func TestLicenseValidationSuccess(t *testing.T) {
 
 	require.NoError(t, err, "lstk start failed: %s", output)
 
-	inspect, err := dockerClient.ContainerInspect(ctx, licenseContainerName)
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
 	require.NoError(t, err, "failed to inspect container")
 	assert.True(t, inspect.State.Running, "container should be running")
 }
@@ -99,12 +97,12 @@ func TestLicenseValidationFailure(t *testing.T) {
 	assert.Contains(t, string(output), "invalid, inactive, or expired")
 
 	// Verify container was not started
-	_, err = dockerClient.ContainerInspect(ctx, licenseContainerName)
+	_, err = dockerClient.ContainerInspect(ctx, containerName)
 	assert.Error(t, err, "container should not exist after license failure")
 }
 
 func cleanupLicense() {
 	ctx := context.Background()
-	_ = dockerClient.ContainerStop(ctx, licenseContainerName, container.StopOptions{})
-	_ = dockerClient.ContainerRemove(ctx, licenseContainerName, container.RemoveOptions{Force: true})
+	_ = dockerClient.ContainerStop(ctx, containerName, container.StopOptions{})
+	_ = dockerClient.ContainerRemove(ctx, containerName, container.RemoveOptions{Force: true})
 }

--- a/test/integration/stop_test.go
+++ b/test/integration/stop_test.go
@@ -2,35 +2,13 @@ package integration_test
 
 import (
 	"context"
-	"io"
 	"os/exec"
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-const testImage = "alpine:latest"
-
-func startTestContainer(t *testing.T, ctx context.Context) {
-	t.Helper()
-
-	reader, err := dockerClient.ImagePull(ctx, testImage, image.PullOptions{})
-	require.NoError(t, err, "failed to pull test image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
-
-	resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
-		Image: testImage,
-		Cmd:   []string{"sleep", "infinity"},
-	}, nil, nil, nil, containerName)
-	require.NoError(t, err, "failed to create test container")
-	err = dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
-	require.NoError(t, err, "failed to start test container")
-}
 
 func TestStopCommandSucceeds(t *testing.T) {
 	requireDocker(t)


### PR DESCRIPTION
Before pulling images or validating licenses, `lstk start` now checks the state of each configured container:

- If a container is already running, it logs `"<name> is already running"` and skips it. If all containers are already running, the command exits successfully without doing any work.
- If the configured port is already bound by another process, it returns an error `"port <N> already in use"` with a hint pointing to the config file.