### PR TITLE
Add `lstk logs` command

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+	"github.com/spf13/cobra"
+)
+
+var logsCmd = &cobra.Command{
+	Use:     "logs",
+	Short:   "Stream container logs",
+	Long:    "Stream logs from the LocalStack container in real-time. Press Ctrl+C to stop.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rt, err := runtime.NewDockerRuntime()
+		if err != nil {
+			return err
+		}
+		return container.Logs(cmd.Context(), rt, output.NewPlainSink(os.Stdout))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(logsCmd)
+}

--- a/internal/container/logs.go
+++ b/internal/container/logs.go
@@ -1,0 +1,42 @@
+package container
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink) error {
+	cfg, err := config.Get()
+	if err != nil {
+		return fmt.Errorf("failed to get config: %w", err)
+	}
+	if len(cfg.Containers) == 0 {
+		return fmt.Errorf("no containers configured")
+	}
+
+	// TODO: handle logs per container
+	c := cfg.Containers[0]
+
+	pr, pw := io.Pipe()
+	errCh := make(chan error, 1)
+	go func() {
+		err := rt.StreamLogs(ctx, c.Name(), pw)
+		pw.CloseWithError(err)
+		errCh <- err
+	}()
+
+	scanner := bufio.NewScanner(pr)
+	for scanner.Scan() {
+		output.EmitContainerLogLine(sink, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		return err
+	}
+	return <-errCh
+}

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -1,7 +1,7 @@
 package output
 
 type Event interface {
-	LogEvent | WarningEvent | ContainerStatusEvent | ProgressEvent | UserInputRequestEvent
+	LogEvent | WarningEvent | ContainerStatusEvent | ProgressEvent | UserInputRequestEvent | ContainerLogLineEvent
 }
 
 type Sink interface {
@@ -56,6 +56,10 @@ type UserInputRequestEvent struct {
 	ResponseCh chan<- InputResponse
 }
 
+type ContainerLogLineEvent struct {
+	Line string
+}
+
 // Emit sends an event to the sink with compile-time type safety via generics.
 func Emit[E Event](sink Sink, event E) {
 	if sink == nil {
@@ -88,4 +92,8 @@ func EmitProgress(sink Sink, container, layerID, status string, current, total i
 
 func EmitUserInputRequest(sink Sink, event UserInputRequestEvent) {
 	Emit(sink, event)
+}
+
+func EmitContainerLogLine(sink Sink, line string) {
+	Emit(sink, ContainerLogLineEvent{Line: line})
 }

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -18,6 +18,8 @@ func FormatEventLine(event any) (string, bool) {
 		return formatProgressLine(e)
 	case UserInputRequestEvent:
 		return formatUserInputRequest(e), true
+	case ContainerLogLineEvent:
+		return e.Line, true
 	default:
 		return "", false
 	}

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -140,6 +140,15 @@ func TestPlainSink_EmitsProgressEvent(t *testing.T) {
 	}
 }
 
+func TestPlainSink_EmitsContainerLogLineEvent(t *testing.T) {
+	var out bytes.Buffer
+	sink := NewPlainSink(&out)
+
+	Emit(sink, ContainerLogLineEvent{Line: "2024-01-01 hello from container"})
+
+	assert.Equal(t, "2024-01-01 hello from container\n", out.String())
+}
+
 func TestPlainSink_ErrReturnsNilOnSuccess(t *testing.T) {
 	var out bytes.Buffer
 	sink := NewPlainSink(&out)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,6 +1,9 @@
 package runtime
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 type ContainerConfig struct {
 	Image      string
@@ -25,5 +28,6 @@ type Runtime interface {
 	Remove(ctx context.Context, containerName string) error
 	IsRunning(ctx context.Context, containerID string) (bool, error)
 	Logs(ctx context.Context, containerID string, tail int) (string, error)
+	StreamLogs(ctx context.Context, containerID string, out io.Writer) error
 	GetImageVersion(ctx context.Context, imageName string) (string, error)
 }

--- a/test/integration/logs_test.go
+++ b/test/integration/logs_test.go
@@ -1,0 +1,79 @@
+package integration_test
+
+import (
+	"bufio"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogsCommandFailsWhenNotRunning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "logs")
+	out, err := cmd.CombinedOutput()
+
+	require.Error(t, err, "expected lstk logs to fail when container not running")
+	assert.Contains(t, string(out), "emulator is not running")
+}
+
+func TestLogsCommandStreamsOutput(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	startTestContainer(t, ctx)
+
+	const marker = "lstk-logs-test-marker"
+
+	logsCmd := exec.CommandContext(ctx, binaryPath(), "logs")
+	stdout, err := logsCmd.StdoutPipe()
+	require.NoError(t, err, "failed to get stdout pipe")
+
+	err = logsCmd.Start()
+	require.NoError(t, err, "failed to start lstk logs")
+	t.Cleanup(func() { _ = logsCmd.Process.Kill() })
+
+	// Give lstk logs a moment to connect before generating output
+	time.Sleep(500 * time.Millisecond)
+
+	// Write to /proc/1/fd/1 (PID 1's stdout) so the line appears in docker logs.
+	execResp, err := dockerClient.ContainerExecCreate(ctx, containerName, container.ExecOptions{
+		Cmd: []string{"sh", "-c", "echo " + marker + " >/proc/1/fd/1"},
+	})
+	require.NoError(t, err, "failed to create exec")
+	err = dockerClient.ContainerExecStart(ctx, execResp.ID, container.ExecStartOptions{Detach: true})
+	require.NoError(t, err, "failed to start exec")
+
+	// Scan lines in a goroutine because reading from the pipe blocks until lstk logs exits, which it never does on its own.
+	found := make(chan struct{}, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), marker) {
+				found <- struct{}{}
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-found:
+	case <-ctx.Done():
+		t.Fatal("marker did not appear in lstk logs output within timeout")
+	}
+}


### PR DESCRIPTION
`lstk logs` streams container logs to the terminal until the user cancels with Ctrl+C.
