### PR TITLE
fix: prevent silent errors from overwriting TUI error display

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -217,7 +217,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.err = msg.err
 		a.spinner, _ = a.spinner.Stop()
 		a.flushBufferedLines()
-		a.errorDisplay = a.errorDisplay.Show(output.ErrorEvent{Title: msg.err.Error()})
+		if !output.IsSilent(msg.err) {
+			a.errorDisplay = a.errorDisplay.Show(output.ErrorEvent{Title: msg.err.Error()})
+		}
 		return a, tea.Quit
 	default:
 		if line, ok := output.FormatEventLine(msg); ok {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -198,6 +199,46 @@ func TestAppErrorEventStopsSpinner(t *testing.T) {
 	}
 	if !app.errorDisplay.Visible() {
 		t.Fatal("expected error display to be visible after ErrorEvent")
+	}
+}
+
+func TestAppSilentErrorDoesNotOverwriteErrorDisplay(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+
+	// Simulate EmitUnhealthyError: sink emits a nice ErrorEvent first.
+	model, _ := app.Update(output.ErrorEvent{Title: "Docker is not available"})
+	app = model.(App)
+
+	// Simulate runErrMsg arriving with a SilentError (already displayed).
+	silentErr := output.NewSilentError(fmt.Errorf("runtime not healthy: cannot connect to Docker daemon"))
+	model, _ = app.Update(runErrMsg{err: silentErr})
+	app = model.(App)
+
+	view := app.errorDisplay.View(200)
+	if !strings.Contains(view, "Docker is not available") {
+		t.Fatalf("expected original error to be preserved, got: %q", view)
+	}
+	if strings.Contains(view, "runtime not healthy") {
+		t.Fatalf("expected silent error not to overwrite display, got: %q", view)
+	}
+}
+
+func TestAppNonSilentErrorShowsInErrorDisplay(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+
+	model, _ := app.Update(runErrMsg{err: fmt.Errorf("something unexpected")})
+	app = model.(App)
+
+	if !app.errorDisplay.Visible() {
+		t.Fatal("expected error display to be visible for non-silent error")
+	}
+	view := app.errorDisplay.View(200)
+	if !strings.Contains(view, "something unexpected") {
+		t.Fatalf("expected error title in display, got: %q", view)
 	}
 }
 


### PR DESCRIPTION
Fix regression and bring back change from https://github.com/localstack/lstk/pull/72



| Before   |      After      | 
|----------|:-------------:|
| <img width="1270" height="264" alt="before" src="https://github.com/user-attachments/assets/786a8c58-db5e-4635-9c35-26c75f2bfcec" /> | <img width="1233" height="436" alt="after" src="https://github.com/user-attachments/assets/181c8db8-1954-4d33-865b-baf9b0084bc6" /> |

