### PR TITLE
Collapse image pull progress into loading indicator

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,8 @@ func Execute(ctx context.Context) error {
 	defer tel.Close()
 
 	root := NewRootCmd(cfg, tel)
+	root.SilenceErrors = true
+	root.SilenceUsage = true
 
 	if err := root.ExecuteContext(ctx); err != nil {
 		if !output.IsSilent(err) {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2
-	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.6.0
@@ -30,6 +29,7 @@ require (
 	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
+	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 // indirect
@@ -73,6 +73,7 @@ require (
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlv
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.2 h1:BdSNuMjRbotnxHSfxy+PCSa4xAmz7szw70ktAtWRYrY=
 github.com/charmbracelet/colorprofile v0.4.2/go.mod h1:0rTi81QpwDElInthtrQ6Ni7cG0sDtwAd4C4le060fT8=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
 github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF7ihZW8=

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -94,6 +94,7 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, conta
 			return fmt.Errorf("failed to remove existing container %s: %w", c.Name, err)
 		}
 
+		output.EmitSpinnerStart(sink, fmt.Sprintf("Pulling %s", c.Image))
 		output.EmitStatus(sink, "pulling", c.Image, "")
 		progress := make(chan runtime.PullProgress)
 		go func() {
@@ -102,8 +103,11 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, conta
 			}
 		}()
 		if err := rt.PullImage(ctx, c.Image, progress); err != nil {
+			output.EmitSpinnerStop(sink)
 			return fmt.Errorf("failed to pull image %s: %w", c.Image, err)
 		}
+		output.EmitSpinnerStop(sink)
+		output.EmitSuccess(sink, fmt.Sprintf("Pulled %s", c.Image))
 	}
 	return nil
 }

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -104,7 +104,11 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, conta
 		}()
 		if err := rt.PullImage(ctx, c.Image, progress); err != nil {
 			output.EmitSpinnerStop(sink)
-			return fmt.Errorf("failed to pull image %s: %w", c.Image, err)
+			output.EmitError(sink, output.ErrorEvent{
+				Title:   fmt.Sprintf("Failed to pull %s", c.Image),
+				Summary: err.Error(),
+			})
+			return output.NewSilentError(fmt.Errorf("failed to pull image %s: %w", c.Image, err))
 		}
 		output.EmitSpinnerStop(sink)
 		output.EmitSuccess(sink, fmt.Sprintf("Pulled %s", c.Image))

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -20,9 +20,9 @@ func FormatEventLine(event any) (string, bool) {
 	case ErrorEvent:
 		return formatErrorEvent(e), true
 	case ContainerStatusEvent:
-		return formatStatusLine(e), true
+		return formatStatusLine(e)
 	case ProgressEvent:
-		return formatProgressLine(e)
+		return "", false
 	case UserInputRequestEvent:
 		return formatUserInputRequest(e), true
 	case ContainerLogLineEvent:
@@ -32,37 +32,27 @@ func FormatEventLine(event any) (string, bool) {
 	}
 }
 
