### PR TITLE
Add Claude Code skills for common tasks

### DIFF
--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: add-command
+description: Scaffold a new CLI subcommand following lstk patterns. Use when adding a new command to the CLI.
+argument-hint: <command-name>
+allowed-tools: Read, Write, Edit, Glob, Grep
+---
+
+# Add CLI Command
+
+Scaffold a new CLI subcommand named `$ARGUMENTS` following lstk's architecture.
+
+## Step 0: Clarify requirements and challenge the design
+
+Before writing any code, understand what the command should do and whether the approach is sound. Ask the user these questions, plus any others that make sense given the specific command. Wait for answers before proceeding.
+
+**Core questions:**
+1. **What does this command do?** (one sentence — e.g., "shows the status of running emulators")
+2. **Does it need to talk to Docker/the runtime?** (determines whether `runtime.Runtime` is a dependency)
+3. **Does it need configuration?** (determines whether `PreRunE: initConfig` is needed)
+4. **Does it need authentication?** (determines whether auth flow is involved)
+5. **Does it need any new event types?** (e.g., a new kind of progress, a new status phase — if yes, use `/add-event` for each)
+
+**Also ask context-specific questions** that aren't in this list but would help clarify behavior — e.g., edge cases ("what happens if no emulators are running?"), flags/arguments the command should accept, expected output format, whether it should be idempotent, etc.
+
+**Challenge the architecture** if something doesn't fit well:
+- If the command overlaps with an existing one, ask whether it should be a subcommand or flag instead
+- If the proposed behavior mixes concerns (e.g., fetching data AND mutating state), suggest splitting it
+- If a simpler approach exists (reusing existing domain functions, adding a flag to an existing command), propose it
+
+Skip questions where the answer is obvious from context (e.g., if the user already explained the behavior in detail). Be direct — raise concerns early rather than building something that needs reworking.
+
+## Reference: current codebase
+
+Read these files before writing anything — they are the source of truth for patterns:
+
+- `cmd/stop.go` — simplest command pattern (cmd wiring + output mode selection)
+- `cmd/root.go` — where commands are registered via `AddCommand()`
+- `internal/container/stop.go` — simplest domain logic pattern (accepts `output.Sink`, emits events)
+
+## Step 1: Create the command file in `cmd/`
+
+Create `cmd/$ARGUMENTS.go` with:
+
+- A `new<Name>Cmd()` factory function returning `*cobra.Command`
+- `PreRunE: initConfig` if the command needs configuration
+- Output mode decision at the boundary:
+  - Interactive: delegate to `ui.Run<Name>(...)` or TUI path
+  - Non-interactive: call domain function with `output.NewPlainSink(os.Stdout)`
+- No business logic — only Cobra wiring, dependency creation, and output mode selection
+
+## Step 2: Create the domain logic package
+
+Create `internal/<package>/<name>.go` (use an existing package if it fits, or create a new one) with:
+
+- A function that accepts `ctx context.Context`, `rt runtime.Runtime`, `sink output.Sink`, and any other dependencies
+- Emit events via `output.EmitXxx(sink, ...)` — never `fmt.Print` or `log.Print`
+- Return errors normally; use `output.NewSilentError(err)` only if the error was already displayed via `EmitError`
+- No imports from `internal/ui` or `charmbracelet/bubbletea`
+
+## Step 3: Register the command
+
+In `cmd/root.go`, add the new command to `root.AddCommand(...)`.
+
+If the command constructor needs dependencies (like `*env.Env` or `*telemetry.Client`), add them as parameters matching the existing pattern.
+
+## Step 4: Add new event types (if needed)
+
+If the command needs to communicate domain state that doesn't fit existing event types, use `/add-event` for each new event. Common cases:
+
+- New status phases → may just need a new string in `ContainerStatusEvent.Phase`
+- New kinds of progress → may need a new event type
+- New structured errors → use `ErrorEvent` with appropriate `Actions`
+
+Prefer reusing existing events before creating new ones.
+
+## Step 5: Add TUI path (if needed)
+
+If the command has interactive output beyond plain text:
+
+1. Add a `Run<Name>()` function in `internal/ui/` following the pattern in `internal/ui/run.go`
+2. Create the Bubble Tea program, run domain logic in a goroutine, send events via `output.NewTUISink(programSender{p: p})`
+
+If the command needs custom UI elements (progress bars, tables, etc.), use `/add-component` for each new component.
+
+If the command is simple (just spinner + success/error messages), the existing `App` model handles those events already — you may not need a custom TUI path.
+
+## Step 6: Add integration test
+
+Create `test/integration/<name>_test.go` with:
+
+- Non-interactive tests: `exec.CommandContext(ctx, binaryPath(), "<name>")` → `cmd.CombinedOutput()`
+- Interactive (TUI) tests: use `pty.Start(cmd)` from `github.com/creack/pty`
+- Use `requireDocker(t)` if Docker is needed
+- Use `cleanup()` and `t.Cleanup(cleanup)` for container state
+- Use `context.WithTimeout` for all tests
+
+## Anti-patterns to avoid
+
+- Do NOT put business logic in `cmd/` — the command file should be thin wiring only
+- Do NOT construct sinks inside domain code — always accept `output.Sink` as a parameter
+- Do NOT use `fmt.Print`/`log.Print` in domain code — use `output.EmitXxx()` helpers
+- Do NOT import `internal/ui` or Bubble Tea from domain packages
+- Do NOT create package-level global variables — inject dependencies via constructors
+- Do NOT use "container" or "runtime" in user-facing text — use "emulator"

