### PR TITLE
Add payload to auth request

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/localstack/lstk/internal/env"
+	"github.com/localstack/lstk/internal/version"
 )
 
 type PlatformAPI interface {
@@ -73,10 +74,20 @@ func NewPlatformClient() *PlatformClient {
 }
 
 func (c *PlatformClient) CreateAuthRequest(ctx context.Context) (*AuthRequest, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/auth/request", nil)
+	payload := map[string]string{
+		"actor":   "cli-v2",
+		"version": version.Version(),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/auth/request", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -13,6 +13,8 @@ import (
 	"github.com/localstack/lstk/internal/version"
 )
 
+const actor = "lstk"
+
 type PlatformAPI interface {
 	CreateAuthRequest(ctx context.Context) (*AuthRequest, error)
 	CheckAuthRequestConfirmed(ctx context.Context, id, exchangeToken string) (bool, error)
@@ -75,7 +77,7 @@ func NewPlatformClient() *PlatformClient {
 
 func (c *PlatformClient) CreateAuthRequest(ctx context.Context) (*AuthRequest, error) {
 	payload := map[string]string{
-		"actor":   "cli-v2",
+		"actor":   actor,
 		"version": version.Version(),
 	}
 	body, err := json.Marshal(payload)

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -32,7 +32,7 @@ func createMockAPIServer(t *testing.T, licenseToken string, confirmed bool) *htt
 			var payload map[string]string
 			err := json.NewDecoder(r.Body).Decode(&payload)
 			require.NoError(t, err, "failed to decode auth request payload")
-			assert.Equal(t, "cli-v2", payload["actor"], "actor should be cli-v2")
+			assert.Equal(t, "lstk", payload["actor"], "actor should be lstk")
 			assert.NotEmpty(t, payload["version"], "version should not be empty")
 
 			w.WriteHeader(http.StatusCreated)

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -28,8 +28,15 @@ func createMockAPIServer(t *testing.T, licenseToken string, confirmed bool) *htt
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == "POST" && r.URL.Path == "/v1/auth/request":
+			// Validate request payload
+			var payload map[string]string
+			err := json.NewDecoder(r.Body).Decode(&payload)
+			require.NoError(t, err, "failed to decode auth request payload")
+			assert.Equal(t, "cli-v2", payload["actor"], "actor should be cli-v2")
+			assert.NotEmpty(t, payload["version"], "version should not be empty")
+
 			w.WriteHeader(http.StatusCreated)
-			err := json.NewEncoder(w).Encode(map[string]string{
+			err = json.NewEncoder(w).Encode(map[string]string{
 				"id":             authReqID,
 				"code":           "TEST123",
 				"exchange_token": exchangeToken,


### PR DESCRIPTION
Add `{"actor": "lstk", "version": "0.1.0"}` as payload of `POST /v1/auth/request`.
Related PR https://github.com/localstack/localstack-platform/pull/1695
closes DRG-548
cc @Pive01 