### PR TITLE
Improve help command layout

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,7 +9,7 @@ import (
 
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Manage lstk configuration",
+	Short: "Manage configuration",
 }
 
 var configPathCmd = &cobra.Command{

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -1,0 +1,43 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+const usageTemplate = `Usage: {{if .HasParent}}{{.UseLine}}{{else}}lstk [options] [command]{{end}}{{if not .HasParent}}
+
+LSTK - LocalStack command-line interface{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Options:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Options:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}`
+
+const helpTemplate = `{{if not .HasParent}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{else}}{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{end}}
+`
+
+func configureHelp(cmd *cobra.Command) {
+	cmd.InitDefaultHelpFlag()
+	cmd.Flags().Lookup("help").Usage = "Show help"
+	cmd.SetUsageTemplate(usageTemplate)
+	cmd.SetHelpTemplate(helpTemplate)
+}

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func executeWithArgs(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	origOut := rootCmd.OutOrStdout()
+	origErr := rootCmd.ErrOrStderr()
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args)
+
+	err := rootCmd.ExecuteContext(context.Background())
+	out := buf.String()
+
+	rootCmd.SetArgs(nil)
+	rootCmd.SetOut(origOut)
+	rootCmd.SetErr(origErr)
+
+	return out, err
+}
+
+func TestRootHelpOutputTemplate(t *testing.T) {
+	out, err := executeWithArgs(t, "--help")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assertContains(t, out, "Usage:")
+	assertContains(t, out, "lstk [options] [command]")
+	assertContains(t, out, "LSTK - LocalStack command-line interface")
+	assertContains(t, out, "Commands:")
+	assertContains(t, out, "Options:")
+	assertNotContains(t, out, "Available Commands:")
+	assertNotContains(t, out, `Use "lstk [command] --help" for more information about a command.`)
+}
+
+func TestSubcommandHelpUsesSubcommandUsageLine(t *testing.T) {
+	out, err := executeWithArgs(t, "start", "--help")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assertContains(t, out, "Start emulator and services.")
+	assertContains(t, out, "Usage:")
+	assertContains(t, out, "lstk start")
+	assertContains(t, out, "Options:")
+	assertNotContains(t, out, "LSTK - LocalStack command-line interface")
+}
+
+func assertContains(t *testing.T, s, want string) {
+	t.Helper()
+	if !strings.Contains(s, want) {
+		t.Fatalf("expected output to contain %q\noutput:\n%s", want, s)
+	}
+}
+
+func assertNotContains(t *testing.T, s, want string) {
+	t.Helper()
+	if strings.Contains(s, want) {
+		t.Fatalf("expected output not to contain %q\noutput:\n%s", want, s)
+	}
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -11,8 +11,8 @@ import (
 
 var loginCmd = &cobra.Command{
 	Use:     "login",
-	Short:   "Authenticate with LocalStack",
-	Long:    "Authenticate with LocalStack and store credentials in system keyring",
+	Short:   "Manage login",
+	Long:    "Manage login and store credentials in system keyring",
 	PreRunE: initConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !ui.IsInteractive() {

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -12,7 +12,7 @@ import (
 
 var logoutCmd = &cobra.Command{
 	Use:     "logout",
-	Short:   "Remove stored authentication token",
+	Short:   "Remove stored authentication credentials",
 	PreRunE: initConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sink := output.NewPlainSink(os.Stdout)

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -11,8 +11,8 @@ import (
 
 var logsCmd = &cobra.Command{
 	Use:     "logs",
-	Short:   "Show container logs",
-	Long:    "Show logs from the LocalStack container. Use --follow to stream in real-time.",
+	Short:   "Show emulator logs",
+	Long:    "Show logs from the emulator. Use --follow to stream in real-time.",
 	PreRunE: initConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		follow, err := cmd.Flags().GetBool("follow")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/config"
@@ -40,32 +39,10 @@ func init() {
 	rootCmd.Version = version.Version()
 	rootCmd.SetVersionTemplate(versionLine() + "\n")
 
-	rootCmd.InitDefaultHelpFlag()
-	rootCmd.Flags().Lookup("help").Usage = "Show help"
+	configureHelp(rootCmd)
 
 	rootCmd.InitDefaultVersionFlag()
 	rootCmd.Flags().Lookup("version").Usage = "Show version"
-
-	usageTemplate := rootCmd.UsageTemplate()
-	usageTemplate = strings.Replace(usageTemplate, "Available Commands:", "Commands:", 1)
-	usageTemplate = strings.Replace(usageTemplate, "Flags:", "Options:", 1)
-	usageTemplate = strings.Replace(
-		usageTemplate,
-		`Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}`,
-		`Usage: {{if not .HasParent}}lstk [options] [command]{{else}}{{.UseLine}}{{end}}{{if not .HasParent}}
-
-LSTK - LocalStack command-line interface{{end}}`,
-		1,
-	)
-	usageTemplate = strings.ReplaceAll(usageTemplate, `Use "{{.CommandPath}} [command] --help" for more information about a command.`, "")
-	usageTemplate = strings.TrimRight(usageTemplate, "\n")
-	rootCmd.SetUsageTemplate(usageTemplate)
-
-	rootCmd.SetHelpTemplate(`{{if not .HasParent}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{else}}{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
-
-{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{end}}`)
 	rootCmd.AddCommand(startCmd)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/config"
@@ -38,6 +39,33 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.Version = version.Version()
 	rootCmd.SetVersionTemplate(versionLine() + "\n")
+
+	rootCmd.InitDefaultHelpFlag()
+	rootCmd.Flags().Lookup("help").Usage = "Show help"
+
+	rootCmd.InitDefaultVersionFlag()
+	rootCmd.Flags().Lookup("version").Usage = "Show version"
+
+	usageTemplate := rootCmd.UsageTemplate()
+	usageTemplate = strings.Replace(usageTemplate, "Available Commands:", "Commands:", 1)
+	usageTemplate = strings.Replace(usageTemplate, "Flags:", "Options:", 1)
+	usageTemplate = strings.Replace(
+		usageTemplate,
+		`Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}`,
+		`Usage: {{if not .HasParent}}lstk [options] [command]{{else}}{{.UseLine}}{{end}}{{if not .HasParent}}
+
+LSTK - LocalStack command-line interface{{end}}`,
+		1,
+	)
+	usageTemplate = strings.ReplaceAll(usageTemplate, `Use "{{.CommandPath}} [command] --help" for more information about a command.`, "")
+	usageTemplate = strings.TrimRight(usageTemplate, "\n")
+	rootCmd.SetUsageTemplate(usageTemplate)
+
+	rootCmd.SetHelpTemplate(`{{if not .HasParent}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{else}}{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{end}}`)
 	rootCmd.AddCommand(startCmd)
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,8 +10,8 @@ import (
 
 var startCmd = &cobra.Command{
 	Use:     "start",
-	Short:   "Start container",
-	Long:    "Start container and services.",
+	Short:   "Start emulator",
+	Long:    "Start emulator and services.",
 	PreRunE: initConfig,
 	Run: func(cmd *cobra.Command, args []string) {
 		rt, err := runtime.NewDockerRuntime()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,8 +10,8 @@ import (
 
 var startCmd = &cobra.Command{
 	Use:     "start",
-	Short:   "Start LocalStack",
-	Long:    "Start the LocalStack emulator.",
+	Short:   "Start container",
+	Long:    "Start container and services.",
 	PreRunE: initConfig,
 	Run: func(cmd *cobra.Command, args []string) {
 		rt, err := runtime.NewDockerRuntime()

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -11,8 +11,8 @@ import (
 
 var stopCmd = &cobra.Command{
 	Use:     "stop",
-	Short:   "Stop LocalStack",
-	Long:    "Stop the LocalStack emulator.",
+	Short:   "Stop container",
+	Long:    "Stop container and services",
 	PreRunE: initConfig,
 	Run: func(cmd *cobra.Command, args []string) {
 		rt, err := runtime.NewDockerRuntime()

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -11,8 +11,8 @@ import (
 
 var stopCmd = &cobra.Command{
 	Use:     "stop",
-	Short:   "Stop container",
-	Long:    "Stop container and services",
+	Short:   "Stop emulator",
+	Long:    "Stop emulator and services",
 	PreRunE: initConfig,
 	Run: func(cmd *cobra.Command, args []string) {
 		rt, err := runtime.NewDockerRuntime()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the lstk version",
+	Short: "Show version",
 	Long:  "Print version information for the lstk binary.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		_, err := fmt.Fprintln(cmd.OutOrStdout(), versionLine())


### PR DESCRIPTION
This will improves `help` command output readability and design.

What changed?
1.  Updated root help usage to a single line (Usage: lstk [options] [command])
1. Added a concise descriptor line under usage (LSTK - LocalStack command-line interace)
1. Renamed section headers in help output (Commands, Options)
1. Updated root flag descriptions (Show help, Show version)
1. Removed default Cobra footer
1. Updated version command short text

| BEFORE | AFTER |
|--------|--------|
| <img width="707" height="587" alt="Frame 514780677" src="https://github.com/user-attachments/assets/88a86e00-62d1-4bb0-9bdf-b953384c831f" /> | <img width="707" height="587" alt="Frame 514780677-1" src="https://github.com/user-attachments/assets/182fc644-b909-49c9-b55d-9e78bf333708" /> |