### PR TITLE
Pressing Enter confirms prompts with an uppercase default

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -94,47 +94,12 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, tea.Quit
 		}
 		if a.pendingInput != nil {
-			// "any" option: any keypress resolves the prompt
-			for _, opt := range a.pendingInput.Options {
-				if opt.Key == "any" {
-					a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, "any")})
-					responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: "any"})
-					a.pendingInput = nil
-					a.inputPrompt = a.inputPrompt.Hide()
-					return a, responseCmd
-				}
-			}
-			if msg.Type == tea.KeyEnter {
-				for _, opt := range a.pendingInput.Options {
-					// explicit "enter" option takes priority
-					if opt.Key == "enter" {
-						a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, "enter")})
-						responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: "enter"})
-						a.pendingInput = nil
-						a.inputPrompt = a.inputPrompt.Hide()
-						return a, responseCmd
-					}
-				}
-				// fall back to the option with an uppercase label (conventional default)
-				for _, opt := range a.pendingInput.Options {
-					if opt.Label != "" && hasLetters(opt.Label) && opt.Label == strings.ToUpper(opt.Label) {
-						a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
-						responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
-						a.pendingInput = nil
-						a.inputPrompt = a.inputPrompt.Hide()
-						return a, responseCmd
-					}
-				}
-				return a, nil
-			}
-			for _, opt := range a.pendingInput.Options {
-				if strings.EqualFold(msg.String(), opt.Key) {
-					a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
-					responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
-					a.pendingInput = nil
-					a.inputPrompt = a.inputPrompt.Hide()
-					return a, responseCmd
-				}
+			if opt := resolveOption(a.pendingInput.Options, msg); opt != nil {
+				a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
+				responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
+				a.pendingInput = nil
+				a.inputPrompt = a.inputPrompt.Hide()
+				return a, responseCmd
 			}
 		}
 	case tea.WindowSizeMsg:
@@ -291,6 +256,28 @@ func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) s
 
 const lineIndent = 2
 
+// resolveOption finds the best matching option for a key event, in priority order:
+//  1. "any" — matches any keypress
+//  2. "enter" — matches the Enter key explicitly
+//  3. uppercase label — matches Enter as the conventional default
+//  4. case-insensitive key match — matches any other key
+func resolveOption(options []output.InputOption, msg tea.KeyMsg) *output.InputOption {
+	var uppercaseDefault *output.InputOption
+	for i, opt := range options {
+		switch {
+		case opt.Key == "any":
+			return &options[i]
+		case msg.Type == tea.KeyEnter && opt.Key == "enter":
+			return &options[i]
+		case msg.Type == tea.KeyEnter && uppercaseDefault == nil &&
+			opt.Label != "" && hasLetters(opt.Label) && opt.Label == strings.ToUpper(opt.Label):
+			uppercaseDefault = &options[i]
+		case msg.Type != tea.KeyEnter && strings.EqualFold(msg.String(), opt.Key):
+			return &options[i]
+		}
+	}
+	return uppercaseDefault
+}
 
 func hasLetters(s string) bool {
 	for _, r := range s {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -116,7 +117,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				// fall back to the option with an uppercase label (conventional default)
 				for _, opt := range a.pendingInput.Options {
-					if opt.Label != "" && opt.Label == strings.ToUpper(opt.Label) {
+					if opt.Label != "" && hasLetters(opt.Label) && opt.Label == strings.ToUpper(opt.Label) {
 						a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
 						responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
 						a.pendingInput = nil
@@ -290,6 +291,15 @@ func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) s
 
 const lineIndent = 2
 
+
+func hasLetters(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) {
+			return true
+		}
+	}
+	return false
+}
 
 func isURL(s string) bool {
 	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -105,6 +105,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if msg.Type == tea.KeyEnter {
 				for _, opt := range a.pendingInput.Options {
+					// explicit "enter" option takes priority
 					if opt.Key == "enter" {
 						a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, "enter")})
 						responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: "enter"})
@@ -113,10 +114,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return a, responseCmd
 					}
 				}