--- a/.claude/skills/add-component/SKILL.md
+++ b/.claude/skills/add-component/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: add-component
+description: Scaffold a new Bubble Tea TUI component following lstk's UI patterns. Use when adding a new reusable UI element.
+argument-hint: <component-name>
+allowed-tools: Read, Write, Edit, Glob, Grep
+---
+
+# Add TUI Component
+
+Scaffold a new Bubble Tea component named `$ARGUMENTS`.
+
+## Reference: current codebase
+
+Read these files first — they are the source of truth:
+
+- `internal/ui/components/spinner.go` — stateful component with Update/View pattern
+- `internal/ui/components/error_display.go` — simple show/hide component driven by events
+- `internal/ui/components/header.go` — pure presentational component (View only)
+- `internal/ui/styles/styles.go` — all style definitions
+- `internal/ui/app.go` — how components are composed in the main App model
+
+## Step 1: Create the component
+
+Create `internal/ui/components/<name>.go` with:
+
+1. **A struct** holding component state:
+   ```go
+   type <Name> struct {
+       // Private fields for internal state
+       visible bool
+   }
+   ```
+
+2. **A constructor**:
+   ```go
+   func New<Name>() <Name> {
+       return <Name>{}
+   }
+   ```
+
+3. **State mutation methods** that return a new copy (value receiver pattern, like Spinner):
+   ```go
+   func (c <Name>) Show(...) <Name> {
+       c.visible = true
+       // set fields
+       return c
+   }
+   ```
+
+4. **A View method**:
+   ```go
+   func (c <Name>) View() string {
+       if !c.visible {
+           return ""
+       }
+       // Render using styles from internal/ui/styles
+   }
+   ```
+
+5. **An Update method** (only if the component handles tea.Msg internally, like Spinner):
+   ```go
+   func (c <Name>) Update(msg tea.Msg) (<Name>, tea.Cmd) {
+       // Must be non-blocking
+   }
+   ```
+
+## Step 2: Add styles (if needed)
+
+In `internal/ui/styles/styles.go`, add new style variables with **semantic names**:
+
+```go
+var (
+    <Name>Style = lipgloss.NewStyle().
+        Foreground(lipgloss.Color("..."))
+)
+```
+
+Use existing palette constants (`NimboDarkColor`, `NimboMidColor`, `NimboLightColor`) or standard ANSI color codes. Name styles after what they represent, not how they look.
+
+## Step 3: Wire into App
+
+In `internal/ui/app.go`:
+
+1. Add the component as a field on the `App` struct
+2. Initialize it in `NewApp()`
+3. Handle relevant events in `Update()` to drive the component
+4. Render it in `View()` at the appropriate position
+
+## Step 4: Add component test
+
+Create `internal/ui/components/<name>_test.go` with tests covering:
+
+- Initial state (hidden/empty)
+- State transitions (Show/Hide)
+- View output for different states
+- Edge cases (empty data, zero values)
+
+Follow the existing test patterns in `spinner_test.go` or `error_display_test.go`.
+
+## Step 5: Add event type (if needed)
+
+If the component is driven by a new domain event, use `/add-event` to create the event type first. The component should consume the event — not define it. Events live in `internal/output/`, not in `internal/ui/components/`.
+
+## UI-only messages
+
+If the component needs messages that are purely UI concerns (not domain events), define them in the component file with the `...Msg` suffix:
+
+```go
+type <Name>DoneMsg struct{}
+```
+
+These are for internal component coordination only and should not appear in `internal/output/`.
+
+## Anti-patterns to avoid
+
+- Do NOT put business logic in components — they are presentational only
+- Do NOT make `Update()` blocking — no network calls, no file I/O, no channel waits
+- Do NOT define domain events in component files — events belong in `internal/output/events.go`
+- Do NOT import domain packages from components (except `internal/output` for event types and `internal/ui/styles` for styling)
+- Do NOT create "god components" — keep each component focused on a single concern

