### PR TITLE
Rename keyring token label

### DIFF
--- a/internal/auth/token_storage.go
+++ b/internal/auth/token_storage.go
@@ -18,7 +18,7 @@ const (
 	keyringAuthTokenKey   = "lstk.auth-token"
 	keyringPassword       = "lstk-keyring"
 	keyringFilename       = "keyring"
-	keyringAuthTokenLabel = "lstk auth token"
+	keyringAuthTokenLabel = "LocalStack Auth Token"
 )
 
 type AuthTokenStorage interface {

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -47,7 +47,7 @@ const (
 	keyringAuthTokenKey   = "lstk.auth-token"
 	keyringPassword       = "lstk-keyring"
 	keyringFilename       = "keyring"
-	keyringAuthTokenLabel = "lstk auth token"
+	keyringAuthTokenLabel = "LocalStack Auth Token"
 )
 
 func binaryPath() string {


### PR DESCRIPTION
This will update the keyring item label used for storing the CLI auth token for clearer and more accurate naming in system credential managers. The previous label was CLI-specific and less readable in OS keychain.

See also [relevant discussion](https://localstack-cloud.slack.com/archives/C0A1857LGTU/p1771509038840179) and https://github.com/localstack/lstk/pull/44 for more context.

| BEFORE | AFTER |
|--------|--------|
| <img width="546" height="284" alt="Screenshot 2026-02-20 at 14 29 08" src="https://github.com/user-attachments/assets/77c37456-cbec-4d23-a9e8-b2a0227cd282" /> | <img width="546" height="291" alt="Screenshot 2026-02-20 at 14 29 34" src="https://github.com/user-attachments/assets/e7e75e38-c237-42e7-a515-0af4b8e0bc44" /> | 