### PR TITLE
Add npm publishing for npx lstk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,3 +158,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to NPM
+        uses: evg4b/goreleaser-npm-publisher-action@v1
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
+          license: Apache-2.0
+          description: "LocalStack CLI v2 - Start and manage LocalStack emulators"
+          keywords: localstack, cli, aws, emulator, docker


### PR DESCRIPTION
Adds automatic npm publishing via `evg4b/goreleaser-npm-publisher-action`. This enables users to run the CLI directly with `npx lstk` without any installation.

GoReleaser's native npm publisher is a Pro-only feature. The `evg4b/goreleaser-npm-publisher-action` is an open-source alternative that works the same way. It reads GoReleaser's output and creates npm packages that download the correct binary for the user's platform during `postinstall`.

## Changes

- Add Node.js setup step to release job
- Add `goreleaser-npm-publisher-action` to publish npm packages after GoReleaser builds

## After merge

1. Tag a release to trigger the first npm publish (this will claim the `lstk` name)
2. Test: `npx lstk version`

## Related

FLC-464