### PR TITLE
Use default login keyring on Linux

### DIFF
--- a/internal/auth/token_storage.go
+++ b/internal/auth/token_storage.go
@@ -39,8 +39,9 @@ func NewTokenStorage(forceFileKeyring bool) (AuthTokenStorage, error) {
 	}
 
 	keyringConfig := keyring.Config{
-		ServiceName: keyringService,
-		FileDir:     filepath.Join(configDir, keyringFilename),
+		ServiceName:             keyringService,
+		LibSecretCollectionName: "login", // use the default login keyring on Linux, ignored on other platforms
+		FileDir:                 filepath.Join(configDir, keyringFilename),
 		FilePasswordFunc: func(prompt string) (string, error) {
 			return keyringPassword, nil
 		},


### PR DESCRIPTION
Fixes DRG-577.

## Problem

`lstk` was creating a separate `lstk` keyring collection instead of using the system's default `login` keyring. This caused users to be prompted to manually unlock the `lstk` keyring on each session, unlike other tools (`gh`, Chrome) which use the `login` keyring and get auto-unlocked at login.

## Fix

Set `LibSecretCollectionName: "login"` in the keyring config. This is picked up by the `99designs/keyring` SecretService backend (Linux only) and points it to the existing `login` collection instead of creating a new one named after the service.

  | Platform | Behavior |
  |---|---|
  | GNOME Keyring (most Linux desktop users) | Fixed — token stored in `login` collection, auto-unlocked at login |
  | KDE + KWallet native (no SecretService bridge) | Unaffected — `LibSecretCollectionName` ignored by KWallet backend |
  | KDE + KWallet SecretService bridge enabled | `login` collection created in KWallet instead of `lstk` —  functional, no worse than before |
  | macOS / Windows | Unaffected — `LibSecretCollectionName` ignored on non-Linux platforms |


## :heavy_check_mark: Tested





  | Before | After |
  |---|---|
  | <img width="1157" height="415" alt="before" src="https://github.com/user-attachments/assets/64c382c4-e1d5-4097-9260-fb980134b137" /> | <img width="945" height="367" alt="after" src="https://github.com/user-attachments/assets/c445db8d-12a1-4bdf-b690-a71fa970c34b" /> |