### PR TITLE
Telemetry client

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ When no config file exists, `lstk` creates one at:
 
 Use `lstk config path` to print the resolved config file path currently in use.
 
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `LOCALSTACK_AUTH_TOKEN` | Auth token; for CI only |
+| `LOCALSTACK_DISABLE_EVENTS=1` | Disables telemetry event reporting |
+
 ## Versioning
 `lstk` uses calendar versioning in a SemVer-compatible format:
 

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/localstack/lstk/internal/env"
+	"github.com/localstack/lstk/internal/telemetry"
 )
 
 func executeWithArgs(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	buf := new(bytes.Buffer)
-	cmd := NewRootCmd(&env.Env{})
+	cmd := NewRootCmd(&env.Env{}, telemetry.New("", true))
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
 	cmd.SetArgs(args)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 func Execute(ctx context.Context) error {
 	cfg := env.Init()
 	tel := telemetry.New(cfg.AnalyticsEndpoint, cfg.DisableEvents)
-	defer tel.Flush()
+	defer tel.Close()
 
 	root := NewRootCmd(cfg, tel)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,25 +17,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewRootCmd(cfg *env.Env) *cobra.Command {
+func NewRootCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	root := &cobra.Command{
 		Use:     "lstk",
 		Short:   "LocalStack CLI",
 		Long:    "lstk is the command-line interface for LocalStack.",
 		PreRunE: initConfig,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
+				return err
 			}
-
-			if err := runStart(cmd.Context(), rt, cfg); err != nil {
-				if !output.IsSilent(err) {
-					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				}
-				os.Exit(1)
-			}
+			return runStart(cmd.Context(), rt, cfg, tel)
 		},
 	}
 
@@ -48,7 +41,7 @@ func NewRootCmd(cfg *env.Env) *cobra.Command {
 	root.Flags().Lookup("version").Usage = "Show version"
 
 	root.AddCommand(
-		newStartCmd(cfg),
+		newStartCmd(cfg, tel),
 		newStopCmd(),
 		newLoginCmd(cfg),
 		newLogoutCmd(cfg),
@@ -62,12 +55,21 @@ func NewRootCmd(cfg *env.Env) *cobra.Command {
 
 func Execute(ctx context.Context) error {
 	cfg := env.Init()
-	return NewRootCmd(cfg).ExecuteContext(ctx)
-}
-
-func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env) error {
 	tel := telemetry.New(cfg.AnalyticsEndpoint, cfg.DisableEvents)
 	defer tel.Flush()
+
+	root := NewRootCmd(cfg, tel)
+
+	if err := root.ExecuteContext(ctx); err != nil {
+		if !output.IsSilent(err) {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+		return err
+	}
+	return nil
+}
+
+func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client) error {
 	// TODO: replace map with a typed payload struct once event schema is finalised
 	tel.Track("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/localstack/lstk/internal/version"
 	"github.com/spf13/cobra"
@@ -65,6 +66,11 @@ func Execute(ctx context.Context) error {
 }
 
 func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env) error {
+	tel := telemetry.New(cfg.AnalyticsEndpoint, cfg.DisableEvents)
+	defer tel.Flush()
+	// TODO: replace map with a typed payload struct once event schema is finalised
+	tel.Track("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
+
 	platformClient := api.NewPlatformClient(cfg.APIEndpoint)
 	if ui.IsInteractive() {
 		return ui.Run(ctx, rt, version.Version(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,7 @@ func Execute(ctx context.Context) error {
 
 func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client) error {
 	// TODO: replace map with a typed payload struct once event schema is finalised
-	tel.Track("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
+	tel.Emit("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
 
 	platformClient := api.NewPlatformClient(cfg.APIEndpoint)
 	if ui.IsInteractive() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,7 @@ func Execute(ctx context.Context) error {
 
 func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client) error {
 	// TODO: replace map with a typed payload struct once event schema is finalised
-	tel.Emit("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
+	tel.Emit(ctx, "cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
 
 	platformClient := api.NewPlatformClient(cfg.APIEndpoint)
 	if ui.IsInteractive() {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,34 +1,24 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/localstack/lstk/internal/env"
-	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
-func newStartCmd(cfg *env.Env) *cobra.Command {
+func newStartCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:     "start",
 		Short:   "Start emulator",
 		Long:    "Start emulator and services.",
 		PreRunE: initConfig,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
+				return err
 			}
-
-			if err := runStart(cmd.Context(), rt, cfg); err != nil {
-				if !output.IsSilent(err) {
-					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				}
-				os.Exit(1)
-			}
+			return runStart(cmd.Context(), rt, cfg, tel)
 		},
 	}
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/localstack/lstk/internal/container"
 	"github.com/localstack/lstk/internal/runtime"
@@ -15,21 +14,14 @@ func newStopCmd() *cobra.Command {
 		Short:   "Stop emulator",
 		Long:    "Stop emulator and services",
 		PreRunE: initConfig,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
+				return err
 			}
-
-			onProgress := func(msg string) {
+			return container.Stop(cmd.Context(), rt, func(msg string) {
 				fmt.Println(msg)
-			}
-
-			if err := container.Stop(cmd.Context(), rt, onProgress); err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				os.Exit(1)
-			}
+			})
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
+	github.com/google/uuid v1.6.0
 	github.com/muesli/termenv v0.16.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -8,10 +8,12 @@ import (
 )
 
 type Env struct {
-	AuthToken        string
-	APIEndpoint      string
-	WebAppURL        string
-	ForceFileKeyring bool
+	AuthToken         string
+	APIEndpoint       string
+	WebAppURL         string
+	ForceFileKeyring  bool
+	AnalyticsEndpoint string
+	DisableEvents     bool
 }
 
 // Init initializes environment variable configuration and returns the result.
@@ -22,14 +24,16 @@ func Init() *Env {
 
 	viper.SetDefault("api_endpoint", "https://api.localstack.cloud")
 	viper.SetDefault("web_app_url", "https://app.localstack.cloud")
-
-	// LOCALSTACK_AUTH_TOKEN is not prefixed with LSTK_
-	// in order to be shared seamlessly with other LocalStack tools
+	viper.SetDefault("analytics_endpoint", "https://analytics.localstack.cloud/v1/events")
+	// LOCALSTACK_AUTH_TOKEN and LOCALSTACK_DISABLE_EVENTS are not prefixed with LSTK_
+	// so they work seamlessly across all LocalStack tools without per-tool configuration
 	return &Env{
-		AuthToken:        os.Getenv("LOCALSTACK_AUTH_TOKEN"),
-		APIEndpoint:      viper.GetString("api_endpoint"),
-		WebAppURL:        viper.GetString("web_app_url"),
-		ForceFileKeyring: viper.GetString("keyring") == "file",
+		AuthToken:         os.Getenv("LOCALSTACK_AUTH_TOKEN"),
+		APIEndpoint:       viper.GetString("api_endpoint"),
+		WebAppURL:         viper.GetString("web_app_url"),
+		ForceFileKeyring:  viper.GetString("keyring") == "file",
+		AnalyticsEndpoint: viper.GetString("analytics_endpoint"),
+		DisableEvents:     os.Getenv("LOCALSTACK_DISABLE_EVENTS") == "1",
 	}
 
 }

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"runtime"
@@ -13,7 +14,9 @@ import (
 	"github.com/localstack/lstk/internal/version"
 )
 
-const clientHeader = "lstk/v2"
+func userAgent() string {
+	return fmt.Sprintf("localstack lstk/%s (%s; %s)", version.Version(), runtime.GOOS, runtime.GOARCH)
+}
 
 type Client struct {
 	enabled    bool
@@ -97,7 +100,7 @@ func (c *Client) Track(name string, payload map[string]any) {
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-Client", clientHeader)
+		req.Header.Set("User-Agent", userAgent())
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -20,30 +19,36 @@ func userAgent() string {
 }
 
 type Client struct {
-	enabled    bool
-	sessionID  string
-	machineID  string
+	enabled   bool
+	sessionID string
+	machineID string
+
 	httpClient *http.Client
 	endpoint   string
-	wg         sync.WaitGroup
+
+	events chan eventBody
+	done   chan struct{}
 }
 
 func New(endpoint string, disabled bool) *Client {
 	if disabled {
 		return &Client{enabled: false}
 	}
-	return &Client{
+	c := &Client{
 		enabled:   true,
 		sessionID: uuid.NewString(),
 		machineID: LoadOrCreateMachineID(),
 		// http.Client has no default timeout (zero means none). Without one, a
-		// slow or unreachable endpoint would block the goroutine until process
-		// exit — which matters for long-running commands like `lstk logs --follow`.
+		// slow or unreachable endpoint would block the worker goroutine.
 		httpClient: &http.Client{
 			Timeout: 3 * time.Second,
 		},
 		endpoint: endpoint,
+		events:   make(chan eventBody, 64),
+		done:     make(chan struct{}),
 	}
+	go c.worker()
+	return c
 }
 
 type requestBody struct {
@@ -51,9 +56,10 @@ type requestBody struct {
 }
 
 type eventBody struct {
-	Name     string        `json:"name"`
-	Metadata eventMetadata `json:"metadata"`
-	Payload  any           `json:"payload"`
+	ctx      context.Context // not serialized; carries context to the worker
+	Name     string          `json:"name"`
+	Metadata eventMetadata   `json:"metadata"`
+	Payload  any             `json:"payload"`
 }
 
 type eventMetadata struct {
@@ -79,6 +85,7 @@ func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) 
 	}
 
 	body := eventBody{
+		ctx:  context.WithoutCancel(ctx),
 		Name: name,
 		Metadata: eventMetadata{
 			ClientTime: time.Now().UTC().Format("2006-01-02 15:04:05.000000"),
@@ -87,35 +94,46 @@ func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) 
 		Payload: enriched,
 	}
 
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
-
-		data, err := json.Marshal(requestBody{Events: []eventBody{body}})
-		if err != nil {
-			return
-		}
-
-		req, err := http.NewRequestWithContext(context.WithoutCancel(ctx), http.MethodPost, c.endpoint, bytes.NewReader(data))
-		if err != nil {
-			return
-		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("User-Agent", userAgent())
-
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			return
-		}
-		_ = resp.Body.Close()
-	}()
+	select {
+	case c.events <- body:
+	default:
+	}
 }
 
-// Flush blocks until all in-flight Track goroutines have completed. Call it
-// before process exit to avoid dropping telemetry events. It returns quickly
-// when no events are pending, and is bounded by the HTTP client's timeout in
-// the worst case.
-func (c *Client) Flush() {
-	c.wg.Wait()
+func (c *Client) worker() {
+	defer close(c.done)
+	for body := range c.events {
+		c.send(body)
+	}
 }
 
+func (c *Client) send(body eventBody) {
+	data, err := json.Marshal(requestBody{Events: []eventBody{body}})
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(body.ctx, http.MethodPost, c.endpoint, bytes.NewReader(data))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgent())
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+// Close stops accepting new events, drains the event buffer, and blocks until
+// all pending HTTP requests have completed. Call it before process exit to
+// avoid dropping telemetry events.
+func (c *Client) Close() {
+	if !c.enabled {
+		return
+	}
+	close(c.events)
+	<-c.done
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -79,7 +79,7 @@ func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) 
 	enriched["version"] = version.Version()
 	enriched["os"] = runtime.GOOS
 	enriched["arch"] = runtime.GOARCH
-	enriched["is_ci"] = os.Getenv("CI") != ""
+	_, enriched["is_ci"] = os.LookupEnv("CI")
 	if c.machineID != "" {
 		enriched["machine_id"] = c.machineID
 	}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -26,8 +27,9 @@ type Client struct {
 	httpClient *http.Client
 	endpoint   string
 
-	events chan eventBody
-	done   chan struct{}
+	events    chan eventBody
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 func New(endpoint string, disabled bool) *Client {
@@ -134,6 +136,8 @@ func (c *Client) Close() {
 	if !c.enabled {
 		return
 	}
-	close(c.events)
-	<-c.done
+	c.closeOnce.Do(func() {
+		close(c.events)
+		<-c.done
+	})
 }

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,0 +1,117 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/localstack/lstk/internal/version"
+)
+
+const clientHeader = "lstk/v2"
+
+type Client struct {
+	enabled    bool
+	sessionID  string
+	machineID  string
+	httpClient *http.Client
+	endpoint   string
+	wg         sync.WaitGroup
+}
+
+func New(endpoint string, disabled bool) *Client {
+	if disabled {
+		return &Client{enabled: false}
+	}
+	return &Client{
+		enabled:   true,
+		sessionID: uuid.NewString(),
+		machineID: LoadOrCreateMachineID(),
+		// http.Client has no default timeout (zero means none). Without one, a
+		// slow or unreachable endpoint would block the goroutine until process
+		// exit — which matters for long-running commands like `lstk logs --follow`.
+		httpClient: &http.Client{
+			Timeout: 3 * time.Second,
+		},
+		endpoint: endpoint,
+	}
+}
+
+type requestBody struct {
+	Events []eventBody `json:"events"`
+}
+
+type eventBody struct {
+	Name     string        `json:"name"`
+	Metadata eventMetadata `json:"metadata"`
+	Payload  any           `json:"payload"`
+}
+
+type eventMetadata struct {
+	ClientTime string `json:"client_time"`
+	SessionID  string `json:"session_id"`
+}
+
+func (c *Client) Track(name string, payload map[string]any) {
+	if !c.enabled {
+		return
+	}
+
+	enriched := make(map[string]any, len(payload)+6)
+	for k, v := range payload {
+		enriched[k] = v
+	}
+	enriched["version"] = version.Version()
+	enriched["os"] = runtime.GOOS
+	enriched["arch"] = runtime.GOARCH
+	enriched["is_ci"] = os.Getenv("CI") != ""
+	if c.machineID != "" {
+		enriched["machine_id"] = c.machineID
+	}
+
+	body := eventBody{
+		Name: name,
+		Metadata: eventMetadata{
+			ClientTime: time.Now().UTC().Format("2006-01-02 15:04:05.000000"),
+			SessionID:  c.sessionID,
+		},
+		Payload: enriched,
+	}
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+
+		data, err := json.Marshal(requestBody{Events: []eventBody{body}})
+		if err != nil {
+			return
+		}
+
+		req, err := http.NewRequest(http.MethodPost, c.endpoint, bytes.NewReader(data))
+		if err != nil {
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Client", clientHeader)
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return
+		}
+		_ = resp.Body.Close()
+	}()
+}
+
+// Flush blocks until all in-flight Track goroutines have completed. Call it
+// before process exit to avoid dropping telemetry events. It returns quickly
+// when no events are pending, and is bounded by the HTTP client's timeout in
+// the worst case.
+func (c *Client) Flush() {
+	c.wg.Wait()
+}
+

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -60,7 +61,7 @@ type eventMetadata struct {
 	SessionID  string `json:"session_id"`
 }
 
-func (c *Client) Emit(name string, payload map[string]any) {
+func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) {
 	if !c.enabled {
 		return
 	}
@@ -95,7 +96,7 @@ func (c *Client) Emit(name string, payload map[string]any) {
 			return
 		}
 
-		req, err := http.NewRequest(http.MethodPost, c.endpoint, bytes.NewReader(data))
+		req, err := http.NewRequestWithContext(context.WithoutCancel(ctx), http.MethodPost, c.endpoint, bytes.NewReader(data))
 		if err != nil {
 			return
 		}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -60,7 +60,7 @@ type eventMetadata struct {
 	SessionID  string `json:"session_id"`
 }
 
-func (c *Client) Track(name string, payload map[string]any) {
+func (c *Client) Emit(name string, payload map[string]any) {
 	if !c.enabled {
 		return
 	}

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -42,7 +42,7 @@ func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
 
 	c := New(srv.URL, false)
 	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
-	c.Flush()
+	c.Close()
 
 	var got captured
 	select {

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -40,7 +41,7 @@ func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, false)
-	c.Emit("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
+	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
 	c.Flush()
 
 	var got captured

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -40,7 +40,7 @@ func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, false)
-	c.Track("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
+	c.Emit("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
 	c.Flush()
 
 	var got captured

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -24,15 +24,17 @@ func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		var req struct {
 			Events []map[string]any `json:"events"`
 		}
-		require.NoError(t, json.Unmarshal(body, &req))
-		require.Len(t, req.Events, 1)
+		assert.NoError(t, json.Unmarshal(body, &req))
+		assert.Len(t, req.Events, 1)
 
-		ch <- captured{event: req.Events[0], header: r.Header.Clone()}
+		if len(req.Events) == 1 {
+			ch <- captured{event: req.Events[0], header: r.Header.Clone()}
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -41,7 +43,12 @@ func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
 	c.Track("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
 	c.Flush()
 
-	got := <-ch
+	var got captured
+	select {
+	case got = <-ch:
+	default:
+		t.Fatal("no telemetry event received")
+	}
 
 	assert.Equal(t, "cli_cmd", got.event["name"])
 

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -16,6 +16,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestClose_IsIdempotent(t *testing.T) {
+	c := New("http://localhost", false)
+	c.Close()
+	// Second call must not panic.
+	c.Close()
+}
+
 func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
 	type captured struct {
 		event  map[string]any

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -67,7 +67,8 @@ func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
 	assert.Equal(t, version.Version(), payload["version"])
 	assert.Equal(t, runtime.GOOS, payload["os"])
 	assert.Equal(t, runtime.GOARCH, payload["arch"])
-	assert.Equal(t, os.Getenv("CI") != "", payload["is_ci"])
+	_, isCI := os.LookupEnv("CI")
+	assert.Equal(t, isCI, payload["is_ci"])
 
 	assert.Equal(t, userAgent(), got.header.Get("User-Agent"))
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,0 +1,65 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/localstack/lstk/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
+	type captured struct {
+		event  map[string]any
+		header http.Header
+	}
+	ch := make(chan captured, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var req struct {
+			Events []map[string]any `json:"events"`
+		}
+		require.NoError(t, json.Unmarshal(body, &req))
+		require.Len(t, req.Events, 1)
+
+		ch <- captured{event: req.Events[0], header: r.Header.Clone()}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, false)
+	c.Track("cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
+	c.Flush()
+
+	got := <-ch
+
+	assert.Equal(t, "cli_cmd", got.event["name"])
+
+	metadata, ok := got.event["metadata"].(map[string]any)
+	require.True(t, ok, "metadata should be an object")
+	assert.Equal(t, c.sessionID, metadata["session_id"])
+	_, err := time.Parse("2006-01-02 15:04:05.000000", metadata["client_time"].(string))
+	assert.NoError(t, err, "client_time should match expected format")
+	assert.Nil(t, metadata["version"], "version should be in payload, not metadata")
+	assert.Nil(t, metadata["machine_id"], "machine_id should be in payload, not metadata")
+
+	payload, ok := got.event["payload"].(map[string]any)
+	require.True(t, ok, "payload should be an object")
+	assert.Equal(t, "lstk start", payload["cmd"])
+	assert.Equal(t, version.Version(), payload["version"])
+	assert.Equal(t, runtime.GOOS, payload["os"])
+	assert.Equal(t, runtime.GOARCH, payload["arch"])
+	assert.Equal(t, os.Getenv("CI") != "", payload["is_ci"])
+
+	assert.Equal(t, "lstk/v2", got.header.Get("X-Client"))
+}

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -68,5 +68,5 @@ func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
 	assert.Equal(t, runtime.GOARCH, payload["arch"])
 	assert.Equal(t, os.Getenv("CI") != "", payload["is_ci"])
 
-	assert.Equal(t, "lstk/v2", got.header.Get("X-Client"))
+	assert.Equal(t, userAgent(), got.header.Get("User-Agent"))
 }

--- a/internal/telemetry/machine_id.go
+++ b/internal/telemetry/machine_id.go
@@ -1,0 +1,49 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/localstack/lstk/internal/config"
+)
+
+const machineIDFileName = "machine_id"
+
+// LoadOrCreateMachineID reads the persisted machine ID from disk, generating
+// and writing a new one if none exists. Returns an empty string on any error
+// so that telemetry can continue without a machine ID rather than failing.
+func LoadOrCreateMachineID() string {
+	path, err := machineIDPath()
+	if err != nil {
+		return ""
+	}
+
+	data, err := os.ReadFile(path)
+	if err == nil {
+		id := strings.TrimSpace(string(data))
+		if id != "" {
+			return id
+		}
+	} else if !os.IsNotExist(err) {
+		return ""
+	}
+
+	id := uuid.NewString()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return ""
+	}
+	if err := os.WriteFile(path, []byte(id), 0600); err != nil {
+		return ""
+	}
+	return id
+}
+
+func machineIDPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, machineIDFileName), nil
+}

--- a/internal/telemetry/machine_id.go
+++ b/internal/telemetry/machine_id.go
@@ -1,23 +1,67 @@
 package telemetry
 
 import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
 
+	dockerclient "github.com/docker/docker/client"
 	"github.com/google/uuid"
 	"github.com/localstack/lstk/internal/config"
 )
 
-const machineIDFileName = "machine_id"
+const (
+	machineIDFileName = "machine_id"
+	salt              = "ls"
+)
 
-// LoadOrCreateMachineID reads the persisted machine ID from disk, generating
-// and writing a new one if none exists. Returns an empty string on any error
-// so that telemetry can continue without a machine ID rather than failing.
+// LoadOrCreateMachineID attempts to derive a stable, anonymized machine ID by
+// trying in order: Docker daemon ID, /etc/machine-id, then a persisted random UUID.
+// Prefixes (dkr_, sys_, gen_) indicate origin, matching the Python implementation
+// in localstack-core so IDs can be correlated across tools.
 func LoadOrCreateMachineID() string {
-	path, err := machineIDPath()
+	if id := dockerDaemonID(); id != "" {
+		return "dkr_" + anonymize(id)
+	}
+	if id := systemMachineID(); id != "" {
+		return "sys_" + anonymize(id)
+	}
+	return "gen_" + persistedRandomID()
+}
+
+func anonymize(physicalID string) string {
+	h := md5.Sum([]byte(salt + physicalID))
+	return hex.EncodeToString(h[:])[:12]
+}
+
+func dockerDaemonID() string {
+	c, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
 	if err != nil {
 		return ""
+	}
+	defer func() { _ = c.Close() }()
+	info, err := c.Info(context.Background())
+	if err != nil {
+		return ""
+	}
+	return info.ID
+}
+
+func systemMachineID() string {
+	data, err := os.ReadFile("/etc/machine-id")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func persistedRandomID() string {
+	path, err := machineIDPath()
+	if err != nil {
+		return uuid.NewString()[:12]
 	}
 
 	data, err := os.ReadFile(path)
@@ -27,16 +71,14 @@ func LoadOrCreateMachineID() string {
 			return id
 		}
 	} else if !os.IsNotExist(err) {
-		return ""
+		return uuid.NewString()[:12]
 	}
 
-	id := uuid.NewString()
+	id := uuid.NewString()[:12]
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return ""
+		return id
 	}
-	if err := os.WriteFile(path, []byte(id), 0600); err != nil {
-		return ""
-	}
+	_ = os.WriteFile(path, []byte(id), 0600)
 	return id
 }
 

--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -9,10 +9,12 @@ import (
 type Key string
 
 const (
-	AuthToken   Key = "LOCALSTACK_AUTH_TOKEN"
-	APIEndpoint Key = "LSTK_API_ENDPOINT"
-	Keyring     Key = "LSTK_KEYRING"
-	CI          Key = "CI"
+	AuthToken         Key = "LOCALSTACK_AUTH_TOKEN"
+	APIEndpoint       Key = "LSTK_API_ENDPOINT"
+	Keyring           Key = "LSTK_KEYRING"
+	CI                Key = "CI"
+	AnalyticsEndpoint Key = "LSTK_ANALYTICS_ENDPOINT"
+	DisableEvents     Key = "LOCALSTACK_DISABLE_EVENTS"
 )
 
 func Get(key Key) string {

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/99designs/keyring v1.2.2
 	github.com/creack/pty v1.1.18
 	github.com/docker/docker v28.2.2+incompatible
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/test/integration/telemetry_test.go
+++ b/test/integration/telemetry_test.go
@@ -83,8 +83,7 @@ func TestStartCommandSendsTelemetryEvent(t *testing.T) {
 		assert.NotEmpty(t, payload["version"])
 		assert.Equal(t, runtime.GOOS, payload["os"])
 		assert.Equal(t, runtime.GOARCH, payload["arch"])
-		_, err = uuid.Parse(payload["machine_id"].(string))
-		assert.NoError(t, err, "machine_id should be a valid UUID")
+		assert.NotEmpty(t, payload["machine_id"], "machine_id should be present")
 		assert.Equal(t, os.Getenv("CI") != "", payload["is_ci"])
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for telemetry event")

--- a/test/integration/telemetry_test.go
+++ b/test/integration/telemetry_test.go
@@ -1,0 +1,138 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockAnalyticsServer returns a test server that records received analytics events.
+// The returned channel receives one value per event (unwrapped from the events array).
+func mockAnalyticsServer(t *testing.T) (*httptest.Server, <-chan map[string]any) {
+	t.Helper()
+	ch := make(chan map[string]any, 10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var req struct {
+			Events []map[string]any `json:"events"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		for _, event := range req.Events {
+			ch <- event
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, ch
+}
+
+func TestStartCommandSendsTelemetryEvent(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Pre-start a container so lstk start exits immediately after telemetry fires,
+	// without needing a real token or license server.
+	startTestContainer(t, ctx)
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd.Env = env.With(env.AuthToken, "fake-token").
+		With(env.AnalyticsEndpoint, analyticsSrv.URL)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "lstk start failed: %s", out)
+
+	// The telemetry goroutine is async; wait up to 3s for the event to arrive.
+	select {
+	case event := <-events:
+		assert.Equal(t, "cli_cmd", event["name"])
+
+		metadata, ok := event["metadata"].(map[string]any)
+		require.True(t, ok)
+		_, err := uuid.Parse(metadata["session_id"].(string))
+		assert.NoError(t, err, "session_id should be a valid UUID")
+		_, err = time.Parse("2006-01-02 15:04:05.000000", metadata["client_time"].(string))
+		assert.NoError(t, err, "client_time should match expected format")
+
+		payload, ok := event["payload"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "lstk start", payload["cmd"])
+		assert.NotEmpty(t, payload["version"])
+		assert.Equal(t, runtime.GOOS, payload["os"])
+		assert.Equal(t, runtime.GOARCH, payload["arch"])
+		_, err = uuid.Parse(payload["machine_id"].(string))
+		assert.NoError(t, err, "machine_id should be a valid UUID")
+		assert.Equal(t, os.Getenv("CI") != "", payload["is_ci"])
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for telemetry event")
+	}
+}
+
+func TestStartCommandSucceedsWhenAnalyticsEndpointUnreachable(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	startTestContainer(t, ctx)
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd.Env = env.With(env.AuthToken, "fake-token").
+		With(env.AnalyticsEndpoint, "http://127.0.0.1:1")
+	out, err := cmd.CombinedOutput()
+
+	require.NoError(t, err, "lstk start should succeed even when analytics endpoint is unreachable: %s", out)
+}
+
+func TestStartCommandDoesNotSendTelemetryWhenDisabled(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	startTestContainer(t, ctx)
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd.Env = env.With(env.AuthToken, "fake-token").
+		With(env.AnalyticsEndpoint, analyticsSrv.URL).
+		With(env.DisableEvents, "1")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "lstk start failed: %s", out)
+
+	// Wait long enough that a goroutine would have fired if enabled.
+	select {
+	case event := <-events:
+		t.Fatalf("unexpected telemetry event received: %v", event)
+	case <-time.After(time.Second):
+		// No event received — correct.
+	}
+}


### PR DESCRIPTION
Adds a telemetry client that fires a single `cli_cmd` event when `lstk start` runs (this is merely to not have deadcode. Defining telemetry is still WIP PRO-210) 

- Enriches every event with `version`, `os`, `arch`, `is_ci`, `machine_id` (persistent uuid stored in the lstk config dir),  a per-session UUID (ultimately one session ID per command), a `X-Client` header with value `lstk/v2`
- Can be disabled when `LOCALSTACK_DISABLE_EVENTS=1`
- Sent in a background goroutine with a 3s timeout so a slow/unreachable endpoint never blocks
- Flushes on exit so that the event is sent even when the command returns early

## :heavy_check_mark: Tested

Ran analytics-backend locally and observed:
```{"timestamp": "2026-03-03T12:08:38.280", "level": "INFO", "threadName": "Dummy-8", "process": 1312488, "name": "analytics.core", "message": "record_events: Event(name='cli_cmd', metadata=EventMetadata(session_id='6ec424b8-0196-4815-83b7-2ae45e2d6146', client_time='2026-03-03 11:08:28.019701'), payload={'arch': 'amd64', 'cmd': 'lstk start', 'is_ci': False, 'machine_id': '5df95f6a-6dc0-4449-9ea8-f0f1b23b8f7c', 'os': 'linux', 'params': [], 'version': 'dev'})"}```
