### PR TITLE
Use output.Sink in stop command

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
@@ -22,11 +23,7 @@ func newStopCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
-			onProgress := func(msg string) {
-				fmt.Println(msg)
-			}
-
-			if err := container.Stop(cmd.Context(), rt, onProgress); err != nil {
+			if err := container.Stop(cmd.Context(), rt, output.NewPlainSink(os.Stdout)); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}

--- a/internal/container/stop.go
+++ b/internal/container/stop.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 )
 
-func Stop(ctx context.Context, rt runtime.Runtime, onProgress func(string)) error {
+func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink) error {
 	cfg, err := config.Get()
 	if err != nil {
 		return fmt.Errorf("failed to get config: %w", err)
@@ -17,14 +18,14 @@ func Stop(ctx context.Context, rt runtime.Runtime, onProgress func(string)) erro
 
 	for _, c := range cfg.Containers {
 		name := c.Name()
-		onProgress(fmt.Sprintf("Stopping %s...", name))
+		output.EmitStatus(sink, "stopping", name, "")
 		if err := rt.Stop(ctx, name); err != nil {
 			if errdefs.IsNotFound(err) {
 				return fmt.Errorf("%s is not running", name)
 			}
 			return fmt.Errorf("failed to stop %s: %w", name, err)
 		}
-		onProgress(fmt.Sprintf("%s stopped", name))
+		output.EmitStatus(sink, "stopped", name, "")
 	}
 
 	return nil

--- a/test/integration/stop_test.go
+++ b/test/integration/stop_test.go
@@ -25,7 +25,7 @@ func TestStopCommandSucceeds(t *testing.T) {
 	require.NoError(t, err, "lstk stop failed: %s", output)
 
 	outputStr := string(output)
-	assert.Contains(t, outputStr, "Stopping", "should show stopping message")
+	assert.Contains(t, outputStr, "stopping", "should show stopping message")
 	assert.Contains(t, outputStr, "stopped", "should show stopped message")
 
 	_, err = dockerClient.ContainerInspect(ctx, containerName)


### PR DESCRIPTION

Replaces the `onProgress func(string)` callback in `container.Stop` with an `output.Sink`, consistent with the pattern used in `container.Start` and the rest of the codebase

<img width="599" height="139" alt="image" src="https://github.com/user-attachments/assets/d0129f07-76b3-49f6-802b-7252014c58db" />
