### PR TITLE
Support named environments in lstk config.toml

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Config struct {
-	Containers []ContainerConfig `mapstructure:"containers"`
+	Containers []ContainerConfig            `mapstructure:"containers"`
+	Env        map[string]map[string]string `mapstructure:"env"`
 }
 
 func setDefaults() {

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -1,6 +1,9 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type EmulatorType string
 
@@ -32,7 +35,24 @@ type ContainerConfig struct {
 	Type EmulatorType `mapstructure:"type"`
 	Tag  string       `mapstructure:"tag"`
 	Port string       `mapstructure:"port"`
-	Env  []string     `mapstructure:"env"`
+	// Env is a list of named environment references defined in the top-level [env.*] config sections.
+	Env []string `mapstructure:"env"`
+}
+
+// ResolvedEnv resolves the container's named environment references into KEY=value pairs.
+// namedEnvs is the top-level [env.*] map from Config.
+func (c *ContainerConfig) ResolvedEnv(namedEnvs map[string]map[string]string) ([]string, error) {
+	var result []string
+	for _, name := range c.Env {
+		vars, ok := namedEnvs[name]
+		if !ok {
+			return nil, fmt.Errorf("environment %q referenced in container config not found", name)
+		}
+		for k, v := range vars {
+			result = append(result, strings.ToUpper(k)+"="+v)
+		}
+	}
+	return result, nil
 }
 
 func (c *ContainerConfig) Image() (string, error) {

--- a/internal/config/containers_test.go
+++ b/internal/config/containers_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvedEnv_ResolvesNamedEnvs(t *testing.T) {
+	c := &ContainerConfig{
+		Env: []string{"test", "debug"},
+	}
+	namedEnvs := map[string]map[string]string{
+		"test":  {"iam_soft_mode": "1"},
+		"debug": {"ls_log": "trace", "debug": "1"},
+	}
+
+	resolved, err := c.ResolvedEnv(namedEnvs)
+	require.NoError(t, err)
+
+	sort.Strings(resolved)
+	assert.Equal(t, []string{"DEBUG=1", "IAM_SOFT_MODE=1", "LS_LOG=trace"}, resolved)
+}
+
+func TestResolvedEnv_KeysAreUppercased(t *testing.T) {
+	// Viper lowercases all config keys internally; ResolvedEnv must restore them.
+	c := &ContainerConfig{Env: []string{"test"}}
+	namedEnvs := map[string]map[string]string{
+		"test": {"iam_soft_mode": "1"},
+	}
+
+	resolved, err := c.ResolvedEnv(namedEnvs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"IAM_SOFT_MODE=1"}, resolved)
+}
+
+func TestResolvedEnv_ErrorOnMissingEnv(t *testing.T) {
+	c := &ContainerConfig{Env: []string{"missing"}}
+	_, err := c.ResolvedEnv(map[string]map[string]string{})
+	assert.ErrorContains(t, err, `"missing"`)
+}
+
+func TestResolvedEnv_EmptyWhenNoEnvRefs(t *testing.T) {
+	c := &ContainerConfig{}
+	resolved, err := c.ResolvedEnv(map[string]map[string]string{})
+	require.NoError(t, err)
+	assert.Empty(t, resolved)
+}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -54,7 +54,11 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, platformCl
 			return err
 		}
 
-		env := append(c.Env, "LOCALSTACK_AUTH_TOKEN="+token)
+		resolvedEnv, err := c.ResolvedEnv(cfg.Env)
+		if err != nil {
+			return err
+		}
+		env := append(resolvedEnv, "LOCALSTACK_AUTH_TOKEN="+token)
 		containers[i] = runtime.ContainerConfig{
 			Image:       image,
 			Name:        c.Name(),


### PR DESCRIPTION
Closes DRG-550.

- Adds top-level `[env.*]` sections to the config, where each named environment defines a set of `KEY=value` variables
- Adds `env` field to `[[containers]]` to reference which named environments to apply
- Resolves named environments into `KEY=value` pairs at start time, uppercasing keys to work around Viper's internal key lowercasing

## Example config:

```toml
[[containers]]
type = "aws"
tag = "latest"
port = "4566"
env = ["prod", "debug"]

[env.prod]
LOCALSTACK_HOST = "localstack.cloud"

[env.debug]
LS_LOG = "trace"
DEBUG = "1"
```
## TODO
Add an integration test once we are able to override the config path through a CLI flag (subsequent PR https://github.com/localstack/lstk/pull/80)