--- a/.claude/skills/add-event/SKILL.md
+++ b/.claude/skills/add-event/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: add-event
+description: Add a new output event type to the event/sink system. Use when adding a new kind of event for domain-to-UI communication.
+argument-hint: <EventName> [description]
+allowed-tools: Read, Write, Edit, Glob, Grep
+---
+
+# Add Output Event
+
+Add a new event type `$ARGUMENTS` to the output event system.
+
+## Reference: current codebase
+
+Read these files first — they are the source of truth:
+
+- `internal/output/events.go` — all event types, the `Event` union constraint, and emit helpers
+- `internal/output/plain_format.go` — `FormatEventLine()` switch for plain text rendering
+- `internal/output/plain_format_test.go` — test cases for format parity
+- `internal/ui/app.go` — `Update()` method that handles events in the TUI
+
+## Step 1: Define the event struct
+
+In `internal/output/events.go`:
+
+1. Add a new struct with fields that are **domain facts** (not pre-rendered strings):
+   ```go
+   type <Name>Event struct {
+       // Fields should be typed data, not display strings
+   }
+   ```
+
+2. Add the new type to the `Event` union constraint:
+   ```go
+   type Event interface {
+       MessageEvent | AuthEvent | ... | <Name>Event
+   }
+   ```
+
+3. Add an emit helper function:
+   ```go
+   func Emit<Name>(sink Sink, ...) {
+       Emit(sink, <Name>Event{...})
+   }
+   ```
+
+## Step 2: Add plain text formatting
+
+In `internal/output/plain_format.go`, add a case to `FormatEventLine()`:
+
+```go
+case <Name>Event:
+    return format<Name>(e), true
+```
+
+Write a `format<Name>()` helper that returns a single-line string. Keep formatting consistent with existing events — plain text, no ANSI codes, no lipgloss.
+
+## Step 3: Add format tests
+
+In `internal/output/plain_format_test.go`, add test cases to `TestFormatEventLine` covering:
+
+- The happy path with all fields populated
+- Edge cases (empty optional fields, zero values)
+- The exact expected output string
+
+Follow the existing table-driven test pattern with `name`, `event`, `want`, `wantOK` fields.
+
+## Step 4: Handle in TUI
+
+In `internal/ui/app.go`, add a case in `Update()` for the new event.
+
+Decide based on the event's nature:
+- **Simple text display**: Convert to a `styledLine` and append to `a.lines` (like `MessageEvent`)
+- **Component update**: Update the relevant component (like `ErrorEvent` → `a.errorDisplay.Show()`)
+- **Needs buffering**: If it should wait for spinner, check `a.spinner.PendingStop()` and buffer accordingly (like `MessageEvent`)
+
+If the event doesn't need special TUI handling, the `default` case in `Update()` already falls back to `FormatEventLine()` — so you may not need to add anything here.
+
+## Anti-patterns to avoid
+
+- Do NOT put pre-rendered UI strings in event fields — use typed domain data
+- Do NOT add lipgloss/styling imports to `plain_format.go`
+- Do NOT skip the format test — every event type needs parity coverage
+- Do NOT forget to add the type to the `Event` union — it won't compile without it

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: create-pr
+description: Create a GitHub pull request following lstk conventions with proper title, description, and ticket references.
+argument-hint: [base-branch]
+disable-model-invocation: true
+allowed-tools: Bash(git log *), Bash(git diff *), Bash(git branch *), Bash(git push -u origin HEAD), Bash(gh pr create *), mcp__plugin_linear_linear__get_issue
+---
+
+# Create Pull Request
+
+Create a PR for the current branch following lstk's conventions.
+
+## Step 1: Gather context
+
+Run these to understand what's being submitted:
+
+```
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+git diff main...HEAD
+git branch --show-current
+```
+
+If `$ARGUMENTS` is provided, use it as the base branch instead of `main`.
+
+## Step 2: Determine the Linear ticket
+
+Extract the ticket ID from the branch name. The ticket ID is the last path segment, uppercased (e.g., branch `user/abc-123` → ticket `ABC-123`).
+
+Use the Linear MCP tool (`mcp__plugin_linear_linear__get_issue`) to fetch the ticket details — title, description, and URL. Use this context to inform the PR motivation and to link in the Related section.
+
+## Step 3: Write the PR title
+
+- Start with an action verb: Add, Fix, Improve, Remove, Migrate, Update, Refactor
+- Keep under 70 characters
+- Be specific about what changed, not how
+- Match the style of recent commits: `Telemetry client`, `Improve container engine error`, `Migrate stop command to output event system`
+
+## Step 4: Write the PR body
+
+Use this structure:
+
+```markdown
+## Motivation
+
+<Why this change is needed. 1-2 sentences.>
+
+## Changes
+
+- Bullet point per meaningful change
+- Group related changes together
+
+## Tests
+
+<How this was tested — new tests added, manual verification, etc.>
+
+## Todo
+
+- [ ] Any remaining follow-up items (omit section if none)
+
+## Related
+
+- [TICKET-ID](https://linear.app/localstack/issue/TICKET-ID)
+- Links to related PRs, issues, or design docs
+```
+
+Rules:
+- The Related section always includes the Linear ticket link (use the URL from the Linear API response)
+- Keep bullet points concise — what changed, not how every line was modified
+- Omit Todo section if there are no follow-up items
+- Don't over-explain; the diff speaks for itself
+
+## Step 5: Commit and push
+
+If there are uncommitted changes, commit them with a concise message. Do NOT add `Co-Authored-By: Claude` unless the user explicitly asks for it.
+
+Then push and create the PR:
+
+```
+git push -u origin HEAD
+gh pr create --title "<title>" --body "<body>" --base <base-branch>
+```
+
+Return the PR URL when done.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -78,7 +78,7 @@ Then push and create the PR:
 
 ```
 git push -u origin HEAD
-gh pr create --title "<title>" --body "<body>" --base <base-branch>
+gh pr create --draft --title "<title>" --body "<body>" --base <base-branch>
 ```
 
 Return the PR URL when done.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: review-pr
