### PR TITLE
Rename auth token env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         run: make test-integration
         env:
           CREATE_JUNIT_REPORT: "true"
-          LSTK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v6

--- a/env.example
+++ b/env.example
@@ -1,5 +1,5 @@
 # Authentication token (optional - will trigger device flow login if not set)
-export LSTK_AUTH_TOKEN=ls-...
+export LOCALSTACK_AUTH_TOKEN=ls-...
 
 # API endpoint (defaults to https://api.localstack.cloud)
 export LSTK_API_ENDPOINT=https://api.staging.aws.localstack.cloud

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -27,7 +27,7 @@ func New(sink output.Sink, platform api.PlatformAPI, storage AuthTokenStorage, a
 	}
 }
 
-// GetToken tries in order: 1) keyring 2) LSTK_AUTH_TOKEN env var 3) device flow login
+// GetToken tries in order: 1) keyring 2) LOCALSTACK_AUTH_TOKEN env var 3) device flow login
 func (a *Auth) GetToken(ctx context.Context) (string, error) {
 	if token, err := a.tokenStorage.GetAuthToken(); err == nil && token != "" {
 		return token, nil
@@ -38,7 +38,7 @@ func (a *Auth) GetToken(ctx context.Context) (string, error) {
 	}
 
 	if !a.allowLogin {
-		return "", fmt.Errorf("authentication required: set LSTK_AUTH_TOKEN or run in interactive mode")
+		return "", fmt.Errorf("authentication required: set LOCALSTACK_AUTH_TOKEN or run in interactive mode")
 	}
 
 	output.EmitLog(a.sink, "No existing credentials found. Please log in:")

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	_ = os.Unsetenv("LSTK_AUTH_TOKEN")
+	_ = os.Unsetenv("LOCALSTACK_AUTH_TOKEN")
 	m.Run()
 }
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"os"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -24,8 +25,10 @@ func Init() {
 	viper.SetDefault("api_endpoint", "https://api.localstack.cloud")
 	viper.SetDefault("web_app_url", "https://app.localstack.cloud")
 
+	// LOCALSTACK_AUTH_TOKEN is not prefixed with LSTK_
+	// in order to be shared seamlessly with other LocalStack tools
 	Vars = &Env{
-		AuthToken:   viper.GetString("auth_token"),
+		AuthToken:   os.Getenv("LOCALSTACK_AUTH_TOKEN"),
 		APIEndpoint: viper.GetString("api_endpoint"),
 		WebAppURL:   viper.GetString("web_app_url"),
 		Keyring:     viper.GetString("keyring"),

--- a/internal/ui/run_login_test.go
+++ b/internal/ui/run_login_test.go
@@ -85,7 +85,7 @@ func TestLoginFlow_DeviceFlowSuccess(t *testing.T) {
 	defer mockServer.Close()
 
 	t.Setenv("LSTK_API_ENDPOINT", mockServer.URL)
-	t.Setenv("LSTK_AUTH_TOKEN", "")
+	t.Setenv("LOCALSTACK_AUTH_TOKEN", "")
 	env.Init()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -143,7 +143,7 @@ func TestLoginFlow_DeviceFlowFailure_NotConfirmed(t *testing.T) {
 	defer mockServer.Close()
 
 	t.Setenv("LSTK_API_ENDPOINT", mockServer.URL)
-	t.Setenv("LSTK_AUTH_TOKEN", "")
+	t.Setenv("LOCALSTACK_AUTH_TOKEN", "")
 	env.Init()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -9,7 +9,7 @@ import (
 type Key string
 
 const (
-	AuthToken   Key = "LSTK_AUTH_TOKEN"
+	AuthToken   Key = "LOCALSTACK_AUTH_TOKEN"
 	APIEndpoint Key = "LSTK_API_ENDPOINT"
 	Keyring     Key = "LSTK_KEYRING"
 	CI          Key = "CI"

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -54,7 +54,7 @@ func TestStartCommandSucceedsWithKeyringToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	// Run without LSTK_AUTH_TOKEN should use keyring
+	// Run without LOCALSTACK_AUTH_TOKEN should use keyring
 	cmd := exec.CommandContext(ctx, binaryPath(), "start")
 	cmd.Env = env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL)
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
Rename `LSTK_AUTH_TOKEN` -> `LOCALSTACK_AUTH_TOKEN`

`LOCALSTACK_AUTH_TOKEN` is not prefixed with `LSTK_` in order to be shared seamlessly with other LocalStack tools
