### PR TITLE
Change release workflow to ZeroVer and encapsulate version info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "*.*.*"
+      - "v*.*.*"
   pull_request:
   workflow_dispatch:
 
@@ -142,10 +142,10 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      - name: Validate CalVer tag
+      - name: Validate version tag
         run: |
-          if [[ ! "${GITHUB_REF_NAME}" =~ ^[0-9]{4}\.[1-9][0-9]*\.[0-9]+$ ]]; then
-            echo "Tag '${GITHUB_REF_NAME}' does not match CalVer format YYYY.M.patch"
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v0\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag '${GITHUB_REF_NAME}' does not match version format v0.minor.patch"
             exit 1
           fi
 

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           ref: ${{ inputs.release_ref }}
           fetch-depth: 0
+          token: ${{ secrets.PRO_ACCESS_TOKEN }}
 
       - name: Configure Git user
         env:

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -7,6 +7,13 @@ on:
         description: Git ref to tag
         required: true
         default: main
+      bump:
+        description: Version bump type
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
 
 permissions:
   contents: write
@@ -42,22 +49,30 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags --force
 
-      - name: Compute next CalVer tag
+      - name: Compute next version tag
         id: next_tag
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
           set -euo pipefail
-          year="$(date -u +%Y)"
-          month="$(date -u +%-m)"
-          prefix="${year}.${month}."
 
-          latest="$(git tag --list "${prefix}*" --sort=-v:refname | grep -E "^${year}\.${month}\.[0-9]+$" | head -n 1 || true)"
+          latest="$(git tag --list "v0.*.*" --sort=-v:refname | grep -E "^v0\.[0-9]+\.[0-9]+$" | head -n 1 || true)"
           if [[ -z "${latest}" ]]; then
+            minor=1
             patch=0
           else
-            patch="$(( ${latest##*.} + 1 ))"
+            current_minor="$(echo "${latest}" | cut -d. -f2)"
+            current_patch="$(echo "${latest}" | cut -d. -f3)"
+            if [[ "${BUMP}" == "minor" ]]; then
+              minor="$(( current_minor + 1 ))"
+              patch=0
+            else
+              minor="${current_minor}"
+              patch="$(( current_patch + 1 ))"
+            fi
           fi
 
-          tag="${year}.${month}.${patch}"
+          tag="v0.${minor}.${patch}"
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
             echo "Tag ${tag} already exists"
             exit 1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X github.com/localstack/lstk/cmd.version={{ .Version }} -X github.com/localstack/lstk/cmd.commit={{ .Commit }} -X github.com/localstack/lstk/cmd.buildDate={{ .Date }}
+      - -s -w -X github.com/localstack/lstk/internal/version.version={{ .Version }} -X github.com/localstack/lstk/internal/version.commit={{ .Commit }} -X github.com/localstack/lstk/internal/version.buildDate={{ .Date }}
 
 archives:
   - id: lstk

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/ui"
+	"github.com/localstack/lstk/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +19,7 @@ var loginCmd = &cobra.Command{
 			return fmt.Errorf("login requires an interactive terminal")
 		}
 		platformClient := api.NewPlatformClient()
-		return ui.RunLogin(cmd.Context(), version, platformClient)
+		return ui.RunLogin(cmd.Context(), version.Version(), platformClient)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,12 +12,9 @@ import (
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/localstack/lstk/internal/ui"
+	"github.com/localstack/lstk/internal/version"
 	"github.com/spf13/cobra"
 )
-
-var version = "dev"
-var commit = "none"
-var buildDate = "unknown"
 
 var rootCmd = &cobra.Command{
 	Use:     "lstk",
@@ -39,7 +36,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.Version = version
+	rootCmd.Version = version.Version()
 	rootCmd.SetVersionTemplate(versionLine() + "\n")
 	rootCmd.AddCommand(startCmd)
 }
@@ -51,7 +48,7 @@ func Execute(ctx context.Context) error {
 func runStart(ctx context.Context, rt runtime.Runtime) error {
 	platformClient := api.NewPlatformClient()
 	if ui.IsInteractive() {
-		return ui.Run(ctx, rt, version, platformClient)
+		return ui.Run(ctx, rt, version.Version(), platformClient)
 	}
 	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout), platformClient, false)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/localstack/lstk/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -21,5 +22,5 @@ func init() {
 }
 
 func versionLine() string {
-	return fmt.Sprintf("lstk %s (%s, %s)", version, commit, buildDate)
+	return fmt.Sprintf("lstk %s (%s, %s)", version.Version(), version.Commit(), version.BuildDate())
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,24 +1,17 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestVersionLine(t *testing.T) {
-	originalVersion := version
-	originalCommit := commit
-	originalBuildDate := buildDate
-	t.Cleanup(func() {
-		version = originalVersion
-		commit = originalCommit
-		buildDate = originalBuildDate
-	})
-
-	version = "2026.2.0"
-	commit = "abc1234"
-	buildDate = "2026-02-17T15:04:05Z"
-
 	got := versionLine()
-	want := "lstk 2026.2.0 (abc1234, 2026-02-17T15:04:05Z)"
-	if got != want {
-		t.Fatalf("versionLine() = %q, want %q", got, want)
+
+	if !strings.HasPrefix(got, "lstk ") {
+		t.Fatalf("versionLine() = %q, should start with 'lstk '", got)
+	}
+	if !strings.Contains(got, "(") || !strings.Contains(got, ")") {
+		t.Fatalf("versionLine() = %q, should contain parentheses with commit and date", got)
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+// Set via ldflags at build time. Must be variables, not constants,
+// because the linker can only modify variables at link time.
+var (
+	version   = "dev"
+	commit    = "none"
+	buildDate = "unknown"
+)
+
+func Version() string   { return version }
+func Commit() string    { return commit }
+func BuildDate() string { return buildDate }


### PR DESCRIPTION
## Motivation

Going with [ZeroVer](https://0ver.org/) first keeps our options open. We can still decide later if we want CalVer or a proper SemVer 1.0.0 release. The March release doesn't need to be `0.1.0` either. It's fine if we end up at `0.6.0` after some internal iterations. We won't focus on the version number anyway. See [PRO-220](https://linear.app/localstack/issue/PRO-220).

Also, it turns out tags pushed with `GITHUB_TOKEN` don't trigger other workflows. That's why CI wasn't running automatically after creating a release tag. Using `PRO_ACCESS_TOKEN` fixes this. [GitHub docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow)

## Changes

- Switch from CalVer to ZeroVer (`v0.minor.patch`)
- Add bump type input (minor/patch) to release tag workflow
- Use PAT for tag push to trigger CI
- Move version info to `internal/version` package

## Tests

Verified goreleaser ldflags locally:
```
$ goreleaser build --snapshot --clean --single-target
$ ./dist/lstk_darwin_arm64_v8.0/lstk version
lstk 0.1.0-SNAPSHOT-ff50a42 (ff50a42..., 2026-02-24T16:27:40Z)
```