### PR TITLE
Run single integration test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ make clean              # Remove build artifacts
 
 Run a single integration test:
 ```bash
-cd test/integration && go test -count=1 -v -run TestStartCommandSucceedsWithValidToken .
+make test-integration RUN=TestStartCommandSucceedsWithValidToken
 ```
 
 Note: Integration tests require `LOCALSTACK_AUTH_TOKEN` environment variable for valid token tests.

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ test:
 test-integration: $(BUILD_DIR)/$(BINARY_NAME)
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
 	if [ "$$(uname)" = "Darwin" ]; then \
-		cd test/integration && LSTK_KEYRING=file go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 ./...; \
+		cd test/integration && LSTK_KEYRING=file go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 $(if $(RUN),-run $(RUN)) ./...; \
 	else \
-		cd test/integration && go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 ./...; \
+		cd test/integration && go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 $(if $(RUN),-run $(RUN)) ./...; \
 	fi
 
 mock-generate:


### PR DESCRIPTION
Added a `RUN` variable to the `test-integration` Makefile target so a single integration test can be run from the repo root without having to `cd` into `test/integration`:
```bash
make test-integration RUN=TestStartCommandSucceedsWithValidToken
```

Without `RUN`, the target behaves exactly as before and runs all integration tests.