### PR TITLE
Make pulling output use primary colors

### DIFF
--- a/internal/ui/components/pull_progress.go
+++ b/internal/ui/components/pull_progress.go
@@ -115,7 +115,7 @@ func (p PullProgress) View() string {
 	// Fixed-width: "Downloading" is the longest phase (11 chars), counts padded to "XX/XX"
 	label := fmt.Sprintf("%-11s %2d/%-2d layers", phase, done, total)
 	return fmt.Sprintf("  %s  %s",
-		label,
+		styles.Secondary.Render(label),
 		p.bar.View(),
 	)
 }

--- a/internal/ui/components/spinner.go
+++ b/internal/ui/components/spinner.go
@@ -85,7 +85,7 @@ func (s Spinner) View() string {
 	if !s.visible {
 		return ""
 	}
-	return s.model.View() + styles.Secondary.Render(s.text)
+	return s.model.View() + s.text
 }
 
 func (s Spinner) Tick() tea.Cmd {


### PR DESCRIPTION
See DES-152 for more context.

| BEFORE | AFTER |
|--------|--------|
| <img width="707" height="275" alt="Screenshot 2026-03-09 at 21 21 21" src="https://github.com/user-attachments/assets/ac19dce7-a545-4b84-9e0d-e58c59f648ca" /> | <img width="707" height="275" alt="Screenshot 2026-03-09 at 21 19 25" src="https://github.com/user-attachments/assets/cb65a0a1-4e46-4b17-9109-956fcd63e25c" /> | 