### PR TITLE
Implement `lstk logs --follow` and exit by default

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -11,18 +11,23 @@ import (
 
 var logsCmd = &cobra.Command{
 	Use:     "logs",
-	Short:   "Stream container logs",
-	Long:    "Stream logs from the LocalStack container in real-time. Press Ctrl+C to stop.",
+	Short:   "Show container logs",
+	Long:    "Show logs from the LocalStack container. Use --follow to stream in real-time.",
 	PreRunE: initConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		follow, err := cmd.Flags().GetBool("follow")
+		if err != nil {
+			return err
+		}
 		rt, err := runtime.NewDockerRuntime()
 		if err != nil {
 			return err
 		}
-		return container.Logs(cmd.Context(), rt, output.NewPlainSink(os.Stdout))
+		return container.Logs(cmd.Context(), rt, output.NewPlainSink(os.Stdout), follow)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(logsCmd)
+	logsCmd.Flags().BoolP("follow", "f", false, "Follow log output")
 }

--- a/internal/container/logs.go
+++ b/internal/container/logs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/localstack/lstk/internal/runtime"
 )
 
-func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink) error {
+func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink, follow bool) error {
 	cfg, err := config.Get()
 	if err != nil {
 		return fmt.Errorf("failed to get config: %w", err)
@@ -26,7 +26,7 @@ func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink) error {
 	pr, pw := io.Pipe()
 	errCh := make(chan error, 1)
 	go func() {
-		err := rt.StreamLogs(ctx, c.Name(), pw)
+		err := rt.StreamLogs(ctx, c.Name(), pw, follow)
 		pw.CloseWithError(err)
 		errCh <- err
 	}()

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -152,11 +152,11 @@ func (d *DockerRuntime) Logs(ctx context.Context, containerID string, tail int) 
 	return string(logs), nil
 }
 
-func (d *DockerRuntime) StreamLogs(ctx context.Context, containerID string, out io.Writer) error {
+func (d *DockerRuntime) StreamLogs(ctx context.Context, containerID string, out io.Writer, follow bool) error {
 	reader, err := d.client.ContainerLogs(ctx, containerID, container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
-		Follow:     true,
+		Follow:     follow,
 		Tail:       "all",
 	})
 	if err != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -30,6 +30,6 @@ type Runtime interface {
 	Remove(ctx context.Context, containerName string) error
 	IsRunning(ctx context.Context, containerID string) (bool, error)
 	Logs(ctx context.Context, containerID string, tail int) (string, error)
-	StreamLogs(ctx context.Context, containerID string, out io.Writer) error
+	StreamLogs(ctx context.Context, containerID string, out io.Writer, follow bool) error
 	GetImageVersion(ctx context.Context, imageName string) (string, error)
 }


### PR DESCRIPTION
Implement `lstk logs --follow`, which should stream the logs. Exit by default on `lstk logs`.

Resolves DRG-537