+description: Review a PR against lstk architectural patterns and coding conventions. Use when asked to review a pull request.
+argument-hint: [pr-number]
+allowed-tools: Read, Grep, Glob, Bash(gh pr diff *), Bash(gh pr view *), Bash(git diff *), Bash(git log *)
+---
+
+# Review PR
+
+Review PR #$ARGUMENTS against lstk's architectural patterns and conventions.
+
+## Step 1: Gather PR data
+
+Run these commands to collect context:
+
+```
+gh pr diff $ARGUMENTS
+gh pr view $ARGUMENTS --json title,body,files
+```
+
+## Step 2: Review checklist
+
+Go through each changed file and check for violations. Flag only actual problems — don't nitpick style or formatting that's already consistent with the codebase.
+
+### Architecture boundaries
+
+- [ ] No business logic in `cmd/` — only Cobra wiring, output mode selection, and dependency creation
+- [ ] Domain packages (`internal/container/`, `internal/auth/`, etc.) do not import `charmbracelet/bubbletea` or `internal/ui`
+- [ ] Output mode (TUI vs plain) is selected at the command boundary in `cmd/`, not inside domain logic
+
+### Output and event system
+
+- [ ] No direct `fmt.Print`/`log.Print` in domain code — uses `output.EmitXxx()` helpers instead
+- [ ] New event types (if any) are added to all required locations:
+  - `internal/output/events.go` (struct + `Event` union + emit helper)
+  - `internal/output/plain_format.go` (`FormatEventLine` case)
+  - Tests in `internal/output/*_test.go`
+- [ ] Event payloads carry domain facts, not pre-rendered UI strings
+- [ ] `PlainSink` formatting has no lipgloss/styling imports
+
+### Sink and dependency injection
+
+- [ ] Domain functions accept `output.Sink` as a parameter (not constructed internally)
+- [ ] No package-level global variables — dependencies injected via constructors
+
+### User input
+
+- [ ] Domain code never reads from stdin directly
+- [ ] Interactive input uses `UserInputRequestEvent` + `ResponseCh` pattern
+- [ ] Non-TTY mode fails early with a helpful error if input would be required
+
+### TUI (if UI changes)
+
+- [ ] `Update()` is non-blocking
+- [ ] UI-only messages are suffixed with `...Msg`
+- [ ] Styles use semantic names defined in `internal/ui/styles/styles.go`
+- [ ] Components are single-concern and presentational only
+
+### Testing
+
+- [ ] New functionality has tests (prefer integration tests)
+- [ ] Interactive tests use PTY (`github.com/creack/pty`)
+- [ ] No unchecked errors outside of test files
+
+### General
+
+- [ ] User-facing text uses "emulator" (not "container" or "runtime")
+- [ ] CLAUDE.md updated if architecture changed
+- [ ] No unnecessary comments on self-explanatory code
+
+## Step 3: Output
+
+Provide a summary with:
+1. **Verdict**: Approve / Request changes / Comment
+2. **Issues found**: List each with file path, line, and why it's a problem
+3. **Suggestions**: Optional improvements (clearly marked as non-blocking)
+
+Keep feedback actionable and specific. Don't flag things that aren't problems.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,16 @@ case <-ctx.Done():
 - Preserve the Nimbo palette constants (`#3F51C7`, `#5E6AD2`, `#7E88EC`) unless intentionally changing branding.
 - If changing palette constants, update/add tests to guard against accidental drift.
 