+				// fall back to the option with an uppercase label (conventional default)
+				for _, opt := range a.pendingInput.Options {
+					if opt.Label != "" && opt.Label == strings.ToUpper(opt.Label) {
+						a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
+						responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
+						a.pendingInput = nil
+						a.inputPrompt = a.inputPrompt.Hide()
+						return a, responseCmd
+					}
+				}
 				return a, nil
 			}
 			for _, opt := range a.pendingInput.Options {
-				if msg.String() == opt.Key {
+				if strings.EqualFold(msg.String(), opt.Key) {
 					a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
 					responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
 					a.pendingInput = nil

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -309,6 +309,39 @@ func TestAppEnterDoesNothingWithoutDefault(t *testing.T) {
 	}
 }
 
+func TestAppEnterDoesNothingWithNonLetterLabel(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+	responseCh := make(chan output.InputResponse, 1)
+
+	model, _ := app.Update(output.UserInputRequestEvent{
+		Prompt: "Choose:",
+		Options: []output.InputOption{
+			{Key: "1", Label: "1"},
+			{Key: "2", Label: "2"},
+		},
+		ResponseCh: responseCh,
+	})
+	app = model.(App)
+
+	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	app = model.(App)
+	if cmd != nil {
+		t.Fatal("expected no response command when label contains no letters")
+	}
+
+	select {
+	case resp := <-responseCh:
+		t.Fatalf("expected no response, got %+v", resp)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if !app.inputPrompt.Visible() {
+		t.Fatal("expected input prompt to remain visible")
+	}
+}
+
 func TestAppAnyKeyOptionResolvesOnAnyKeypress(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -503,3 +503,122 @@ func TestAppPendingInputOptionCOverridesClipboardShortcut(t *testing.T) {
 		t.Fatal("expected input prompt to be hidden after response")
 	}
 }
+
+func TestResolveOption(t *testing.T) {
+	enter := tea.KeyMsg{Type: tea.KeyEnter}
+	keyY := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+	keyYUpper := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}}
+
+	tests := []struct {
+		name           string
+		options        []output.InputOption
+		press          tea.KeyMsg
+		wantOptionKey  string // key of the expected returned option; empty means nil
+	}{
+		// "any" option
+		{
+			name:          "any matches regular keypress",
+			options:       []output.InputOption{{Key: "any", Label: "Press any key"}},
+			press:         keyY,
+			wantOptionKey: "any",
+		},
+		{
+			name:          "any matches Enter and takes priority over explicit enter",
+			options:       []output.InputOption{{Key: "any"}, {Key: "enter"}},
+			press:         enter,
+			wantOptionKey: "any",
+		},
+
+		// explicit "enter" option
+		{
+			name:          "enter matches Enter key",
+			options:       []output.InputOption{{Key: "enter", Label: "Continue"}},
+			press:         enter,
+			wantOptionKey: "enter",
+		},
+		{
+			name:          "enter does not match regular key",
+			options:       []output.InputOption{{Key: "enter", Label: "Continue"}},
+			press:         keyY,
+			wantOptionKey: "",
+		},
+		{
+			name:          "enter takes priority over uppercase label",
+			options:       []output.InputOption{{Key: "y", Label: "Y"}, {Key: "enter", Label: "Continue"}},
+			press:         enter,
+			wantOptionKey: "enter",
+		},
+
+		// uppercase label default
+		{
+			name:          "uppercase label matches Enter key",
+			options:       []output.InputOption{{Key: "y", Label: "Y"}, {Key: "n", Label: "n"}},
+			press:         enter,
+			wantOptionKey: "y",
+		},
+		{
+			name:          "first uppercase label wins",
+			options:       []output.InputOption{{Key: "y", Label: "Y"}, {Key: "a", Label: "ALL"}},
+			press:         enter,
+			wantOptionKey: "y",
+		},
+		{
+			name:          "uppercase label does not act as default for unmatched regular key",
+			options:       []output.InputOption{{Key: "y", Label: "Y"}, {Key: "n", Label: "n"}},
+			press:         tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}},
+			wantOptionKey: "",
+		},
+		{
+			name:          "non-letter label not treated as uppercase default",
+			options:       []output.InputOption{{Key: "1", Label: "1"}, {Key: "2", Label: "2"}},
+			press:         enter,
+			wantOptionKey: "",
+		},
+
+		// case-insensitive key matching
+		{
+			name:          "lowercase key matches lowercase option",
+			options:       []output.InputOption{{Key: "y", Label: "Y"}, {Key: "n", Label: "n"}},
+			press:         keyY,
+			wantOptionKey: "y",
+		},
+		{
+			name:          "uppercase key matches lowercase option",
+			options:       []output.InputOption{{Key: "y", Label: "Y"}, {Key: "n", Label: "n"}},
+			press:         keyYUpper,
+			wantOptionKey: "y",
+		},
+
+		// no match
+		{
+			name:          "no options returns nil",
+			options:       []output.InputOption{},
+			press:         keyY,
+			wantOptionKey: "",
+		},
+		{
+			name:          "no matching option returns nil",
+			options:       []output.InputOption{{Key: "n", Label: "n"}},
+			press:         keyY,
+			wantOptionKey: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveOption(tc.options, tc.press)
+			if tc.wantOptionKey == "" {
+				if got != nil {
+					t.Fatalf("expected nil, got option with key %q", got.Key)
+				}
+			} else {
+				if got == nil {
+					t.Fatal("expected non-nil option, got nil")
+				}
+				if got.Key != tc.wantOptionKey {
+					t.Fatalf("got key %q, want %q", got.Key, tc.wantOptionKey)
+				}
+			}
+		})
+	}
+}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -239,7 +239,7 @@ func TestAppEnterPrefersExplicitEnterOption(t *testing.T) {
 	}
 }
 
