### PR TITLE
Display error with TUI and suppress duplicate error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,8 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 
 	root.Version = version.Version()
 	root.SetVersionTemplate(versionLine() + "\n")
+	root.SilenceErrors = true
+	root.SilenceUsage = true
 
 	root.PersistentFlags().String("config", "", "Path to config file")
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -217,6 +217,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.err = msg.err
 		a.spinner, _ = a.spinner.Stop()
 		a.flushBufferedLines()
+		a.errorDisplay = a.errorDisplay.Show(output.ErrorEvent{Title: msg.err.Error()})
 		return a, tea.Quit
 	default:
 		if line, ok := output.FormatEventLine(msg); ok {

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -64,7 +64,7 @@ func Run(parentCtx context.Context, rt runtime.Runtime, version string, platform
 	}
 
 	if app, ok := model.(App); ok && app.Err() != nil {
-		return app.Err()
+		return output.NewSilentError(app.Err())
 	}
 
 	runErr := <-runErrCh

--- a/internal/ui/run_stop.go
+++ b/internal/ui/run_stop.go
@@ -35,7 +35,7 @@ func RunStop(parentCtx context.Context, rt runtime.Runtime) error {
 	}
 
 	if app, ok := model.(App); ok && app.Err() != nil {
-		return app.Err()
+		return output.NewSilentError(app.Err())
 	}
 
 	runErr := <-runErrCh


### PR DESCRIPTION
Output of `lstk stop` for container not running:

### Before
<img width="435" height="177" alt="image" src="https://github.com/user-attachments/assets/d345065a-6d37-4088-a72a-02085322390d" />

### After
<img width="372" height="45" alt="image" src="https://github.com/user-attachments/assets/a65a0897-609c-498d-8771-9677b892caf6" />

- Show errors in the TUI error display
- Suppress duplicate plain-text output
- Cobra's `SilenceErrors = true` stops from printing `RunE` errors itself.
- Cobras' `SilenceUsage = true` stops from dumping the full usage block on every runtime error (e.g. "container not running"). Flag parsing errors are caught by cobra before `RunE` is reached, so usage suppression does not affect those.