-func formatStatusLine(e ContainerStatusEvent) string {
+func formatStatusLine(e ContainerStatusEvent) (string, bool) {
 	switch e.Phase {
 	case "pulling":
-		return fmt.Sprintf("Pulling %s...", e.Container)
+		return "", false
 	case "starting":
-		return fmt.Sprintf("Starting %s...", e.Container)
+		return fmt.Sprintf("Starting %s...", e.Container), true
 	case "waiting":
-		return fmt.Sprintf("Waiting for %s to be ready...", e.Container)
+		return fmt.Sprintf("Waiting for %s to be ready...", e.Container), true
 	case "ready":
 		if e.Detail != "" {
-			return fmt.Sprintf("%s ready (%s)", e.Container, e.Detail)
+			return fmt.Sprintf("%s ready (%s)", e.Container, e.Detail), true
 		}
-		return fmt.Sprintf("%s ready", e.Container)
+		return fmt.Sprintf("%s ready", e.Container), true
 	default:
 		if e.Detail != "" {
-			return fmt.Sprintf("%s: %s (%s)", e.Container, e.Phase, e.Detail)
+			return fmt.Sprintf("%s: %s (%s)", e.Container, e.Phase, e.Detail), true
 		}
-		return fmt.Sprintf("%s: %s", e.Container, e.Phase)
+		return fmt.Sprintf("%s: %s", e.Container, e.Phase), true
 	}
 }
 
-func formatProgressLine(e ProgressEvent) (string, bool) {
-	if e.Total > 0 {
-		pct := float64(e.Current) / float64(e.Total) * 100
-		return fmt.Sprintf("  %s: %s %.1f%%", e.LayerID, e.Status, pct), true
-	}
-	if e.Status != "" {
-		return fmt.Sprintf("  %s: %s", e.LayerID, e.Status), true
-	}
-	return "", false
-}
 
 func formatUserInputRequest(e UserInputRequestEvent) string {
 	return FormatPrompt(e.Prompt, e.Options)

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -48,10 +48,10 @@ func TestFormatEventLine(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name:   "status pulling",
+			name:   "status pulling suppressed",
 			event:  ContainerStatusEvent{Phase: "pulling", Container: "localstack/localstack:latest"},
-			want:   "Pulling localstack/localstack:latest...",
-			wantOK: true,
+			want:   "",
+			wantOK: false,
 		},
 		{
 			name:   "status ready with detail",
@@ -60,20 +60,8 @@ func TestFormatEventLine(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name:   "progress with total",
+			name:   "progress suppressed",
 			event:  ProgressEvent{LayerID: "abc123", Status: "Downloading", Current: 50, Total: 100},
-			want:   "  abc123: Downloading 50.0%",
-			wantOK: true,
-		},
-		{
-			name:   "progress with status only",
-			event:  ProgressEvent{LayerID: "abc123", Status: "Pull complete"},
-			want:   "  abc123: Pull complete",
-			wantOK: true,
-		},
-		{
-			name:   "progress ignored when empty",
-			event:  ProgressEvent{LayerID: "abc123"},
 			want:   "",
 			wantOK: false,
 		},

--- a/internal/output/plain_sink.go
+++ b/internal/output/plain_sink.go
@@ -30,10 +30,6 @@ func (s *PlainSink) setErr(err error) {
 }
 
 func (s *PlainSink) emit(event any) {
-	switch event.(type) {
-	case ProgressEvent:
-		return
-	}
 	line, ok := FormatEventLine(event)
 	if !ok {
 		return

--- a/internal/output/plain_sink.go
+++ b/internal/output/plain_sink.go
@@ -30,6 +30,10 @@ func (s *PlainSink) setErr(err error) {
 }
 
 func (s *PlainSink) emit(event any) {
+	switch event.(type) {
+	case ProgressEvent:
+		return
+	}
 	line, ok := FormatEventLine(event)
 	if !ok {
 		return

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -90,54 +90,19 @@ func TestPlainSink_EmitsStatusEvent(t *testing.T) {
 	}
 }
 
-func TestPlainSink_EmitsProgressEvent(t *testing.T) {
-	tests := []struct {
-		name     string
-		event    ProgressEvent
-		expected string
-	}{
-		{
-			name: "with total (percentage)",
-			event: ProgressEvent{
-				Container: "localstack",
-				LayerID:   "abc123",
-				Status:    "Downloading",
-				Current:   50,
-				Total:     100,
-			},
-			expected: "  abc123: Downloading 50.0%\n",
-		},
-		{
-			name: "without total (status only)",
-			event: ProgressEvent{
-				Container: "localstack",
-				LayerID:   "abc123",
-				Status:    "Pull complete",
-				Current:   0,
-				Total:     0,
-			},
-			expected: "  abc123: Pull complete\n",
-		},
-		{
-			name: "no status and no total",
-			event: ProgressEvent{
-				Container: "localstack",
-				LayerID:   "abc123",
-			},
-			expected: "",
-		},
-	}
+func TestPlainSink_SuppressesProgressEvent(t *testing.T) {
+	var out bytes.Buffer
+	sink := NewPlainSink(&out)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var out bytes.Buffer
-			sink := NewPlainSink(&out)
+	Emit(sink, ProgressEvent{
+		Container: "localstack",
+		LayerID:   "abc123",
+		Status:    "Downloading",
+		Current:   50,
+		Total:     100,
+	})
 
-			Emit(sink, tt.event)
-
-			assert.Equal(t, tt.expected, out.String())
-		})
-	}
+	assert.Equal(t, "", out.String())
 }
 
 func TestPlainSink_EmitsContainerLogLineEvent(t *testing.T) {
@@ -223,7 +188,6 @@ func TestPlainSink_UsesFormatterParity(t *testing.T) {
 		SpinnerEvent{Active: true, Text: "Loading"},
 		ErrorEvent{Title: "Failed", Summary: "Something broke"},
 		ContainerStatusEvent{Phase: "starting", Container: "localstack"},
-		ProgressEvent{LayerID: "abc", Status: "Downloading", Current: 1, Total: 2},
 	}
 
 	for _, event := range events {
@@ -240,8 +204,6 @@ func TestPlainSink_UsesFormatterParity(t *testing.T) {
 		case ErrorEvent:
 			Emit(sink, e)
 		case ContainerStatusEvent:
-			Emit(sink, e)
-		case ProgressEvent:
 			Emit(sink, e)
 		default:
 			t.Fatalf("unsupported event type in test: %T", event)

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -42,9 +42,9 @@ func TestPlainSink_EmitsStatusEvent(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "pulling phase",
+			name:     "pulling phase suppressed",
 			event:    ContainerStatusEvent{Phase: "pulling", Container: "localstack/localstack:latest"},
-			expected: "Pulling localstack/localstack:latest...\n",
+			expected: "",
 		},
 		{
 			name:     "starting phase",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/localstack/lstk/internal/output"
@@ -31,6 +32,7 @@ type App struct {
 	header        components.Header
 	inputPrompt   components.InputPrompt
 	spinner       components.Spinner
+	pullProgress  components.PullProgress
 	errorDisplay  components.ErrorDisplay
 	lines         []styledLine
 	bufferedLines []styledLine // lines waiting for spinner to finish
@@ -53,6 +55,7 @@ func NewApp(version, emulatorName, endpoint string, cancel func(), opts ...AppOp
 		header:       components.NewHeader(version, emulatorName, endpoint),
 		inputPrompt:  components.NewInputPrompt(),
 		spinner:      components.NewSpinner(),
+		pullProgress: components.NewPullProgress(),
 		errorDisplay: components.NewErrorDisplay(),
 		lines:        make([]styledLine, 0, maxLines),
 		cancel:       cancel,
@@ -181,6 +184,29 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.lines = appendLine(a.lines, styledLine{text: msg.URL, secondary: true})
 		}
 		return a, nil
+	case output.ContainerStatusEvent:
+		if msg.Phase == "pulling" {
+			a.pullProgress = a.pullProgress.Show(msg.Container)
+			return a, nil
+		}
+		if a.pullProgress.Visible() {
+			a.pullProgress = a.pullProgress.Hide()
+		}
+		if line, ok := output.FormatEventLine(msg); ok {
+			a.lines = appendLine(a.lines, styledLine{text: line})
+		}
+		return a, nil
+	case output.ProgressEvent:
+		if a.pullProgress.Visible() {
+			var cmd tea.Cmd
+			a.pullProgress, cmd = a.pullProgress.SetProgress(msg)
+			return a, cmd
+		}
+		return a, nil
+	case progress.FrameMsg:
+		var cmd tea.Cmd
+		a.pullProgress, cmd = a.pullProgress.Update(msg)
+		return a, cmd
 	case runDoneMsg:
 		if a.spinner.PendingStop() {
 			a.quitting = true
@@ -306,6 +332,10 @@ func (a App) View() string {
 	if spinnerView := a.spinner.View(); spinnerView != "" {
 		sb.WriteString(spinnerView)
 		sb.WriteString("\n")
+		if pullView := a.pullProgress.View(); pullView != "" {
+			sb.WriteString(pullView)
+			sb.WriteString("\n")
+		}
 	} else if promptView := a.inputPrompt.View(); promptView != "" {
 		sb.WriteString(promptView)
 		sb.WriteString("\n")

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -307,6 +307,90 @@ func TestAppAnyKeyOptionResolvesOnAnyKeypress(t *testing.T) {
 	}
 }
 
+func TestAppPullProgressShowsOnPullingPhase(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+
+	model, _ := app.Update(output.ContainerStatusEvent{Phase: "pulling", Container: "localstack/localstack-pro:latest"})
+	app = model.(App)
+
+	if !app.pullProgress.Visible() {
+		t.Fatal("expected pull progress to be visible during pulling phase")
+	}
+	if len(app.lines) != 0 {
+		t.Fatalf("expected no lines appended for pulling phase, got %d", len(app.lines))
+	}
+}
+
+func TestAppPullProgressHidesOnNextPhase(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+
+	model, _ := app.Update(output.ContainerStatusEvent{Phase: "pulling", Container: "localstack/localstack-pro:latest"})
+	app = model.(App)
+
+	model, _ = app.Update(output.ContainerStatusEvent{Phase: "starting", Container: "localstack"})
+	app = model.(App)
+
+	if app.pullProgress.Visible() {
+		t.Fatal("expected pull progress to be hidden after pulling phase ends")
+	}
+	if len(app.lines) != 1 {
+		t.Fatalf("expected 1 line for starting phase, got %d", len(app.lines))
+	}
+}
+
+func TestAppProgressEventUpdatesPullProgress(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+
+	model, _ := app.Update(output.ContainerStatusEvent{Phase: "pulling", Container: "localstack/localstack-pro:latest"})
+	app = model.(App)
+
+	model, _ = app.Update(output.ProgressEvent{
+		Container: "localstack/localstack-pro:latest",
+		LayerID:   "abc123",
+		Status:    "Downloading",
+		Current:   50,
+		Total:     100,
+	})
+	app = model.(App)
+
+	if len(app.lines) != 0 {
+		t.Fatalf("expected no lines appended for progress event, got %d", len(app.lines))
+	}
+
+	view := app.pullProgress.View()
+	if !strings.Contains(view, "layers") {
+		t.Fatalf("expected pull progress view to show layer count, got: %q", view)
+	}
+}
+
+func TestAppProgressEventIgnoredWhenNotPulling(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+
+	model, cmd := app.Update(output.ProgressEvent{
+		Container: "localstack/localstack-pro:latest",
+		LayerID:   "abc123",
+		Status:    "Downloading",
+		Current:   50,
+		Total:     100,
+	})
+	app = model.(App)
+
+	if cmd != nil {
+		t.Fatal("expected no command when pull progress is not visible")
+	}
+	if len(app.lines) != 0 {
+		t.Fatalf("expected no lines appended, got %d", len(app.lines))
+	}
+}
+
 func TestAppPendingInputOptionCOverridesClipboardShortcut(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/components/pull_progress.go
+++ b/internal/ui/components/pull_progress.go
@@ -10,9 +10,11 @@ import (
 )
 
 type layerState struct {
-	status  string
-	current int64
-	total   int64
+	status   string
+	current  int64
+	total    int64
+	maxTotal int64
+	complete bool
 }
 
 type PullProgress struct {
@@ -56,6 +58,12 @@ func (p PullProgress) SetProgress(e output.ProgressEvent) (PullProgress, tea.Cmd
 	layer.status = e.Status
 	layer.current = e.Current
 	layer.total = e.Total
+	if e.Total > layer.maxTotal {
+		layer.maxTotal = e.Total
+	}
+	if e.Status == "Pull complete" || e.Status == "Already exists" {
+		layer.complete = true
+	}
 
 	pct := p.aggregatePercent()
 	cmd := p.bar.SetPercent(pct)
@@ -65,9 +73,13 @@ func (p PullProgress) SetProgress(e output.ProgressEvent) (PullProgress, tea.Cmd
 func (p PullProgress) aggregatePercent() float64 {
 	var totalBytes, currentBytes int64
 	for _, l := range p.layers {
-		if l.total > 0 {
-			totalBytes += l.total
-			currentBytes += l.current
+		if l.maxTotal > 0 {
+			totalBytes += l.maxTotal
+			if l.complete {
+				currentBytes += l.maxTotal
+			} else {
+				currentBytes += l.current
+			}
 		}
 	}
 	if totalBytes == 0 {
@@ -111,7 +123,7 @@ func (p PullProgress) View() string {
 func (p PullProgress) layerCounts() (total, done int) {
 	total = len(p.layers)
 	for _, l := range p.layers {
-		if l.status == "Pull complete" || l.status == "Already exists" {
+		if l.complete {
 			done++
 		}
 	}

--- a/internal/ui/components/pull_progress.go
+++ b/internal/ui/components/pull_progress.go
@@ -1,0 +1,138 @@
+package components
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/progress"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/ui/styles"
+)
+
+type layerState struct {
+	status  string
+	current int64
+	total   int64
+}
+
+type PullProgress struct {
+	bar     progress.Model
+	layers  map[string]*layerState
+	visible bool
+}
+
+func NewPullProgress() PullProgress {
+	bar := progress.New(
+		progress.WithGradient(styles.NimboDarkColor, styles.NimboMidColor),
+		progress.WithWidth(30),
+		progress.WithFillCharacters('━', '─'),
+	)
+	bar.EmptyColor = "#3A3A3A"
+	return PullProgress{bar: bar}
+}
+
+func (p PullProgress) Show(imageName string) PullProgress {
+	p.layers = make(map[string]*layerState)
+	p.visible = true
+	return p
+}
+
+func (p PullProgress) Hide() PullProgress {
+	p.visible = false
+	p.layers = nil
+	return p
+}
+
+func (p PullProgress) SetProgress(e output.ProgressEvent) (PullProgress, tea.Cmd) {
+	if e.LayerID == "" {
+		return p, nil
+	}
+
+	layer, ok := p.layers[e.LayerID]
+	if !ok {
+		layer = &layerState{}
+		p.layers[e.LayerID] = layer
+	}
+	layer.status = e.Status
+	layer.current = e.Current
+	layer.total = e.Total
+
+	pct := p.aggregatePercent()
+	cmd := p.bar.SetPercent(pct)
+	return p, cmd
+}
+
+func (p PullProgress) aggregatePercent() float64 {
+	var totalBytes, currentBytes int64
+	for _, l := range p.layers {
+		if l.total > 0 {
+			totalBytes += l.total
+			currentBytes += l.current
+		}
+	}
+	if totalBytes == 0 {
+		return 0
+	}
+	return float64(currentBytes) / float64(totalBytes)
+}
+
+func (p PullProgress) Update(msg tea.Msg) (PullProgress, tea.Cmd) {
+	if !p.visible {
+		return p, nil
+	}
+	model, cmd := p.bar.Update(msg)
+	p.bar = model.(progress.Model)
+	return p, cmd
+}
+
+func (p PullProgress) Visible() bool {
+	return p.visible
+}
+
+func (p PullProgress) View() string {
+	if !p.visible {
+		return ""
+	}
+
+	total, done := p.layerCounts()
+	if total == 0 {
+		return ""
+	}
+
+	phase := p.dominantPhase()
+	// Fixed-width: "Downloading" is the longest phase (11 chars), counts padded to "XX/XX"
+	label := fmt.Sprintf("%-11s %2d/%-2d layers", phase, done, total)
+	return fmt.Sprintf("  %s  %s",
+		label,
+		p.bar.View(),
+	)
+}
+
+func (p PullProgress) layerCounts() (total, done int) {
+	total = len(p.layers)
+	for _, l := range p.layers {
+		if l.status == "Pull complete" || l.status == "Already exists" {
+			done++
+		}
+	}
+	return total, done
+}
+
+func (p PullProgress) dominantPhase() string {
+	downloading, extracting := 0, 0
+	for _, l := range p.layers {
+		switch l.status {
+		case "Downloading":
+			downloading++
+		case "Extracting":
+			extracting++
+		}
+	}
+	if extracting > downloading {
+		return "Extracting"
+	}
+	if downloading > 0 {
+		return "Downloading"
+	}
+	return "Pulling"
+}

--- a/internal/ui/components/pull_progress_test.go
+++ b/internal/ui/components/pull_progress_test.go
@@ -1,0 +1,101 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/localstack/lstk/internal/output"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPullProgress_InitiallyHidden(t *testing.T) {
+	p := NewPullProgress()
+	assert.False(t, p.Visible())
+	assert.Equal(t, "", p.View())
+}
+
+func TestPullProgress_ShowMakesVisible(t *testing.T) {
+	p := NewPullProgress()
+	p = p.Show("localstack/localstack-pro:latest")
+	assert.True(t, p.Visible())
+}
+
+func TestPullProgress_HideMakesInvisible(t *testing.T) {
+	p := NewPullProgress()
+	p = p.Show("localstack/localstack-pro:latest")
+	p = p.Hide()
+	assert.False(t, p.Visible())
+	assert.Equal(t, "", p.View())
+}
+
+func TestPullProgress_AggregatesMultipleLayers(t *testing.T) {
+	p := NewPullProgress()
+	p = p.Show("image")
+
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "aaa", Status: "Downloading", Current: 50, Total: 100})
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "bbb", Status: "Downloading", Current: 25, Total: 100})
+
+	pct := p.aggregatePercent()
+	assert.InDelta(t, 0.375, pct, 0.001)
+}
+
+func TestPullProgress_ViewShowsLayerCounts(t *testing.T) {
+	p := NewPullProgress()
+	p = p.Show("image")
+
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "aaa", Status: "Pull complete", Current: 0, Total: 0})
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "bbb", Status: "Downloading", Current: 50, Total: 100})
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "ccc", Status: "Downloading", Current: 10, Total: 100})
+
+	view := p.View()
+	assert.Contains(t, view, "1/3")
+	assert.Contains(t, view, "layers")
+}
+
+func TestPullProgress_ViewEmptyWithNoLayers(t *testing.T) {
+	p := NewPullProgress()
+	p = p.Show("image")
+	assert.Equal(t, "", p.View())
+}
+
+func TestPullProgress_DominantPhase(t *testing.T) {
+	p := NewPullProgress()
+	p = p.Show("image")
+
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "aaa", Status: "Downloading", Current: 50, Total: 100})
+	assert.True(t, strings.Contains(p.View(), "Downloading"))
+
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "aaa", Status: "Extracting", Current: 50, Total: 100})
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "bbb", Status: "Extracting", Current: 10, Total: 100})
+	assert.True(t, strings.Contains(p.View(), "Extracting"))
+}
+
+func TestPullProgress_AlreadyExistsCountsAsDone(t *testing.T) {
+	p := NewPullProgress()
+	p = p.Show("image")
+
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "aaa", Status: "Already exists"})
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "bbb", Status: "Downloading", Current: 50, Total: 100})
+
+	view := p.View()
+	assert.Contains(t, view, "1/2")
+	assert.Contains(t, view, "layers")
+}
+
+func TestPullProgress_ShowResetsLayers(t *testing.T) {
+	p := NewPullProgress()
+	p = p.Show("image-a")
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "aaa", Status: "Downloading", Current: 50, Total: 100})
+
+	p = p.Show("image-b")
+	assert.True(t, p.Visible())
+	assert.Equal(t, 0, len(p.layers))
+}
+
+func TestPullProgress_IgnoresEmptyLayerID(t *testing.T) {
+	p := NewPullProgress()
+	p = p.Show("image")
+
+	p, _ = p.SetProgress(output.ProgressEvent{LayerID: "", Status: "Pulling from library/localstack"})
+	assert.Equal(t, 0, len(p.layers))
+}


