### PR TITLE
Add homebrew private tap publishing target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,14 @@ version: 2
 
 project_name: lstk
 
+before:
+  hooks:
+    - go mod tidy
+    - mkdir -p completions
+    - sh -c "go run . completion bash > completions/lstk.bash"
+    - sh -c "go run . completion zsh > completions/lstk.zsh"
+    - sh -c "go run . completion fish > completions/lstk.fish"
+
 builds:
   - id: lstk
     main: ./main.go
@@ -31,9 +39,34 @@ archives:
       - goos: windows
         formats:
           - zip
+    files:
+      - completions/*
 
 checksum:
   name_template: checksums.txt
 
 changelog:
   use: github-native
+
+homebrew_casks:
+  - name: lstk
+    directory: Casks
+    repository:
+      owner: localstack
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/localstack/lstk
+    description: "LocalStack CLI v2 - Start and manage LocalStack emulators"
+    license: Apache-2.0
+    url:
+      verified: github.com/localstack/lstk
+    completions:
+      bash: completions/lstk.bash
+      zsh: completions/lstk.zsh
+      fish: completions/lstk.fish
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/lstk"]
+          end


### PR DESCRIPTION
Adds automatic Homebrew cask publishing to `localstack/homebrew-tap` via GoReleaser. This is the first step toward Homebrew distribution. Once this works, we can submit to homebrew-core for `brew install lstk` without the tap.

## Changes

- Add `homebrew_casks` config to `.goreleaser.yaml`
- Generate shell completions (bash/zsh/fish) and include them in archives
- Add quarantine removal hook for unsigned macOS binaries
- Pass `HOMEBREW_TAP_TOKEN` to release job

## After merge

1. Tag a release to trigger the first cask publish
2. Verify the cask appears in `localstack/homebrew-tap/Casks/lstk.rb`
3. Test: `brew tap localstack/tap && brew install --cask lstk`

## Validation

- `goreleaser check` passes
- Config mirrors [goreleaser's own setup](https://github.com/goreleaser/goreleaser/blob/main/.goreleaser.yaml)
- `PRO_ACCESS_TOKEN` already has write access to homebrew-tap (used by localstack-cli)