-func TestAppEnterDoesNothingWithoutExplicitEnterOption(t *testing.T) {
+func TestAppEnterSelectsUppercaseLabelDefault(t *testing.T) {
 	t.Parallel()
 
 	app := NewApp("dev", "", "", nil)
@@ -257,8 +257,45 @@ func TestAppEnterDoesNothingWithoutExplicitEnterOption(t *testing.T) {
 
 	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	app = model.(App)
+	if cmd == nil {
+		t.Fatal("expected response command when enter is pressed with uppercase default")
+	}
+	cmd()
+
+	select {
+	case resp := <-responseCh:
+		if resp.SelectedKey != "y" {
+			t.Fatalf("expected y key, got %q", resp.SelectedKey)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for response on channel")
+	}
+
+	if app.inputPrompt.Visible() {
+		t.Fatal("expected input prompt to be hidden after response")
+	}
+}
+
+func TestAppEnterDoesNothingWithoutDefault(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+	responseCh := make(chan output.InputResponse, 1)
+
+	model, _ := app.Update(output.UserInputRequestEvent{
+		Prompt: "Choose:",
+		Options: []output.InputOption{
+			{Key: "y", Label: "y"},
+			{Key: "n", Label: "n"},
+		},
+		ResponseCh: responseCh,
+	})
+	app = model.(App)
+
+	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	app = model.(App)
 	if cmd != nil {
-		t.Fatal("expected no response command when enter is not an explicit option")
+		t.Fatal("expected no response command when no uppercase default option exists")
 	}
 
 	select {


### PR DESCRIPTION
- Case-insensitive key matching for input prompts (e.g. pressing Y now works, not just y)
- Pressing Enter selects the option with an uppercase label as the default — no need to explicitly add {Key: "enter"} to every prompt definition; just capitalize the label (e.g. {Key: "y", Label: "Y"})

Example: Pressing Enter or y here will confirm as well
<img width="698" height="313" alt="image" src="https://github.com/user-attachments/assets/42f15626-1a61-4c68-9e40-ebf013be38d0" />
