### PR TITLE
Add AGENTS.md symlink and document emulator terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Environment variables:
 - Don't add comments for self-explanatory code. Only comment when the "why" isn't obvious from the code itself.
 - Do not remove comments added by someone else than yourself.
 - Errors returned by functions should always be checked unless in test files.
+- Terminology: in user-facing CLI/help/docs, prefer `emulator` over `container`/`runtime`; use `container`/`runtime` only for internal implementation details.
 
 # Testing
 


### PR DESCRIPTION
Add agent instructions to standardize user-facing terminology, and add `AGENTS.md` symlink for other AI tools.

See [relevant discussion](https://localstack-cloud.slack.com/archives/C0A1857LGTU/p1772094161931569) for more context.