### PR DESCRIPTION
## Motivation

When pulling a Docker image, the CLI printed every individual layer progress line from Docker (downloading, extracting, etc. for each layer). This flooded the terminal with dozens of rapidly updating lines, making the output noisy and hard to follow.

## Changes

- Added a new `PullProgress` Bubble Tea component backed by `bubbles/progress` that aggregates pull progress across all Docker layers into a single animated progress bar. Shows the dominant phase (Downloading/Extracting), completed layer count, and overall byte progress with a Nimbo-themed gradient.
- The pull phase now shows a spinner ("Pulling image...") with the aggregated progress bar rendered below it, replacing the per-layer log spam.
- Pull errors now emit a styled `ErrorEvent` instead of a raw error string, consistent with how other failures (e.g., Docker not available) are displayed.
- Non-interactive output suppresses per-layer progress events entirely, showing only "Pulling..." and "Pulled" lines.

## Tests

- Unit tests for the `PullProgress` component covering aggregation, layer counting, phase detection, visibility, and edge cases.
- Unit tests for the TUI app verifying pull progress shows/hides on the correct status events and progress events update the component without appending lines.
- Updated existing plain sink tests to match the new suppression behavior.

## Screenshots

<img width="847" height="171" alt="image" src="https://github.com/user-attachments/assets/68f3d42d-d710-4652-8419-30af8f6241b5" />

<img width="847" height="171" alt="image" src="https://github.com/user-attachments/assets/5b339a98-70dc-4d67-a7c0-c3196fa69edb" />

<!-- TODO: add before/after screenshots -->