### PR TITLE
Implement --non-interactive flag

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -17,7 +17,7 @@ func newLoginCmd(cfg *env.Env) *cobra.Command {
 		Long:    "Manage login and store credentials in system keyring",
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !ui.IsInteractive() || cfg.NonInteractive {
+			if !isInteractiveMode(cfg) {
 				return fmt.Errorf("login requires an interactive terminal")
 			}
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -17,7 +17,7 @@ func newLoginCmd(cfg *env.Env) *cobra.Command {
 		Long:    "Manage login and store credentials in system keyring",
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !ui.IsInteractive() {
+			if !ui.IsInteractive() || cfg.NonInteractive {
 				return fmt.Errorf("login requires an interactive terminal")
 			}
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint)

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -20,7 +20,7 @@ func newLogoutCmd(cfg *env.Env) *cobra.Command {
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint)
-			if ui.IsInteractive() {
+			if !cfg.NonInteractive && ui.IsInteractive() {
 				return ui.RunLogout(cmd.Context(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring)
 			}
 

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -20,7 +20,7 @@ func newLogoutCmd(cfg *env.Env) *cobra.Command {
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint)
-			if !cfg.NonInteractive && ui.IsInteractive() {
+			if isInteractiveMode(cfg) {
 				return ui.RunLogout(cmd.Context(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring)
 			}
 

--- a/cmd/non_interactive_test.go
+++ b/cmd/non_interactive_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/localstack/lstk/internal/env"
+	"github.com/localstack/lstk/internal/telemetry"
+)
+
+func TestNonInteractiveFlagIsRegistered(t *testing.T) {
+	root := NewRootCmd(&env.Env{}, telemetry.New("", true))
+
+	flag := root.PersistentFlags().Lookup("non-interactive")
+	if flag == nil {
+		t.Fatal("expected --non-interactive flag to be registered on root command")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("expected default value to be false, got %q", flag.DefValue)
+	}
+}
+
+func TestNonInteractiveFlagAppearsInHelp(t *testing.T) {
+	out, err := executeWithArgs(t, "--help")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	assertContains(t, out, "--non-interactive")
+}
+
+func TestNonInteractiveFlagAppearsInStartHelp(t *testing.T) {
+	out, err := executeWithArgs(t, "start", "--help")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	assertContains(t, out, "--non-interactive")
+}
+
+func TestNonInteractiveFlagAppearsInStopHelp(t *testing.T) {
+	out, err := executeWithArgs(t, "stop", "--help")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	assertContains(t, out, "--non-interactive")
+}
+
+func TestNonInteractiveFlagBindsToCfg(t *testing.T) {
+	cfg := &env.Env{}
+	root := NewRootCmd(cfg, telemetry.New("", true))
+	root.SetArgs([]string{"--non-interactive", "version"})
+	_ = root.Execute()
+
+	if !cfg.NonInteractive {
+		t.Fatal("expected cfg.NonInteractive to be true after --non-interactive flag")
+	}
+}
+
+func TestNonInteractiveFlagDefaultIsOff(t *testing.T) {
+	cfg := &env.Env{}
+	root := NewRootCmd(cfg, telemetry.New("", true))
+	root.SetArgs([]string{"version"})
+	_ = root.Execute()
+
+	if cfg.NonInteractive {
+		t.Fatal("expected cfg.NonInteractive to be false when flag is not set")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	root.SilenceUsage = true
 
 	root.PersistentFlags().String("config", "", "Path to config file")
+	root.PersistentFlags().BoolVar(&cfg.NonInteractive, "non-interactive", false, "Disable interactive mode")
 
 	configureHelp(root)
 
@@ -46,7 +47,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 
 	root.AddCommand(
 		newStartCmd(cfg, tel),
-		newStopCmd(),
+		newStopCmd(cfg),
 		newLoginCmd(cfg),
 		newLogoutCmd(cfg),
 		newLogsCmd(),
@@ -80,7 +81,7 @@ func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *teleme
 	tel.Emit(ctx, "cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
 
 	platformClient := api.NewPlatformClient(cfg.APIEndpoint)
-	if ui.IsInteractive() {
+	if !cfg.NonInteractive && ui.IsInteractive() {
 		return ui.Run(ctx, rt, version.Version(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL)
 	}
 	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL, false)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,10 +81,14 @@ func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *teleme
 	tel.Emit(ctx, "cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
 
 	platformClient := api.NewPlatformClient(cfg.APIEndpoint)
-	if !cfg.NonInteractive && ui.IsInteractive() {
+	if isInteractiveMode(cfg) {
 		return ui.Run(ctx, rt, version.Version(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL)
 	}
 	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL, false)
+}
+
+func isInteractiveMode(cfg *env.Env) bool {
+	return !cfg.NonInteractive && ui.IsInteractive()
 }
 
 func initConfig(cmd *cobra.Command, _ []string) error {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -4,13 +4,14 @@ import (
 	"os"
 
 	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newStopCmd() *cobra.Command {
+func newStopCmd(cfg *env.Env) *cobra.Command {
 	return &cobra.Command{
 		Use:     "stop",
 		Short:   "Stop emulator",
@@ -22,7 +23,7 @@ func newStopCmd() *cobra.Command {
 				return err
 			}
 
-			if ui.IsInteractive() {
+			if !cfg.NonInteractive && ui.IsInteractive() {
 				return ui.RunStop(cmd.Context(), rt)
 			}
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -23,7 +23,7 @@ func newStopCmd(cfg *env.Env) *cobra.Command {
 				return err
 			}
 
-			if !cfg.NonInteractive && ui.IsInteractive() {
+			if isInteractiveMode(cfg) {
 				return ui.RunStop(cmd.Context(), rt)
 			}
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -14,6 +14,7 @@ type Env struct {
 	ForceFileKeyring  bool
 	AnalyticsEndpoint string
 	DisableEvents     bool
+	NonInteractive    bool
 }
 
 // Init initializes environment variable configuration and returns the result.

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/99designs/keyring"
+	"github.com/creack/pty"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
@@ -201,6 +202,38 @@ func runLstk(t *testing.T, ctx context.Context, dir string, env []string, args .
 
 	err = cmd.Run()
 	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
+}
+
+// runs the lstk binary inside a PTY so that ui.IsInteractive() returns true,
+// making --non-interactive the actual condition under test
+func runLstkInPTY(t *testing.T, ctx context.Context, environ []string, args ...string) (string, error) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	binPath, err := filepath.Abs(binaryPath())
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(ctx, binPath, args...)
+	if environ != nil {
+		cmd.Env = environ
+	}
+
+	ptmx, err := pty.Start(cmd)
+	require.NoError(t, err, "failed to start command in PTY")
+	defer func() { _ = ptmx.Close() }()
+
+	out := &syncBuffer{}
+	outputCh := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(out, ptmx)
+		close(outputCh)
+	}()
+
+	err = cmd.Wait()
+	<-outputCh
+	return strings.TrimSpace(out.String()), err
 }
 
 func createMockLicenseServer(success bool) *httptest.Server {

--- a/test/integration/non_interactive_test.go
+++ b/test/integration/non_interactive_test.go
@@ -1,0 +1,41 @@
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonInteractiveFlagBlocksLogin(t *testing.T) {
+	_, stderr, err := runLstk(t, testContext(t), "", nil, "login", "--non-interactive")
+	require.Error(t, err, "expected login --non-interactive to fail")
+	assert.Contains(t, stderr, "login requires an interactive terminal")
+}
+
+func TestNonInteractiveFlagFailsWithoutToken(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	_, stderr, err := runLstk(t, testContext(t), "", env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL), "start", "--non-interactive")
+	require.Error(t, err, "expected start --non-interactive to fail with no auth token")
+	assert.Contains(t, stderr, "LOCALSTACK_AUTH_TOKEN")
+}
+
+func TestRootNonInteractiveFlagFailsWithoutToken(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	_, stderr, err := runLstk(t, testContext(t), "", env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL), "--non-interactive")
+	require.Error(t, err, "expected lstk --non-interactive to fail with no auth token")
+	assert.Contains(t, stderr, "LOCALSTACK_AUTH_TOKEN")
+}

--- a/test/integration/non_interactive_test.go
+++ b/test/integration/non_interactive_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestNonInteractiveFlagBlocksLogin(t *testing.T) {
-	_, stderr, err := runLstk(t, testContext(t), "", nil, "login", "--non-interactive")
+	out, err := runLstkInPTY(t, testContext(t), nil, "login", "--non-interactive")
 	require.Error(t, err, "expected login --non-interactive to fail")
-	assert.Contains(t, stderr, "login requires an interactive terminal")
+	assert.Contains(t, out, "login requires an interactive terminal")
 }
 
 func TestNonInteractiveFlagFailsWithoutToken(t *testing.T) {
@@ -22,9 +22,9 @@ func TestNonInteractiveFlagFailsWithoutToken(t *testing.T) {
 	mockServer := createMockLicenseServer(true)
 	defer mockServer.Close()
 
-	_, stderr, err := runLstk(t, testContext(t), "", env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL), "start", "--non-interactive")
+	out, err := runLstkInPTY(t, testContext(t), env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL), "start", "--non-interactive")
 	require.Error(t, err, "expected start --non-interactive to fail with no auth token")
-	assert.Contains(t, stderr, "LOCALSTACK_AUTH_TOKEN")
+	assert.Contains(t, out, "authentication required: set LOCALSTACK_AUTH_TOKEN or run in interactive mode")
 }
 
 func TestRootNonInteractiveFlagFailsWithoutToken(t *testing.T) {
@@ -35,7 +35,7 @@ func TestRootNonInteractiveFlagFailsWithoutToken(t *testing.T) {
 	mockServer := createMockLicenseServer(true)
 	defer mockServer.Close()
 
-	_, stderr, err := runLstk(t, testContext(t), "", env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL), "--non-interactive")
+	out, err := runLstkInPTY(t, testContext(t), env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL), "--non-interactive")
 	require.Error(t, err, "expected lstk --non-interactive to fail with no auth token")
-	assert.Contains(t, stderr, "LOCALSTACK_AUTH_TOKEN")
+	assert.Contains(t, out, "authentication required: set LOCALSTACK_AUTH_TOKEN or run in interactive mode")
 }


### PR DESCRIPTION
- adds `--non-interactive` as a persistent flag on the root command                                                                                
- forces plain output (no TUI/spinners) and disables login prompts
- `lstk login --non-interactive` fails because it can't open browser
- `lstk start` fails when `LOCALSTACK_AUTH_TOKEN` is not set