### PR TITLE
fix: remove CalVer mention from release workflow

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   create-tag:
-    name: Create next CalVer tag
+    name: Create next tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Small cleanup: the `create-release-tag` workflow job was named "Create next CalVer tag", which is misleading since we decided not to use calendar versioning for now.