### PR TITLE
Remove left indent from messages in TUI

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -26,6 +26,7 @@ type styledLine struct {
 	text      string
 	highlight bool
 	secondary bool
+	noIndent  bool
 }
 
 type App struct {
@@ -164,7 +165,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.spinner, _ = a.spinner.Stop()
 		return a, nil
 	case output.MessageEvent:
-		line := styledLine{text: components.RenderMessage(msg)}
+		noIndent := msg.Severity == output.SeveritySuccess || msg.Severity == output.SeverityNote || msg.Severity == output.SeverityWarning
+		line := styledLine{text: components.RenderMessage(msg), noIndent: noIndent}
 		if a.spinner.PendingStop() {
 			a.bufferedLines = append(a.bufferedLines, line)
 		} else {
@@ -322,6 +324,9 @@ func (a App) View() string {
 			sb.WriteString(indent)
 			text := wrap.HardWrap(line.text, contentWidth)
 			sb.WriteString(styles.SecondaryMessage.Render(text))
+		} else if line.noIndent {
+			text := wrap.HardWrap(line.text, a.width)
+			sb.WriteString(text)
 		} else {
 			sb.WriteString(indent)
 			text := wrap.HardWrap(line.text, contentWidth)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -26,7 +26,6 @@ type styledLine struct {
 	text      string
 	highlight bool
 	secondary bool
-	noIndent  bool
 }
 
 type App struct {
@@ -165,8 +164,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.spinner, _ = a.spinner.Stop()
 		return a, nil
 	case output.MessageEvent:
-		noIndent := msg.Severity == output.SeveritySuccess || msg.Severity == output.SeverityNote || msg.Severity == output.SeverityWarning
-		line := styledLine{text: components.RenderMessage(msg), noIndent: noIndent}
+		line := styledLine{text: components.RenderMessage(msg)}
 		if a.spinner.PendingStop() {
 			a.bufferedLines = append(a.bufferedLines, line)
 		} else {
@@ -279,7 +277,6 @@ func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) s
 	return fmt.Sprintf("%s %s", firstLine, selected)
 }
 
-const lineIndent = 2
 
 
 func isURL(s string) bool {
@@ -297,39 +294,30 @@ func (a App) View() string {
 		sb.WriteString("\n")
 	}
 
-	indent := strings.Repeat(" ", lineIndent)
-	contentWidth := a.width - lineIndent
 	for _, line := range a.lines {
 		if line.highlight {
 			if isURL(line.text) {
-				wrapped := strings.Split(wrap.HardWrap(line.text, contentWidth), "\n")
+				wrapped := strings.Split(wrap.HardWrap(line.text, a.width), "\n")
 				var styledParts []string
 				for _, part := range wrapped {
 					styledParts = append(styledParts, styles.Link.Render(part))
 				}
-				sb.WriteString(indent)
-				sb.WriteString(hyperlink(line.text, strings.Join(styledParts, "\n"+indent)))
+				sb.WriteString(hyperlink(line.text, strings.Join(styledParts, "\n")))
 			} else {
-				sb.WriteString(indent)
-				sb.WriteString(styles.Highlight.Render(wrap.HardWrap(line.text, contentWidth)))
+				sb.WriteString(styles.Highlight.Render(wrap.HardWrap(line.text, a.width)))
 			}
 			sb.WriteString("\n\n")
 			continue
 		} else if line.secondary {
 			if strings.HasPrefix(line.text, ">") {
-				sb.WriteString(styles.SecondaryMessage.Render(wrap.HardWrap(line.text, contentWidth)))
+				sb.WriteString(styles.SecondaryMessage.Render(wrap.HardWrap(line.text, a.width)))
 				sb.WriteString("\n\n")
 				continue
 			}
-			sb.WriteString(indent)
-			text := wrap.HardWrap(line.text, contentWidth)
-			sb.WriteString(styles.SecondaryMessage.Render(text))
-		} else if line.noIndent {
 			text := wrap.HardWrap(line.text, a.width)
-			sb.WriteString(text)
+			sb.WriteString(styles.SecondaryMessage.Render(text))
 		} else {
-			sb.WriteString(indent)
-			text := wrap.HardWrap(line.text, contentWidth)
+			text := wrap.HardWrap(line.text, a.width)
 			sb.WriteString(text)
 		}
 		sb.WriteString("\n")
@@ -347,7 +335,7 @@ func (a App) View() string {
 		sb.WriteString("\n")
 	}
 
-	if errorView := a.errorDisplay.View(contentWidth); errorView != "" {
+	if errorView := a.errorDisplay.View(a.width); errorView != "" {
 		sb.WriteString(errorView)
 	}
 


### PR DESCRIPTION
See DES-152 for more context.

** Ignore the missing information in the header, will fix in a follow up PR, logout does not need the header. 👾

| BEFORE | AFTER |
|--------|--------|
| <img width="707" height="532" alt="Screenshot 2026-03-04 at 00 38 21" src="https://github.com/user-attachments/assets/a7afa555-9e67-41f8-98e3-5ea3a9be2b48" /> | <img width="707" height="532" alt="Screenshot 2026-03-04 at 00 37 50" src="https://github.com/user-attachments/assets/42728131-c08d-43f7-b5a0-401b999dd70a" /> | 