### PR TITLE
fix: logout message when auth token env var is set

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -62,14 +62,17 @@ func (a *Auth) Logout() error {
 	output.EmitSpinnerStart(a.sink, "Logging out...")
 
 	_, err := a.tokenStorage.GetAuthToken()
-	if errors.Is(err, ErrTokenNotFound) {
-		output.EmitSpinnerStop(a.sink)
-		output.EmitNote(a.sink, "Not currently logged in")
-		return ErrNotLoggedIn
-	}
 	if err != nil {
 		output.EmitSpinnerStop(a.sink)
-		return fmt.Errorf("failed to read auth token: %w", err)
+		if env.Vars.AuthToken != "" {
+			output.EmitNote(a.sink, "Authenticated via LOCALSTACK_AUTH_TOKEN environment variable; unset it to log out")
+			return nil
+		}
+		if !errors.Is(err, ErrTokenNotFound) {
+			return fmt.Errorf("failed to read auth token: %w", err)
+		}
+		output.EmitNote(a.sink, "Not currently logged in")
+		return ErrNotLoggedIn
 	}
 
 	if err := a.tokenStorage.DeleteAuthToken(); err != nil {

--- a/test/integration/logout_test.go
+++ b/test/integration/logout_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,9 +45,26 @@ func TestLogoutCommandSucceedsWhenNoToken(t *testing.T) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, binaryPath(), "logout")
+	cmd.Env = env.Without(env.AuthToken)
 	output, err := cmd.CombinedOutput()
 
 	// Should succeed even if no token
 	require.NoError(t, err, "lstk logout should succeed even with no token: %s", output)
 	assert.Contains(t, string(output), "Not currently logged in")
 }
+
+func TestLogoutCommandWithEnvVarToken(t *testing.T) {
+	// Ensure no keyring token — only the env var is set
+	_ = DeleteAuthTokenFromKeyring()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "logout")
+	cmd.Env = env.Without(env.AuthToken).With(env.AuthToken, "test-env-token")
+	output, err := cmd.CombinedOutput()
+
+	require.NoError(t, err, "lstk logout should succeed: %s", output)
+	assert.Contains(t, string(output), "LOCALSTACK_AUTH_TOKEN")
+}
+


### PR DESCRIPTION
Fix message when the user is trying to logout but they are authenticated using the `LOCALSTACK_AUTH_TOKEN` env var:
<img width="1036" height="1028" alt="logout" src="https://github.com/user-attachments/assets/e3cc2546-0635-47ee-8aae-d0a203e58eec" />