+# Claude Skills
+
+Custom skills are available in `.claude/skills/`:
+
+- `/add-command <name>` — Scaffold a new CLI subcommand with proper cmd/ wiring, domain logic, sink handling, and tests
+- `/add-event <EventName>` — Add a new output event type to the event/sink system with format parity
+- `/add-component <name>` — Scaffold a new Bubble Tea TUI component
+- `/review-pr <number>` — Review a PR against architectural patterns
+- `/create-pr` — Create a PR with conventional format and Linear ticket linking
+
 # Maintaining This File
 
 When making significant changes to the codebase (new commands, architectural changes, build process updates, new patterns), update this CLAUDE.md file to reflect them.


### PR DESCRIPTION
## Motivation

Add Claude Code skills to encode architectural patterns and reduce friction when scaffolding new features. Claude doesn't always follow CLAUDE.md reliably for multi-step scaffolding tasks — skills with explicit step-by-step instructions and anti-pattern lists address this.

## Changes

- `/add-command` — scaffolds a new CLI subcommand (cmd wiring, domain logic, tests), asks clarifying questions first, challenges architectural decisions
- `/add-event` — adds a new output event type with format parity across plain and TUI sinks
- `/add-component` — scaffolds a new Bubble Tea TUI component with styles and tests
- `/review-pr` — reviews a PR against the lstk architectural checklist
- `/create-pr` — creates a PR with conventional Motivation/Changes/Tests/Todo/Related format, fetches Linear ticket context via MCP
- Updated CLAUDE.md with skills reference section

## Tests

Manual verification — invoked skills in a live session to validate structure and behavior.

## Todo

- [ ] Revisit scaffolding skills after more usage to see if they need tuning
- [ ] Consider adding more skills as patterns emerge

## Related

- [FLC-432](https://linear.app/localstack/issue/FLC-432/add-claude-skills-for-common-tasks)