### PR TITLE
Add --config flag to override config file location

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,10 +21,20 @@ func newConfigPathCmd() *cobra.Command {
 		Use:   "path",
 		Short: "Print the configuration file path",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := cmd.Flags().GetString("config")
+			if err != nil {
+				return err
+			}
+			if path != "" {
+				_, err := fmt.Fprintln(cmd.OutOrStdout(), path)
+				return err
+			}
+
 			configPath, err := config.ConfigFilePath()
 			if err != nil {
 				return err
 			}
+
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), configPath)
 			return err
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,8 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	root.Version = version.Version()
 	root.SetVersionTemplate(versionLine() + "\n")
 
+	root.PersistentFlags().String("config", "", "Path to config file")
+
 	configureHelp(root)
 
 	root.InitDefaultVersionFlag()
@@ -82,6 +84,13 @@ func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *teleme
 	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL, false)
 }
 
-func initConfig(_ *cobra.Command, _ []string) error {
+func initConfig(cmd *cobra.Command, _ []string) error {
+	path, err := cmd.Flags().GetString("config")
+	if err != nil {
+		return err
+	}
+	if path != "" {
+		return config.InitFromPath(path)
+	}
 	return config.Init()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,12 +26,17 @@ func setDefaults() {
 func loadConfig(path string) error {
 	viper.Reset()
 	setDefaults()
+	viper.SetConfigType("toml")
 	viper.SetConfigFile(path)
 
 	if err := viper.ReadInConfig(); err != nil {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
 	return nil
+}
+
+func InitFromPath(path string) error {
+	return loadConfig(path)
 }
 
 func Init() error {

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -1,13 +1,10 @@
 package integration_test
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/localstack/lstk/test/integration/env"
@@ -23,7 +20,7 @@ func TestConfigFileCreatedOnStartup(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, ".config"), 0755))
 
 		e := testEnvWithHome(tmpHome, xdgOverride)
-		_, stderr, err := runLstk(t, workDir, e, "logout")
+		_, stderr, err := runLstk(t, testContext(t), workDir, e, "logout")
 		require.NoError(t, err, stderr)
 
 		expectedConfigFile := filepath.Join(tmpHome, ".config", "lstk", "config.toml")
@@ -37,13 +34,55 @@ func TestConfigFileCreatedOnStartup(t *testing.T) {
 		xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
 
 		e := testEnvWithHome(tmpHome, xdgOverride)
-		_, stderr, err := runLstk(t, workDir, e, "logout")
+		_, stderr, err := runLstk(t, testContext(t), workDir, e, "logout")
 		require.NoError(t, err, stderr)
 
 		expectedConfigFile := filepath.Join(expectedOSConfigDir(tmpHome, xdgOverride), "config.toml")
 		assert.FileExists(t, expectedConfigFile)
 		assertDefaultConfigContent(t, expectedConfigFile)
 	})
+}
+
+func TestConfigFlagEnvVarsPassedToContainer(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	configContent := `
+[[containers]]
+type = "aws"
+tag = "latest"
+port = "4566"
+env = ["test"]
+
+[env.test]
+IAM_SOFT_MODE = "1"
+`
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
+	require.NoError(t, err, "failed to inspect container")
+	assert.Contains(t, inspect.Config.Env, "IAM_SOFT_MODE=1")
+}
+
+func TestConfigFlagOverridesConfigPath(t *testing.T) {
+	customConfig := filepath.Join(t.TempDir(), "custom.toml")
+	writeConfigFile(t, customConfig)
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", customConfig, "config", "path")
+	require.NoError(t, err, stderr)
+
+	assertSamePath(t, customConfig, stdout)
 }
 
 func TestLocalConfigTakesPrecedence(t *testing.T) {
@@ -57,7 +96,7 @@ func TestLocalConfigTakesPrecedence(t *testing.T) {
 	writeConfigFile(t, filepath.Join(expectedOSConfigDir(tmpHome, xdgOverride), "config.toml"))
 
 	e := testEnvWithHome(tmpHome, xdgOverride)
-	stdout, stderr, err := runLstk(t, workDir, e, "config", "path")
+	stdout, stderr, err := runLstk(t, testContext(t), workDir, e, "config", "path")
 	require.NoError(t, err, stderr)
 
 	expectedLocalPath, err := filepath.Abs(localConfigFile)
@@ -76,7 +115,7 @@ func TestXDGConfigTakesPrecedence(t *testing.T) {
 	writeConfigFile(t, osConfigFile)
 
 	e := testEnvWithHome(tmpHome, xdgOverride)
-	stdout, stderr, err := runLstk(t, workDir, e, "config", "path")
+	stdout, stderr, err := runLstk(t, testContext(t), workDir, e, "config", "path")
 	require.NoError(t, err, stderr)
 
 	assertSamePath(t, xdgConfigFile, stdout)
@@ -89,7 +128,7 @@ func TestConfigPathCommand(t *testing.T) {
 	writeConfigFile(t, xdgConfigFile)
 
 	e := testEnvWithHome(tmpHome, filepath.Join(tmpHome, "xdg-config-home"))
-	stdout, stderr, err := runLstk(t, workDir, e, "config", "path")
+	stdout, stderr, err := runLstk(t, testContext(t), workDir, e, "config", "path")
 	require.NoError(t, err, stderr)
 
 	assertSamePath(t, xdgConfigFile, stdout)
@@ -102,30 +141,11 @@ func TestConfigPathCommandDoesNotCreateConfig(t *testing.T) {
 	expectedConfigFile := filepath.Join(expectedOSConfigDir(tmpHome, xdgOverride), "config.toml")
 
 	e := testEnvWithHome(tmpHome, xdgOverride)
-	stdout, stderr, err := runLstk(t, workDir, e, "config", "path")
+	stdout, stderr, err := runLstk(t, testContext(t), workDir, e, "config", "path")
 	require.NoError(t, err, stderr)
 
 	assertSamePath(t, expectedConfigFile, stdout)
 	assert.NoFileExists(t, expectedConfigFile)
-}
-
-func runLstk(t *testing.T, dir string, env []string, args ...string) (string, string, error) {
-	t.Helper()
-
-	binPath, err := filepath.Abs(binaryPath())
-	require.NoError(t, err)
-
-	cmd := exec.Command(binPath, args...)
-	cmd.Dir = dir
-	cmd.Env = env
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err = cmd.Run()
-	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
 }
 
 func testEnvWithHome(tmpHome, xdgConfigHome string) []string {

--- a/test/integration/license_test.go
+++ b/test/integration/license_test.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/localstack/lstk/test/integration/env"
@@ -56,12 +54,8 @@ func TestLicenseValidationSuccess(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = env.With(env.APIEndpoint, mockServer.URL)
-	output, err := cmd.CombinedOutput()
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "start")
 
 	// Check for validation errors from handler
 	select {
@@ -70,7 +64,7 @@ func TestLicenseValidationSuccess(t *testing.T) {
 	default:
 	}
 
-	require.NoError(t, err, "lstk start failed: %s", output)
+	require.NoError(t, err, "lstk start failed: %s", stderr)
 
 	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
 	require.NoError(t, err, "failed to inspect container")
@@ -85,18 +79,12 @@ func TestLicenseValidationFailure(t *testing.T) {
 	mockServer := createMockLicenseServer(false)
 	defer mockServer.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = env.With(env.APIEndpoint, mockServer.URL).With(env.AuthToken, "test-token-for-license-validation")
-	output, err := cmd.CombinedOutput()
-
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL).With(env.AuthToken, "test-token-for-license-validation"), "start")
 	require.Error(t, err, "expected lstk start to fail with forbidden license")
-	assert.Contains(t, string(output), "license validation failed")
-	assert.Contains(t, string(output), "invalid, inactive, or expired")
+	assert.Contains(t, stderr, "license validation failed")
+	assert.Contains(t, stderr, "invalid, inactive, or expired")
 
-	// Verify container was not started
 	_, err = dockerClient.ContainerInspect(ctx, containerName)
 	assert.Error(t, err, "container should not exist after license failure")
 }

--- a/test/integration/logout_test.go
+++ b/test/integration/logout_test.go
@@ -1,10 +1,7 @@
 package integration_test
 
 import (
-	"context"
-	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
@@ -12,59 +9,34 @@ import (
 )
 
 func TestLogoutCommandRemovesToken(t *testing.T) {
-	// Clean up any existing token
 	_ = DeleteAuthTokenFromKeyring()
 	t.Cleanup(func() {
 		_ = DeleteAuthTokenFromKeyring()
 	})
 
-	// Store a token in keyring
 	err := SetAuthTokenInKeyring("test-token")
 	require.NoError(t, err, "failed to store token in keyring")
 
-	// Run logout command
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	stdout, stderr, err := runLstk(t, testContext(t), "", nil, "logout")
+	require.NoError(t, err, "lstk logout failed: %s", stderr)
+	assert.Contains(t, stdout, "Logged out successfully")
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "logout")
-	output, err := cmd.CombinedOutput()
-
-	require.NoError(t, err, "lstk logout failed: %s", output)
-	assert.Contains(t, string(output), "Logged out successfully")
-
-	// Verify token was removed
 	_, err = GetAuthTokenFromKeyring()
 	assert.Error(t, err, "token should be removed from keyring")
 }
 
 func TestLogoutCommandSucceedsWhenNoToken(t *testing.T) {
-	// Ensure no token exists
 	_ = DeleteAuthTokenFromKeyring()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, binaryPath(), "logout")
-	cmd.Env = env.Without(env.AuthToken)
-	output, err := cmd.CombinedOutput()
-
-	// Should succeed even if no token
-	require.NoError(t, err, "lstk logout should succeed even with no token: %s", output)
-	assert.Contains(t, string(output), "Not currently logged in")
+	stdout, stderr, err := runLstk(t, testContext(t), "", env.Without(env.AuthToken), "logout")
+	require.NoError(t, err, "lstk logout should succeed even with no token: %s", stderr)
+	assert.Contains(t, stdout, "Not currently logged in")
 }
 
 func TestLogoutCommandWithEnvVarToken(t *testing.T) {
-	// Ensure no keyring token — only the env var is set
 	_ = DeleteAuthTokenFromKeyring()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, binaryPath(), "logout")
-	cmd.Env = env.Without(env.AuthToken).With(env.AuthToken, "test-env-token")
-	output, err := cmd.CombinedOutput()
-
-	require.NoError(t, err, "lstk logout should succeed: %s", output)
-	assert.Contains(t, string(output), "LOCALSTACK_AUTH_TOKEN")
+	stdout, stderr, err := runLstk(t, testContext(t), "", env.Without(env.AuthToken).With(env.AuthToken, "test-env-token"), "logout")
+	require.NoError(t, err, "lstk logout should succeed: %s", stderr)
+	assert.Contains(t, stdout, "LOCALSTACK_AUTH_TOKEN")
 }
-

--- a/test/integration/logs_test.go
+++ b/test/integration/logs_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"bufio"
-	"context"
 	"os/exec"
 	"strings"
 	"testing"
@@ -18,14 +17,10 @@ func TestLogsExitsByDefault(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
+	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "logs")
-	_, err := cmd.CombinedOutput()
-
+	_, _, err := runLstk(t, ctx, "", nil, "logs")
 	require.NoError(t, err, "lstk logs should exit cleanly when container is running")
 }
 
@@ -34,14 +29,9 @@ func TestLogsCommandFailsWhenNotRunning(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, binaryPath(), "logs", "--follow")
-	out, err := cmd.CombinedOutput()
-
+	_, stderr, err := runLstk(t, testContext(t), "", nil, "logs", "--follow")
 	require.Error(t, err, "expected lstk logs --follow to fail when container not running")
-	assert.Contains(t, string(out), "emulator is not running")
+	assert.Contains(t, stderr, "emulator is not running")
 }
 
 func TestLogsFollowStreamsOutput(t *testing.T) {
@@ -49,13 +39,12 @@ func TestLogsFollowStreamsOutput(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
+	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
 	const marker = "lstk-logs-test-marker"
 
+	// Uses StdoutPipe for streaming — cannot use runLstk.
 	logsCmd := exec.CommandContext(ctx, binaryPath(), "logs", "--follow")
 	stdout, err := logsCmd.StdoutPipe()
 	require.NoError(t, err, "failed to get stdout pipe")

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -9,10 +9,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/99designs/keyring"
 	"github.com/docker/docker/api/types/container"
@@ -170,6 +173,34 @@ func startTestContainer(t *testing.T, ctx context.Context) {
 	require.NoError(t, err, "failed to create test container")
 	err = dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
 	require.NoError(t, err, "failed to start test container")
+}
+
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func runLstk(t *testing.T, ctx context.Context, dir string, env []string, args ...string) (string, string, error) {
+	t.Helper()
+
+	binPath, err := filepath.Abs(binaryPath())
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd.Dir = dir
+	if env != nil {
+		cmd.Env = env
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
 }
 
 func createMockLicenseServer(success bool) *httptest.Server {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -3,10 +3,7 @@ package integration_test
 import (
 	"context"
 	"net"
-	"os"
-	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/localstack/lstk/test/integration/env"
@@ -24,14 +21,9 @@ func TestStartCommandSucceedsWithValidToken(t *testing.T) {
 	mockServer := createMockLicenseServer(true)
 	defer mockServer.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = env.With(env.APIEndpoint, mockServer.URL)
-	output, err := cmd.CombinedOutput()
-
-	require.NoError(t, err, "lstk start failed: %s", output)
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
 
 	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
 	require.NoError(t, err, "failed to inspect container")
@@ -51,15 +43,10 @@ func TestStartCommandSucceedsWithKeyringToken(t *testing.T) {
 	mockServer := createMockLicenseServer(true)
 	defer mockServer.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
+	ctx := testContext(t)
 	// Run without LOCALSTACK_AUTH_TOKEN should use keyring
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL)
-	output, err := cmd.CombinedOutput()
-
-	require.NoError(t, err, "lstk start failed: %s", output)
+	_, stderr, err := runLstk(t, ctx, "", env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL), "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
 
 	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
 	require.NoError(t, err, "failed to inspect container")
@@ -74,15 +61,9 @@ func TestStartCommandFailsWithInvalidToken(t *testing.T) {
 	mockServer := createMockLicenseServer(false)
 	defer mockServer.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = env.With(env.AuthToken, "invalid-token").With(env.APIEndpoint, mockServer.URL)
-	output, err := cmd.CombinedOutput()
-
+	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AuthToken, "invalid-token").With(env.APIEndpoint, mockServer.URL), "start")
 	require.Error(t, err, "expected lstk start to fail with invalid token")
-	assert.Contains(t, string(output), "license validation failed")
+	assert.Contains(t, stderr, "license validation failed")
 }
 
 func TestStartCommandDoesNothingWhenAlreadyRunning(t *testing.T) {
@@ -90,17 +71,12 @@ func TestStartCommandDoesNothingWhenAlreadyRunning(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
+	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = append(os.Environ(), "LOCALSTACK_AUTH_TOKEN=fake-token")
-	output, err := cmd.CombinedOutput()
-
-	require.NoError(t, err, "lstk start should succeed when container is already running: %s", output)
-	assert.Contains(t, string(output), "already running")
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.AuthToken, "fake-token"), "start")
+	require.NoError(t, err, "lstk start should succeed when container is already running: %s", stderr)
+	assert.Contains(t, stdout, "already running")
 }
 
 func TestStartCommandFailsWhenPortInUse(t *testing.T) {
@@ -112,15 +88,9 @@ func TestStartCommandFailsWhenPortInUse(t *testing.T) {
 	require.NoError(t, err, "failed to bind port 4566 for test")
 	defer func() { _ = ln.Close() }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = append(os.Environ(), "LOCALSTACK_AUTH_TOKEN=fake-token")
-	output, err := cmd.CombinedOutput()
-
+	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AuthToken, "fake-token"), "start")
 	require.Error(t, err, "expected lstk start to fail when port is in use")
-	assert.Contains(t, string(output), "port 4566 already in use")
+	assert.Contains(t, stderr, "port 4566 already in use")
 }
 
 func cleanup() {

--- a/test/integration/stop_test.go
+++ b/test/integration/stop_test.go
@@ -1,10 +1,7 @@
 package integration_test
 
 import (
-	"context"
-	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,18 +12,13 @@ func TestStopCommandSucceeds(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
+	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
-	stopCmd := exec.CommandContext(ctx, binaryPath(), "stop")
-	output, err := stopCmd.CombinedOutput()
-	require.NoError(t, err, "lstk stop failed: %s", output)
-
-	outputStr := string(output)
-	assert.Contains(t, outputStr, "Stopping", "should show stopping message")
-	assert.Contains(t, outputStr, "stopped", "should show stopped message")
+	stdout, stderr, err := runLstk(t, ctx, "", nil, "stop")
+	require.NoError(t, err, "lstk stop failed: %s", stderr)
+	assert.Contains(t, stdout, "Stopping", "should show stopping message")
+	assert.Contains(t, stdout, "stopped", "should show stopped message")
 
 	_, err = dockerClient.ContainerInspect(ctx, containerName)
 	assert.Error(t, err, "container should not exist after stop")
@@ -37,14 +29,9 @@ func TestStopCommandFailsWhenNotRunning(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, binaryPath(), "stop")
-	output, err := cmd.CombinedOutput()
-
+	_, stderr, err := runLstk(t, testContext(t), "", nil, "stop")
 	require.Error(t, err, "expected lstk stop to fail when container not running")
-	assert.Contains(t, string(output), "is not running")
+	assert.Contains(t, stderr, "is not running")
 }
 
 func TestStopCommandIsIdempotent(t *testing.T) {
@@ -52,19 +39,15 @@ func TestStopCommandIsIdempotent(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
+	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
-	stopCmd := exec.CommandContext(ctx, binaryPath(), "stop")
-	output, err := stopCmd.CombinedOutput()
-	require.NoError(t, err, "first lstk stop failed: %s", output)
+	_, stderr, err := runLstk(t, ctx, "", nil, "stop")
+	require.NoError(t, err, "first lstk stop failed: %s", stderr)
 
 	_, err = dockerClient.ContainerInspect(ctx, containerName)
 	require.Error(t, err, "container should not exist after first stop")
 
-	stopCmd2 := exec.CommandContext(ctx, binaryPath(), "stop")
-	_, err = stopCmd2.CombinedOutput()
+	_, _, err = runLstk(t, ctx, "", nil, "stop")
 	assert.Error(t, err, "second lstk stop should fail since container already removed")
 }


### PR DESCRIPTION
- Adds a `--config` flag, allowing users to specify a custom config file path (e.g. `lstk --config /path/to/config.toml start`)
- This allows integration-testing the changes of PR https://github.com/localstack/lstk/pull/79
