### PR TITLE
Add update command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,16 @@ jobs:
             go.sum
             test/integration/go.sum
 
+      - name: Install lstk via Homebrew
+        if: matrix.os == 'macos-latest'
+        run: brew install localstack/tap/lstk
+
       - name: Run integration tests
         run: make test-integration
         env:
           CREATE_JUNIT_REPORT: "true"
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          LSTK_TEST_HOMEBREW: ${{ matrix.os == 'macos-latest' && '1' || '0' }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
           CREATE_JUNIT_REPORT: "true"
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           LSTK_TEST_HOMEBREW: ${{ matrix.os == 'macos-latest' && '1' || '0' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
             go.sum
             test/integration/go.sum
 
+      # Install lstk via Homebrew so the Homebrew update integration test
+      # (TestUpdateHomebrew) can locate a real Caskroom binary path.
       - name: Install lstk via Homebrew
         if: matrix.os == 'macos-latest'
         run: brew install localstack/tap/lstk
@@ -108,7 +110,7 @@ jobs:
           CREATE_JUNIT_REPORT: "true"
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           LSTK_TEST_HOMEBREW: ${{ matrix.os == 'macos-latest' && '1' || '0' }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LSTK_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Note: Integration tests require `LOCALSTACK_AUTH_TOKEN` environment variable for
   - `config/` - Viper-based TOML config loading and path resolution
   - `output/` - Generic event and sink abstractions for CLI/TUI/non-interactive rendering
   - `ui/` - Bubble Tea views for interactive output
+  - `update/` - Self-update logic: version check via GitHub API, binary/Homebrew/npm update paths, archive extraction
 
 # Configuration
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		newLogsCmd(),
 		newConfigCmd(),
 		newVersionCmd(),
+		newUpdateCmd(cfg),
 	)
 
 	return root

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/localstack/lstk/internal/env"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/ui"
+	"github.com/localstack/lstk/internal/update"
+	"github.com/spf13/cobra"
+)
+
+func newUpdateCmd(cfg *env.Env) *cobra.Command {
+	var checkOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update lstk to the latest version",
+		Long:  "Check for and apply updates to the lstk CLI. Respects the original installation method (Homebrew, npm, or direct binary).",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if isInteractiveMode(cfg) {
+				return ui.RunUpdate(cmd.Context(), checkOnly)
+			}
+			return update.Update(cmd.Context(), output.NewPlainSink(os.Stdout), checkOnly)
+		},
+	}
+
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "Only check for updates without applying them")
+
+	return cmd
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -14,9 +14,10 @@ func newUpdateCmd(cfg *env.Env) *cobra.Command {
 	var checkOnly bool
 
 	cmd := &cobra.Command{
-		Use:   "update",
-		Short: "Update lstk to the latest version",
-		Long:  "Check for and apply updates to the lstk CLI. Respects the original installation method (Homebrew, npm, or direct binary).",
+		Use:     "update",
+		Short:   "Update lstk to the latest version",
+		Long:    "Check for and apply updates to the lstk CLI. Respects the original installation method (Homebrew, npm, or direct binary).",
+		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if isInteractiveMode(cfg) {
 				return ui.RunUpdate(cmd.Context(), checkOnly)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -20,9 +20,9 @@ func newUpdateCmd(cfg *env.Env) *cobra.Command {
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if isInteractiveMode(cfg) {
-				return ui.RunUpdate(cmd.Context(), checkOnly)
+				return ui.RunUpdate(cmd.Context(), checkOnly, cfg.GitHubToken)
 			}
-			return update.Update(cmd.Context(), output.NewPlainSink(os.Stdout), checkOnly)
+			return update.Update(cmd.Context(), output.NewPlainSink(os.Stdout), checkOnly, cfg.GitHubToken)
 		},
 	}
 

--- a/internal/container/logs.go
+++ b/internal/container/logs.go
@@ -33,7 +33,7 @@ func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink, follow bool
 
 	scanner := bufio.NewScanner(pr)
 	for scanner.Scan() {
-		output.EmitContainerLogLine(sink, scanner.Text())
+		output.EmitLogLine(sink, "container", scanner.Text())
 	}
 	if err := scanner.Err(); err != nil && ctx.Err() == nil {
 		return err

--- a/internal/container/logs.go
+++ b/internal/container/logs.go
@@ -33,7 +33,7 @@ func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink, follow bool
 
 	scanner := bufio.NewScanner(pr)
 	for scanner.Scan() {
-		output.EmitLogLine(sink, "container", scanner.Text())
+		output.EmitLogLine(sink, output.LogSourceEmulator, scanner.Text())
 	}
 	if err := scanner.Err(); err != nil && ctx.Err() == nil {
 		return err

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -18,6 +18,7 @@ type Env struct {
 	AnalyticsEndpoint string
 
 	NonInteractive    bool
+	GitHubToken       string
 }
 
 // Init initializes environment variable configuration and returns the result.
@@ -39,6 +40,7 @@ func Init() *Env {
 		WebAppURL:         viper.GetString("web_app_url"),
 		ForceFileKeyring:  viper.GetString("keyring") == "file",
 		AnalyticsEndpoint: viper.GetString("analytics_endpoint"),
+		GitHubToken:       viper.GetString("github_token"),
 	}
 
 }

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -58,7 +58,7 @@ type AuthEvent struct {
 }
 
 type Event interface {
-	MessageEvent | AuthEvent | SpinnerEvent | ErrorEvent | ContainerStatusEvent | ProgressEvent | UserInputRequestEvent | ContainerLogLineEvent
+	MessageEvent | AuthEvent | SpinnerEvent | ErrorEvent | ContainerStatusEvent | ProgressEvent | UserInputRequestEvent | LogLineEvent
 }
 
 type Sink interface {
@@ -105,8 +105,9 @@ type UserInputRequestEvent struct {
 	ResponseCh chan<- InputResponse
 }
 
-type ContainerLogLineEvent struct {
-	Line string
+type LogLineEvent struct {
+	Source string // e.g., "container", "brew", "npm"
+	Line   string
 }
 
 // Emit sends an event to the sink with compile-time type safety via generics.
@@ -155,8 +156,8 @@ func EmitAuth(sink Sink, event AuthEvent) {
 	Emit(sink, event)
 }
 
-func EmitContainerLogLine(sink Sink, line string) {
-	Emit(sink, ContainerLogLineEvent{Line: line})
+func EmitLogLine(sink Sink, source, line string) {
+	Emit(sink, LogLineEvent{Source: source, Line: line})
 }
 
 const DefaultSpinnerMinDuration = 400 * time.Millisecond

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -105,8 +105,14 @@ type UserInputRequestEvent struct {
 	ResponseCh chan<- InputResponse
 }
 
+const (
+	LogSourceEmulator = "emulator"
+	LogSourceBrew     = "brew"
+	LogSourceNPM      = "npm"
+)
+
 type LogLineEvent struct {
-	Source string // e.g., "container", "brew", "npm"
+	Source string // use LogSource* constants
 	Line   string
 }
 

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -25,7 +25,7 @@ func FormatEventLine(event any) (string, bool) {
 		return "", false
 	case UserInputRequestEvent:
 		return formatUserInputRequest(e), true
-	case ContainerLogLineEvent:
+	case LogLineEvent:
 		return e.Line, true
 	default:
 		return "", false

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -188,6 +188,7 @@ func TestPlainSink_UsesFormatterParity(t *testing.T) {
 		SpinnerEvent{Active: true, Text: "Loading"},
 		ErrorEvent{Title: "Failed", Summary: "Something broke"},
 		ContainerStatusEvent{Phase: "starting", Container: "localstack"},
+		LogLineEvent{Source: "container", Line: "2024-01-01 hello"},
 	}
 
 	for _, event := range events {
@@ -204,6 +205,8 @@ func TestPlainSink_UsesFormatterParity(t *testing.T) {
 		case ErrorEvent:
 			Emit(sink, e)
 		case ContainerStatusEvent:
+			Emit(sink, e)
+		case LogLineEvent:
 			Emit(sink, e)
 		default:
 			t.Fatalf("unsupported event type in test: %T", event)

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -105,11 +105,11 @@ func TestPlainSink_SuppressesProgressEvent(t *testing.T) {
 	assert.Equal(t, "", out.String())
 }
 
-func TestPlainSink_EmitsContainerLogLineEvent(t *testing.T) {
+func TestPlainSink_EmitsLogLineEvent(t *testing.T) {
 	var out bytes.Buffer
 	sink := NewPlainSink(&out)
 
-	Emit(sink, ContainerLogLineEvent{Line: "2024-01-01 hello from container"})
+	Emit(sink, LogLineEvent{Source: "container", Line: "2024-01-01 hello from container"})
 
 	assert.Equal(t, "2024-01-01 hello from container\n", out.String())
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -161,6 +161,15 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.lines = appendLine(a.lines, styledLine{text: msg.URL, secondary: true})
 		}
 		return a, nil
+	case output.LogLineEvent:
+		prefix := styles.Secondary.Render(msg.Source + " | ")
+		line := styledLine{text: prefix + styles.Message.Render(msg.Line)}
+		if a.spinner.PendingStop() {
+			a.bufferedLines = append(a.bufferedLines, line)
+		} else {
+			a.lines = appendLine(a.lines, line)
+		}
+		return a, nil
 	case output.ContainerStatusEvent:
 		if msg.Phase == "pulling" {
 			a.pullProgress = a.pullProgress.Show(msg.Container)

--- a/internal/ui/run_update.go
+++ b/internal/ui/run_update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/localstack/lstk/internal/update"
 )
 
-func RunUpdate(parentCtx context.Context, checkOnly bool) error {
+func RunUpdate(parentCtx context.Context, checkOnly bool, githubToken string) error {
 	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
@@ -19,7 +19,7 @@ func RunUpdate(parentCtx context.Context, checkOnly bool) error {
 	runErrCh := make(chan error, 1)
 
 	go func() {
-		err := update.Update(ctx, output.NewTUISink(programSender{p: p}), checkOnly)
+		err := update.Update(ctx, output.NewTUISink(programSender{p: p}), checkOnly, githubToken)
 		runErrCh <- err
 		if err != nil && !errors.Is(err, context.Canceled) {
 			p.Send(runErrMsg{err: err})

--- a/internal/ui/run_update.go
+++ b/internal/ui/run_update.go
@@ -1,0 +1,46 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/update"
+)
+
+func RunUpdate(parentCtx context.Context, checkOnly bool) error {
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	app := NewApp("", "", "", cancel, withoutHeader())
+	p := tea.NewProgram(app, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
+	runErrCh := make(chan error, 1)
+
+	go func() {
+		err := update.Update(ctx, output.NewTUISink(programSender{p: p}), checkOnly)
+		runErrCh <- err
+		if err != nil && !errors.Is(err, context.Canceled) {
+			p.Send(runErrMsg{err: err})
+			return
+		}
+		p.Send(runDoneMsg{})
+	}()
+
+	model, err := p.Run()
+	if err != nil {
+		return err
+	}
+
+	if app, ok := model.(App); ok && app.Err() != nil {
+		return output.NewSilentError(app.Err())
+	}
+
+	runErr := <-runErrCh
+	if runErr != nil && !errors.Is(runErr, context.Canceled) {
+		return runErr
+	}
+
+	return nil
+}

--- a/internal/update/binary.go
+++ b/internal/update/binary.go
@@ -1,0 +1,70 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+)
+
+func updateBinary(ctx context.Context, tag string) error {
+	ver := normalizeVersion(tag)
+	assetName := buildAssetName(ver, goruntime.GOOS, goruntime.GOARCH)
+
+	downloadURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", githubRepo, tag, assetName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: %s", resp.Status)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("cannot determine executable path: %w", err)
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return fmt.Errorf("cannot resolve executable path: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(exe), "lstk-update-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("download write failed: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if goruntime.GOOS == "windows" {
+		return extractAndReplace(tmpPath, exe, "zip")
+	}
+	return extractAndReplace(tmpPath, exe, "tar.gz")
+}
+
+func buildAssetName(ver, goos, goarch string) string {
+	ext := "tar.gz"
+	if goos == "windows" {
+		ext = "zip"
+	}
+	return fmt.Sprintf("lstk_%s_%s_%s.%s", ver, goos, goarch, ext)
+}

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -44,6 +44,19 @@ func extractAndReplace(archivePath, exePath, format string) error {
 		return err
 	}
 
+	// On Windows, a running executable cannot be overwritten but can be renamed.
+	// Move it out of the way first so we can place the new binary at the original path.
+	if goruntime.GOOS == "windows" {
+		oldPath := exePath + ".old"
+		// Clean up leftover from a previous update; ignore error if it doesn't exist.
+		if err := os.Remove(oldPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("cannot remove old binary %s: %w", oldPath, err)
+		}
+		if err := os.Rename(exePath, oldPath); err != nil {
+			return fmt.Errorf("cannot move running binary: %w", err)
+		}
+	}
+
 	if err := os.Rename(newBinary, exePath); err != nil {
 		// Cross-device rename: fall back to copy
 		return copyFile(newBinary, exePath, info.Mode())

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -1,0 +1,155 @@
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+)
+
+func extractAndReplace(archivePath, exePath, format string) error {
+	dir, err := os.MkdirTemp("", "lstk-extract-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	switch format {
+	case "tar.gz":
+		if err := extractTarGz(archivePath, dir); err != nil {
+			return fmt.Errorf("extract failed: %w", err)
+		}
+	case "zip":
+		if err := extractZip(archivePath, dir); err != nil {
+			return fmt.Errorf("extract failed: %w", err)
+		}
+	}
+
+	binaryName := "lstk"
+	if goruntime.GOOS == "windows" {
+		binaryName = "lstk.exe"
+	}
+
+	newBinary := filepath.Join(dir, binaryName)
+	if _, err := os.Stat(newBinary); err != nil {
+		return fmt.Errorf("binary not found in archive: %w", err)
+	}
+
+	info, err := os.Stat(exePath)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Rename(newBinary, exePath); err != nil {
+		// Cross-device rename: fall back to copy
+		return copyFile(newBinary, exePath, info.Mode())
+	}
+
+	return os.Chmod(exePath, info.Mode())
+}
+
+func extractTarGz(archivePath, destDir string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gr.Close() }()
+
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(destDir, filepath.Clean(hdr.Name))
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, hdr.FileInfo().Mode())
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				_ = out.Close()
+				return err
+			}
+			_ = out.Close()
+		}
+	}
+	return nil
+}
+
+func extractZip(archivePath, destDir string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	for _, f := range r.File {
+		target := filepath.Join(destDir, filepath.Clean(f.Name))
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			_ = rc.Close()
+			return err
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			_ = out.Close()
+			_ = rc.Close()
+			return err
+		}
+		_ = out.Close()
+		_ = rc.Close()
+	}
+	return nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/update/extract.go
+++ b/internal/update/extract.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	goruntime "runtime"
+	"strings"
 )
 
 func extractAndReplace(archivePath, exePath, format string) error {
@@ -65,6 +66,18 @@ func extractAndReplace(archivePath, exePath, format string) error {
 	return os.Chmod(exePath, info.Mode())
 }
 
+func safePath(destDir, name string) (string, error) {
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("archive contains absolute path: %s", name)
+	}
+	target := filepath.Join(destDir, filepath.Clean(name))
+	rel, err := filepath.Rel(destDir, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("archive entry escapes destination: %s", name)
+	}
+	return target, nil
+}
+
 func extractTarGz(archivePath, destDir string) error {
 	f, err := os.Open(archivePath)
 	if err != nil {
@@ -88,7 +101,10 @@ func extractTarGz(archivePath, destDir string) error {
 			return err
 		}
 
-		target := filepath.Join(destDir, filepath.Clean(hdr.Name))
+		target, err := safePath(destDir, hdr.Name)
+		if err != nil {
+			return err
+		}
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, 0o755); err != nil {
@@ -120,7 +136,10 @@ func extractZip(archivePath, destDir string) error {
 	defer func() { _ = r.Close() }()
 
 	for _, f := range r.File {
-		target := filepath.Join(destDir, filepath.Clean(f.Name))
+		target, err := safePath(destDir, f.Name)
+		if err != nil {
+			return err
+		}
 		if f.FileInfo().IsDir() {
 			if err := os.MkdirAll(target, 0o755); err != nil {
 				return err

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,18 +11,60 @@ import (
 	goruntime "runtime"
 )
 
+const (
+	githubRepo       = "localstack/lstk"
+	latestReleaseURL = "https://api.github.com/repos/" + githubRepo + "/releases/latest"
+)
+
+type githubRelease struct {
+	TagName string        `json:"tag_name"`
+	Assets  []githubAsset `json:"assets"`
+}
+
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+func githubRequest(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// TODO: this is in here temporarily while we need github for binary downloads. that's why it's not using the Env
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return http.DefaultClient.Do(req)
+}
+
+func fetchLatestVersion(ctx context.Context) (string, error) {
+	resp, err := githubRequest(ctx, latestReleaseURL)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned %s", resp.Status)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+
+	return release.TagName, nil
+}
+
 func updateBinary(ctx context.Context, tag string) error {
 	ver := normalizeVersion(tag)
 	assetName := buildAssetName(ver, goruntime.GOOS, goruntime.GOARCH)
 
 	downloadURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", githubRepo, tag, assetName)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := githubRequest(ctx, downloadURL)
 	if err != nil {
 		return err
 	}

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -26,21 +26,20 @@ type githubAsset struct {
 	BrowserDownloadURL string `json:"browser_download_url"`
 }
 
-func githubRequest(ctx context.Context, url string) (*http.Response, error) {
+func githubRequest(ctx context.Context, url, token string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	// TODO: this is in here temporarily while we need github for binary downloads. that's why it's not using the Env
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	return http.DefaultClient.Do(req)
 }
 
-func fetchLatestVersion(ctx context.Context) (string, error) {
-	resp, err := githubRequest(ctx, latestReleaseURL)
+func fetchLatestVersion(ctx context.Context, token string) (string, error) {
+	resp, err := githubRequest(ctx, latestReleaseURL, token)
 	if err != nil {
 		return "", err
 	}
@@ -58,13 +57,13 @@ func fetchLatestVersion(ctx context.Context) (string, error) {
 	return release.TagName, nil
 }
 
-func updateBinary(ctx context.Context, tag string) error {
+func updateBinary(ctx context.Context, tag, token string) error {
 	ver := normalizeVersion(tag)
 	assetName := buildAssetName(ver, goruntime.GOOS, goruntime.GOARCH)
 
 	downloadURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", githubRepo, tag, assetName)
 
-	resp, err := githubRequest(ctx, downloadURL)
+	resp, err := githubRequest(ctx, downloadURL, token)
 	if err != nil {
 		return err
 	}

--- a/internal/update/homebrew.go
+++ b/internal/update/homebrew.go
@@ -9,7 +9,7 @@ import (
 
 func updateHomebrew(ctx context.Context, sink output.Sink) error {
 	cmd := exec.CommandContext(ctx, "brew", "upgrade", "localstack/tap/lstk")
-	w := newLogLineWriter(sink, "brew")
+	w := newLogLineWriter(sink, output.LogSourceBrew)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	err := cmd.Run()

--- a/internal/update/homebrew.go
+++ b/internal/update/homebrew.go
@@ -1,0 +1,18 @@
+package update
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/localstack/lstk/internal/output"
+)
+
+func updateHomebrew(ctx context.Context, sink output.Sink) error {
+	cmd := exec.CommandContext(ctx, "brew", "upgrade", "localstack/tap/lstk")
+	w := newLogLineWriter(sink, "brew")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	err := cmd.Run()
+	w.Flush()
+	return err
+}

--- a/internal/update/install_method.go
+++ b/internal/update/install_method.go
@@ -1,0 +1,89 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type InstallMethod int
+
+const (
+	InstallBinary   InstallMethod = iota // standalone binary download
+	InstallHomebrew                      // installed via Homebrew cask
+	InstallNPM                           // installed via npm
+)
+
+func (m InstallMethod) String() string {
+	switch m {
+	case InstallHomebrew:
+		return "homebrew"
+	case InstallNPM:
+		return "npm"
+	default:
+		return "binary"
+	}
+}
+
+// InstallInfo holds the detected install method and the resolved binary path.
+type InstallInfo struct {
+	Method       InstallMethod
+	ResolvedPath string
+}
+
+// DetectInstallMethod determines how lstk was installed by inspecting the
+// resolved path of the running binary.
+func DetectInstallMethod() InstallInfo {
+	exe, err := os.Executable()
+	if err != nil {
+		return InstallInfo{Method: InstallBinary}
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		resolved = exe
+	}
+	return InstallInfo{
+		Method:       classifyPath(resolved),
+		ResolvedPath: resolved,
+	}
+}
+
+func classifyPath(resolved string) InstallMethod {
+	lower := strings.ToLower(resolved)
+
+	// Homebrew cask: symlink resolves into /Caskroom/
+	if strings.Contains(lower, "/caskroom/") {
+		return InstallHomebrew
+	}
+
+	// npm install: the Go binary lives inside a node_modules directory
+	// e.g. <prefix>/lib/node_modules/@localstack/lstk_darwin_arm64/lstk
+	if strings.Contains(lower, "node_modules") {
+		return InstallNPM
+	}
+
+	return InstallBinary
+}
+
+// npmProjectDir returns the project directory for a local npm install,
+// or empty string for a global install. A local install has a package.json
+// in the parent of the node_modules directory.
+func npmProjectDir(resolvedPath string) string {
+	// Walk up to find node_modules, then check for package.json one level above
+	dir := resolvedPath
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		if filepath.Base(dir) == "node_modules" {
+			pkgJSON := filepath.Join(parent, "package.json")
+			if _, err := os.Stat(pkgJSON); err == nil {
+				return parent
+			}
+			return ""
+		}
+		dir = parent
+	}
+	return ""
+}

--- a/internal/update/install_method.go
+++ b/internal/update/install_method.go
@@ -49,17 +49,17 @@ func DetectInstallMethod() InstallInfo {
 }
 
 func classifyPath(resolved string) InstallMethod {
-	lower := strings.ToLower(resolved)
+	cleaned := filepath.Clean(resolved)
+	segments := strings.Split(cleaned, string(os.PathSeparator))
 
-	// Homebrew cask: symlink resolves into /Caskroom/
-	if strings.Contains(lower, "/caskroom/") {
-		return InstallHomebrew
-	}
-
-	// npm install: the Go binary lives inside a node_modules directory
-	// e.g. <prefix>/lib/node_modules/@localstack/lstk_darwin_arm64/lstk
-	if strings.Contains(lower, "node_modules") {
-		return InstallNPM
+	for _, seg := range segments {
+		lower := strings.ToLower(seg)
+		if lower == "caskroom" {
+			return InstallHomebrew
+		}
+		if lower == "node_modules" {
+			return InstallNPM
+		}
 	}
 
 	return InstallBinary

--- a/internal/update/install_method_test.go
+++ b/internal/update/install_method_test.go
@@ -1,0 +1,106 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClassifyPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want InstallMethod
+	}{
+		{
+			name: "homebrew cask on apple silicon",
+			path: "/opt/homebrew/Caskroom/lstk/0.3.0/lstk",
+			want: InstallHomebrew,
+		},
+		{
+			name: "homebrew cask on intel mac",
+			path: "/usr/local/Caskroom/lstk/0.3.0/lstk",
+			want: InstallHomebrew,
+		},
+		{
+			name: "npm global install",
+			path: "/Users/someone/.local/share/mise/installs/node/24.8.0/lib/node_modules/@localstack/lstk_darwin_arm64/lstk",
+			want: InstallNPM,
+		},
+		{
+			name: "npm global install default prefix",
+			path: "/usr/local/lib/node_modules/@localstack/lstk_darwin_amd64/lstk",
+			want: InstallNPM,
+		},
+		{
+			name: "standalone binary in usr local bin",
+			path: "/usr/local/bin/lstk",
+			want: InstallBinary,
+		},
+		{
+			name: "standalone binary in home dir",
+			path: "/home/user/bin/lstk",
+			want: InstallBinary,
+		},
+		{
+			name: "dev build",
+			path: "/home/user/Projects/lstk/bin/lstk",
+			want: InstallBinary,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyPath(tt.path)
+			if got != tt.want {
+				t.Fatalf("classifyPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNpmProjectDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("local install with package.json", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		binaryPath := filepath.Join(dir, "node_modules", "@localstack", "lstk_darwin_arm64", "lstk")
+		if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		got := npmProjectDir(binaryPath)
+		if got != dir {
+			t.Fatalf("npmProjectDir() = %q, want %q", got, dir)
+		}
+	})
+
+	t.Run("global install without package.json", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		binaryPath := filepath.Join(dir, "lib", "node_modules", "@localstack", "lstk_darwin_arm64", "lstk")
+		if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		got := npmProjectDir(binaryPath)
+		if got != "" {
+			t.Fatalf("npmProjectDir() = %q, want empty string", got)
+		}
+	})
+
+	t.Run("non-npm path", func(t *testing.T) {
+		t.Parallel()
+		got := npmProjectDir("/usr/local/bin/lstk")
+		if got != "" {
+			t.Fatalf("npmProjectDir() = %q, want empty string", got)
+		}
+	})
+}

--- a/internal/update/npm.go
+++ b/internal/update/npm.go
@@ -1,0 +1,24 @@
+package update
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/localstack/lstk/internal/output"
+)
+
+func updateNPM(ctx context.Context, sink output.Sink, projectDir string) error {
+	var cmd *exec.Cmd
+	if projectDir != "" {
+		cmd = exec.CommandContext(ctx, "npm", "install", "@localstack/lstk")
+		cmd.Dir = projectDir
+	} else {
+		cmd = exec.CommandContext(ctx, "npm", "install", "-g", "@localstack/lstk")
+	}
+	w := newLogLineWriter(sink, "npm")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	err := cmd.Run()
+	w.Flush()
+	return err
+}

--- a/internal/update/npm.go
+++ b/internal/update/npm.go
@@ -15,7 +15,7 @@ func updateNPM(ctx context.Context, sink output.Sink, projectDir string) error {
 	} else {
 		cmd = exec.CommandContext(ctx, "npm", "install", "-g", "@localstack/lstk")
 	}
-	w := newLogLineWriter(sink, "npm")
+	w := newLogLineWriter(sink, output.LogSourceNPM)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	err := cmd.Run()

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
+	"sync"
 
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/version"
@@ -149,6 +150,7 @@ func updateNPM(ctx context.Context, sink output.Sink, projectDir string) error {
 // complete line as a LogLineEvent. Partial writes are buffered until a
 // newline arrives.
 type logLineWriter struct {
+	mu     sync.Mutex
 	sink   output.Sink
 	source string
 	buf    []byte
@@ -159,6 +161,8 @@ func newLogLineWriter(sink output.Sink, source string) *logLineWriter {
 }
 
 func (w *logLineWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.buf = append(w.buf, p...)
 	for {
 		i := bytes.IndexByte(w.buf, '\n')
@@ -176,6 +180,8 @@ func (w *logLineWriter) Write(p []byte) (int, error) {
 
 // Flush emits any remaining buffered content that didn't end with a newline.
 func (w *logLineWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if len(w.buf) > 0 {
 		output.EmitLogLine(w.sink, w.source, string(w.buf))
 		w.buf = nil

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -5,12 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"os"
-	"os/exec"
-	"path/filepath"
-	goruntime "runtime"
 	"strings"
 	"sync"
 
@@ -120,32 +115,6 @@ func fetchLatestVersion(ctx context.Context) (string, error) {
 	return release.TagName, nil
 }
 
-func updateHomebrew(ctx context.Context, sink output.Sink) error {
-	cmd := exec.CommandContext(ctx, "brew", "upgrade", "localstack/tap/lstk")
-	w := newLogLineWriter(sink, "brew")
-	cmd.Stdout = w
-	cmd.Stderr = w
-	err := cmd.Run()
-	w.Flush()
-	return err
-}
-
-func updateNPM(ctx context.Context, sink output.Sink, projectDir string) error {
-	var cmd *exec.Cmd
-	if projectDir != "" {
-		cmd = exec.CommandContext(ctx, "npm", "install", "@localstack/lstk")
-		cmd.Dir = projectDir
-	} else {
-		cmd = exec.CommandContext(ctx, "npm", "install", "-g", "@localstack/lstk")
-	}
-	w := newLogLineWriter(sink, "npm")
-	cmd.Stdout = w
-	cmd.Stderr = w
-	err := cmd.Run()
-	w.Flush()
-	return err
-}
-
 // logLineWriter adapts an output.Sink into an io.Writer, emitting each
 // complete line as a LogLineEvent. Partial writes are buffered until a
 // newline arrives.
@@ -186,65 +155,6 @@ func (w *logLineWriter) Flush() {
 		output.EmitLogLine(w.sink, w.source, string(w.buf))
 		w.buf = nil
 	}
-}
-
-func updateBinary(ctx context.Context, tag string) error {
-	ver := normalizeVersion(tag)
-	assetName := buildAssetName(ver, goruntime.GOOS, goruntime.GOARCH)
-
-	downloadURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", githubRepo, tag, assetName)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download failed: %s", resp.Status)
-	}
-
-	exe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("cannot determine executable path: %w", err)
-	}
-	exe, err = filepath.EvalSymlinks(exe)
-	if err != nil {
-		return fmt.Errorf("cannot resolve executable path: %w", err)
-	}
-
-	tmpFile, err := os.CreateTemp(filepath.Dir(exe), "lstk-update-*")
-	if err != nil {
-		return fmt.Errorf("cannot create temp file: %w", err)
-	}
-	tmpPath := tmpFile.Name()
-	defer func() { _ = os.Remove(tmpPath) }()
-
-	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
-		_ = tmpFile.Close()
-		return fmt.Errorf("download write failed: %w", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("failed to close temp file: %w", err)
-	}
-
-	if goruntime.GOOS == "windows" {
-		return extractAndReplace(tmpPath, exe, "zip")
-	}
-	return extractAndReplace(tmpPath, exe, "tar.gz")
-}
-
-func buildAssetName(ver, goos, goarch string) string {
-	ext := "tar.gz"
-	if goos == "windows" {
-		ext = "zip"
-	}
-	return fmt.Sprintf("lstk_%s_%s_%s.%s", ver, goos, goarch, ext)
 }
 
 // normalizeVersion strips a leading "v" prefix for comparison.

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -123,7 +124,9 @@ func updateHomebrew(ctx context.Context, sink output.Sink) error {
 	w := newLogLineWriter(sink, "brew")
 	cmd.Stdout = w
 	cmd.Stderr = w
-	return cmd.Run()
+	err := cmd.Run()
+	w.Flush()
+	return err
 }
 
 func updateNPM(ctx context.Context, sink output.Sink, projectDir string) error {
@@ -137,13 +140,18 @@ func updateNPM(ctx context.Context, sink output.Sink, projectDir string) error {
 	w := newLogLineWriter(sink, "npm")
 	cmd.Stdout = w
 	cmd.Stderr = w
-	return cmd.Run()
+	err := cmd.Run()
+	w.Flush()
+	return err
 }
 
-// logLineWriter adapts an output.Sink into an io.Writer, emitting each line as a LogLineEvent.
+// logLineWriter adapts an output.Sink into an io.Writer, emitting each
+// complete line as a LogLineEvent. Partial writes are buffered until a
+// newline arrives.
 type logLineWriter struct {
 	sink   output.Sink
 	source string
+	buf    []byte
 }
 
 func newLogLineWriter(sink output.Sink, source string) *logLineWriter {
@@ -151,11 +159,27 @@ func newLogLineWriter(sink output.Sink, source string) *logLineWriter {
 }
 
 func (w *logLineWriter) Write(p []byte) (int, error) {
-	line := strings.TrimRight(string(p), "\n")
-	if line != "" {
-		output.EmitLogLine(w.sink, w.source, line)
+	w.buf = append(w.buf, p...)
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := string(w.buf[:i])
+		w.buf = w.buf[i+1:]
+		if line != "" {
+			output.EmitLogLine(w.sink, w.source, line)
+		}
 	}
 	return len(p), nil
+}
+
+// Flush emits any remaining buffered content that didn't end with a newline.
+func (w *logLineWriter) Flush() {
+	if len(w.buf) > 0 {
+		output.EmitLogLine(w.sink, w.source, string(w.buf))
+		w.buf = nil
+	}
 }
 
 func updateBinary(ctx context.Context, tag string) error {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -3,30 +3,13 @@ package update
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 	"sync"
 
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/version"
 )
-
-const (
-	githubRepo       = "localstack/lstk"
-	latestReleaseURL = "https://api.github.com/repos/" + githubRepo + "/releases/latest"
-)
-
-type githubRelease struct {
-	TagName string        `json:"tag_name"`
-	Assets  []githubAsset `json:"assets"`
-}
-
-type githubAsset struct {
-	Name               string `json:"name"`
-	BrowserDownloadURL string `json:"browser_download_url"`
-}
 
 // Check reports whether a newer version is available.
 // Returns the latest version string and true if an update is available.
@@ -88,31 +71,6 @@ func Update(ctx context.Context, sink output.Sink, checkOnly bool) error {
 
 	output.EmitSuccess(sink, fmt.Sprintf("Updated to %s", latest))
 	return nil
-}
-
-func fetchLatestVersion(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub API returned %s", resp.Status)
-	}
-
-	var release githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", err
-	}
-
-	return release.TagName, nil
 }
 
 // logLineWriter adapts an output.Sink into an io.Writer, emitting each

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -239,66 +239,6 @@ func updateBinary(ctx context.Context, tag string) error {
 	return extractAndReplace(tmpPath, exe, "tar.gz")
 }
 
-func extractAndReplace(archivePath, exePath, format string) error {
-	dir, err := os.MkdirTemp("", "lstk-extract-*")
-	if err != nil {
-		return err
-	}
-	defer func() { _ = os.RemoveAll(dir) }()
-
-	switch format {
-	case "tar.gz":
-		cmd := exec.Command("tar", "xzf", archivePath, "-C", dir)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("extract failed: %s: %w", string(out), err)
-		}
-	case "zip":
-		cmd := exec.Command("unzip", "-o", archivePath, "-d", dir)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("extract failed: %s: %w", string(out), err)
-		}
-	}
-
-	binaryName := "lstk"
-	if goruntime.GOOS == "windows" {
-		binaryName = "lstk.exe"
-	}
-
-	newBinary := filepath.Join(dir, binaryName)
-	if _, err := os.Stat(newBinary); err != nil {
-		return fmt.Errorf("binary not found in archive: %w", err)
-	}
-
-	info, err := os.Stat(exePath)
-	if err != nil {
-		return err
-	}
-
-	if err := os.Rename(newBinary, exePath); err != nil {
-		// Cross-device rename: fall back to copy
-		return copyFile(newBinary, exePath, info.Mode())
-	}
-
-	return os.Chmod(exePath, info.Mode())
-}
-
-func copyFile(src, dst string, mode os.FileMode) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = in.Close() }()
-
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = out.Close() }()
-
-	_, err = io.Copy(out, in)
-	return err
-}
-
 func buildAssetName(ver, goos, goarch string) string {
 	ext := "tar.gz"
 	if goos == "windows" {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -13,7 +13,7 @@ import (
 
 // Check reports whether a newer version is available.
 // Returns the latest version string and true if an update is available.
-func Check(ctx context.Context, sink output.Sink) (string, bool, error) {
+func Check(ctx context.Context, sink output.Sink, githubToken string) (string, bool, error) {
 	current := version.Version()
 	if current == "dev" {
 		output.EmitNote(sink, "Running a development build, skipping update check")
@@ -21,7 +21,7 @@ func Check(ctx context.Context, sink output.Sink) (string, bool, error) {
 	}
 
 	output.EmitSpinnerStart(sink, "Checking for updates")
-	latest, err := fetchLatestVersion(ctx)
+	latest, err := fetchLatestVersion(ctx, githubToken)
 	output.EmitSpinnerStop(sink)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to check for updates: %w", err)
@@ -37,8 +37,8 @@ func Check(ctx context.Context, sink output.Sink) (string, bool, error) {
 }
 
 // Update checks for updates and applies the update if one is available.
-func Update(ctx context.Context, sink output.Sink, checkOnly bool) error {
-	latest, available, err := Check(ctx, sink)
+func Update(ctx context.Context, sink output.Sink, checkOnly bool, githubToken string) error {
+	latest, available, err := Check(ctx, sink, githubToken)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func Update(ctx context.Context, sink output.Sink, checkOnly bool) error {
 		err = updateNPM(ctx, sink, projectDir)
 	default:
 		output.EmitSpinnerStart(sink, "Downloading update")
-		err = updateBinary(ctx, latest)
+		err = updateBinary(ctx, latest, githubToken)
 		output.EmitSpinnerStop(sink)
 	}
 	if err != nil {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,283 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/version"
+)
+
+const (
+	githubRepo       = "localstack/lstk"
+	latestReleaseURL = "https://api.github.com/repos/" + githubRepo + "/releases/latest"
+)
+
+type githubRelease struct {
+	TagName string        `json:"tag_name"`
+	Assets  []githubAsset `json:"assets"`
+}
+
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// Check reports whether a newer version is available.
+// Returns the latest version string and true if an update is available.
+func Check(ctx context.Context, sink output.Sink) (string, bool, error) {
+	current := version.Version()
+	if current == "dev" {
+		output.EmitNote(sink, "Running a development build, skipping update check")
+		return "", false, nil
+	}
+
+	output.EmitSpinnerStart(sink, "Checking for updates")
+	latest, err := fetchLatestVersion(ctx)
+	output.EmitSpinnerStop(sink)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	if normalizeVersion(current) == normalizeVersion(latest) {
+		output.EmitNote(sink, fmt.Sprintf("Already up to date (%s)", current))
+		return latest, false, nil
+	}
+
+	output.EmitInfo(sink, fmt.Sprintf("Update available: %s → %s", current, latest))
+	return latest, true, nil
+}
+
+// Update checks for updates and applies the update if one is available.
+func Update(ctx context.Context, sink output.Sink, checkOnly bool) error {
+	latest, available, err := Check(ctx, sink)
+	if err != nil {
+		return err
+	}
+	if !available || checkOnly {
+		return nil
+	}
+
+	info := DetectInstallMethod()
+
+	switch info.Method {
+	case InstallHomebrew:
+		output.EmitNote(sink, "Installed through Homebrew, running brew upgrade")
+		err = updateHomebrew(ctx, sink)
+	case InstallNPM:
+		projectDir := npmProjectDir(info.ResolvedPath)
+		if projectDir != "" {
+			output.EmitNote(sink, fmt.Sprintf("Installed through npm (local), running npm install in %s", projectDir))
+		} else {
+			output.EmitNote(sink, "Installed through npm (global), running npm install -g")
+		}
+		err = updateNPM(ctx, sink, projectDir)
+	default:
+		output.EmitSpinnerStart(sink, "Downloading update")
+		err = updateBinary(ctx, latest)
+		output.EmitSpinnerStop(sink)
+	}
+	if err != nil {
+		return fmt.Errorf("update failed: %w", err)
+	}
+
+	output.EmitSuccess(sink, fmt.Sprintf("Updated to %s", latest))
+	return nil
+}
+
+func fetchLatestVersion(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned %s", resp.Status)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+
+	return release.TagName, nil
+}
+
+func updateHomebrew(ctx context.Context, sink output.Sink) error {
+	cmd := exec.CommandContext(ctx, "brew", "upgrade", "localstack/tap/lstk")
+	w := newLogLineWriter(sink, "brew")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	return cmd.Run()
+}
+
+func updateNPM(ctx context.Context, sink output.Sink, projectDir string) error {
+	var cmd *exec.Cmd
+	if projectDir != "" {
+		cmd = exec.CommandContext(ctx, "npm", "install", "@localstack/lstk")
+		cmd.Dir = projectDir
+	} else {
+		cmd = exec.CommandContext(ctx, "npm", "install", "-g", "@localstack/lstk")
+	}
+	w := newLogLineWriter(sink, "npm")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	return cmd.Run()
+}
+
+// logLineWriter adapts an output.Sink into an io.Writer, emitting each line as a LogLineEvent.
+type logLineWriter struct {
+	sink   output.Sink
+	source string
+}
+
+func newLogLineWriter(sink output.Sink, source string) *logLineWriter {
+	return &logLineWriter{sink: sink, source: source}
+}
+
+func (w *logLineWriter) Write(p []byte) (int, error) {
+	line := strings.TrimRight(string(p), "\n")
+	if line != "" {
+		output.EmitLogLine(w.sink, w.source, line)
+	}
+	return len(p), nil
+}
+
+func updateBinary(ctx context.Context, tag string) error {
+	ver := normalizeVersion(tag)
+	assetName := buildAssetName(ver, goruntime.GOOS, goruntime.GOARCH)
+
+	downloadURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", githubRepo, tag, assetName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: %s", resp.Status)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("cannot determine executable path: %w", err)
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return fmt.Errorf("cannot resolve executable path: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(exe), "lstk-update-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("download write failed: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if goruntime.GOOS == "windows" {
+		return extractAndReplace(tmpPath, exe, "zip")
+	}
+	return extractAndReplace(tmpPath, exe, "tar.gz")
+}
+
+func extractAndReplace(archivePath, exePath, format string) error {
+	dir, err := os.MkdirTemp("", "lstk-extract-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	switch format {
+	case "tar.gz":
+		cmd := exec.Command("tar", "xzf", archivePath, "-C", dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("extract failed: %s: %w", string(out), err)
+		}
+	case "zip":
+		cmd := exec.Command("unzip", "-o", archivePath, "-d", dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("extract failed: %s: %w", string(out), err)
+		}
+	}
+
+	binaryName := "lstk"
+	if goruntime.GOOS == "windows" {
+		binaryName = "lstk.exe"
+	}
+
+	newBinary := filepath.Join(dir, binaryName)
+	if _, err := os.Stat(newBinary); err != nil {
+		return fmt.Errorf("binary not found in archive: %w", err)
+	}
+
+	info, err := os.Stat(exePath)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Rename(newBinary, exePath); err != nil {
+		// Cross-device rename: fall back to copy
+		return copyFile(newBinary, exePath, info.Mode())
+	}
+
+	return os.Chmod(exePath, info.Mode())
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func buildAssetName(ver, goos, goarch string) string {
+	ext := "tar.gz"
+	if goos == "windows" {
+		ext = "zip"
+	}
+	return fmt.Sprintf("lstk_%s_%s_%s.%s", ver, goos, goarch, ext)
+}
+
+// normalizeVersion strips a leading "v" prefix for comparison.
+func normalizeVersion(v string) string {
+	return strings.TrimPrefix(v, "v")
+}

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -162,6 +162,9 @@ func homebrewLstkBinaryPath(t *testing.T) string {
 }
 
 func TestUpdateHomebrew(t *testing.T) {
+	if os.Getenv("LSTK_TEST_HOMEBREW") != "1" {
+		t.Skip("Skipping: overwrites real Homebrew binary. Set LSTK_TEST_HOMEBREW=1 to opt in.")
+	}
 	requireHomebrew(t)
 	caskBinary := homebrewLstkBinaryPath(t)
 

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -1,0 +1,200 @@
+package integration_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateCheckCommand(t *testing.T) {
+	ctx := testContext(t)
+
+	stdout, stderr, err := runLstk(t, ctx, "", nil, "update", "--check")
+	require.NoError(t, err, "lstk update --check failed: %s", stderr)
+
+	// Dev builds report a note about skipping update check
+	assert.Contains(t, stdout, "Note:", "should show a note (dev build or up-to-date)")
+}
+
+func TestUpdateCheckCommandNonInteractive(t *testing.T) {
+	ctx := testContext(t)
+
+	stdout, stderr, err := runLstk(t, ctx, "", nil, "update", "--check", "--non-interactive")
+	require.NoError(t, err, "lstk update --check --non-interactive failed: %s", stderr)
+	assert.Contains(t, stdout, "Note:", "should show a note in non-interactive mode")
+}
+
+func requireNPM(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("npm"); err != nil {
+		t.Skip("npm is not available")
+	}
+}
+
+func TestUpdateNPMLocalInstall(t *testing.T) {
+	requireNPM(t)
+
+	ctx := testContext(t)
+
+	// Set up a fake local npm project
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "package.json"),
+		[]byte(`{"name":"test-project","version":"1.0.0","dependencies":{"@localstack/lstk":"*"}}`),
+		0o644,
+	))
+
+	// Install @localstack/lstk locally so the node_modules structure exists
+	npmInstall := exec.CommandContext(ctx, "npm", "install", "@localstack/lstk")
+	npmInstall.Dir = projectDir
+	out, err := npmInstall.CombinedOutput()
+	require.NoError(t, err, "npm install failed: %s", string(out))
+
+	// Build a fake old version binary and replace the one in node_modules
+	platformPkg := npmPlatformPackage()
+	binaryName := "lstk"
+	if runtime.GOOS == "windows" {
+		binaryName = "lstk.exe"
+	}
+	nmBinaryPath := filepath.Join(projectDir, "node_modules", "@localstack", platformPkg, binaryName)
+
+	// Verify the binary exists from npm install
+	_, err = os.Stat(nmBinaryPath)
+	require.NoError(t, err, "expected binary at %s after npm install", nmBinaryPath)
+
+	// Build our dev binary with a fake old version into that location
+	repoRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+	buildCmd := exec.CommandContext(ctx, "go", "build",
+		"-ldflags", "-X github.com/localstack/lstk/internal/version.version=0.0.1",
+		"-o", nmBinaryPath,
+		".",
+	)
+	buildCmd.Dir = repoRoot
+	out, err = buildCmd.CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", string(out))
+
+	// Run the binary directly (not through npx) so os.Executable() resolves to the node_modules path
+	cmd := exec.CommandContext(ctx, nmBinaryPath, "update", "--non-interactive")
+	cmd.Dir = projectDir
+	stdout, err := cmd.CombinedOutput()
+	stdoutStr := string(stdout)
+
+	require.NoError(t, err, "lstk update failed: %s", stdoutStr)
+	assert.Contains(t, stdoutStr, "npm (local)", "should detect local npm install")
+	assert.Contains(t, stdoutStr, projectDir, "should show the project directory")
+	assert.Contains(t, stdoutStr, "Updated to", "should complete the update")
+}
+
+func TestUpdateBinaryInPlace(t *testing.T) {
+	ctx := testContext(t)
+
+	// Build a fake old version to a temp location
+	tmpBinary := filepath.Join(t.TempDir(), "lstk")
+	repoRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+
+	buildCmd := exec.CommandContext(ctx, "go", "build",
+		"-ldflags", "-X github.com/localstack/lstk/internal/version.version=0.0.1",
+		"-o", tmpBinary,
+		".",
+	)
+	buildCmd.Dir = repoRoot
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", string(out))
+
+	// Verify it reports the fake version
+	verCmd := exec.CommandContext(ctx, tmpBinary, "version")
+	verOut, err := verCmd.CombinedOutput()
+	require.NoError(t, err)
+	assert.Contains(t, string(verOut), "0.0.1")
+
+	// Run update — should download from GitHub and replace itself
+	updateCmd := exec.CommandContext(ctx, tmpBinary, "update", "--non-interactive")
+	updateOut, err := updateCmd.CombinedOutput()
+	updateStr := string(updateOut)
+	require.NoError(t, err, "lstk update failed: %s", updateStr)
+	assert.Contains(t, updateStr, "Update available: 0.0.1", "should detect update")
+	assert.Contains(t, updateStr, "Downloading update", "should download binary")
+	assert.Contains(t, updateStr, "Updated to", "should complete the update")
+
+	// Verify the binary was actually replaced
+	verCmd2 := exec.CommandContext(ctx, tmpBinary, "version")
+	verOut2, err := verCmd2.CombinedOutput()
+	require.NoError(t, err)
+	assert.NotContains(t, string(verOut2), "0.0.1", "binary should no longer be the old version")
+}
+
+func requireHomebrew(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("brew"); err != nil {
+		t.Skip("Homebrew is not available")
+	}
+}
+
+func homebrewLstkBinaryPath(t *testing.T) string {
+	t.Helper()
+
+	// Find the Caskroom binary by resolving the brew symlink
+	brewBin, err := exec.Command("brew", "--prefix").Output()
+	require.NoError(t, err)
+	prefix := strings.TrimSpace(string(brewBin))
+
+	// Look for lstk in the Caskroom
+	matches, err := filepath.Glob(filepath.Join(prefix, "Caskroom", "lstk", "*", "lstk"))
+	if err != nil || len(matches) == 0 {
+		t.Skip("lstk is not installed via Homebrew")
+	}
+	return matches[0]
+}
+
+func TestUpdateHomebrew(t *testing.T) {
+	requireHomebrew(t)
+	caskBinary := homebrewLstkBinaryPath(t)
+
+	ctx := testContext(t)
+	repoRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+
+	// Build a fake old version into the Caskroom location
+	buildCmd := exec.CommandContext(ctx, "go", "build",
+		"-ldflags", "-X github.com/localstack/lstk/internal/version.version=0.0.1",
+		"-o", caskBinary,
+		".",
+	)
+	buildCmd.Dir = repoRoot
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", string(out))
+
+	// Verify it reports the fake version
+	verCmd := exec.CommandContext(ctx, caskBinary, "version")
+	verOut, err := verCmd.CombinedOutput()
+	require.NoError(t, err)
+	assert.Contains(t, string(verOut), "0.0.1")
+
+	// Run update — should detect Homebrew and run brew upgrade
+	// Note: brew may consider lstk already up-to-date (its metadata tracks the
+	// cask version, not the actual binary content), so "Updated to" may or may
+	// not appear. We verify detection and that brew was invoked without error.
+	updateCmd := exec.CommandContext(ctx, caskBinary, "update", "--non-interactive")
+	updateOut, err := updateCmd.CombinedOutput()
+	updateStr := string(updateOut)
+	require.NoError(t, err, "lstk update failed: %s", updateStr)
+	assert.Contains(t, updateStr, "Homebrew", "should detect Homebrew install")
+	assert.Contains(t, updateStr, "brew upgrade", "should mention brew upgrade")
+}
+
+func npmPlatformPackage() string {
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+	if arch == "amd64" {
+		arch = "amd64"
+	}
+	return "lstk_" + os + "_" + arch
+}

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -42,8 +42,11 @@ func TestUpdateNPMLocalInstall(t *testing.T) {
 
 	ctx := testContext(t)
 
-	// Set up a fake local npm project
-	projectDir := t.TempDir()
+	// Set up a fake local npm project.
+	// On Windows, t.TempDir() may return a short 8.3 path (e.g. RUNNER~1)
+	// while the program resolves the long path. EvalSymlinks normalizes both.
+	projectDir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(
 		filepath.Join(projectDir, "package.json"),
 		[]byte(`{"name":"test-project","version":"1.0.0","dependencies":{"@localstack/lstk":"*"}}`),
@@ -96,7 +99,11 @@ func TestUpdateBinaryInPlace(t *testing.T) {
 	ctx := testContext(t)
 
 	// Build a fake old version to a temp location
-	tmpBinary := filepath.Join(t.TempDir(), "lstk")
+	binaryName := "lstk"
+	if runtime.GOOS == "windows" {
+		binaryName = "lstk.exe"
+	}
+	tmpBinary := filepath.Join(t.TempDir(), binaryName)
 	repoRoot, err := filepath.Abs("../..")
 	require.NoError(t, err)
 

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -198,10 +198,5 @@ func TestUpdateHomebrew(t *testing.T) {
 }
 
 func npmPlatformPackage() string {
-	os := runtime.GOOS
-	arch := runtime.GOARCH
-	if arch == "amd64" {
-		arch = "amd64"
-	}
-	return "lstk_" + os + "_" + arch
+	return "lstk_" + runtime.GOOS + "_" + runtime.GOARCH
 }


### PR DESCRIPTION
Adds `lstk update` to self-update the CLI, respecting the original installation method:

- **Homebrew**: detects Caskroom path, runs `brew upgrade localstack/tap/lstk`
- **npm**: detects `node_modules` path, runs `npm install -g` (global) or `npm install` from project dir (local)
- **Binary**: downloads matching archive from GitHub releases and replaces in place
- `--check` flag to only check for updates without applying -> will enable update notifications later :) 

Also generalizes `ContainerLogLineEvent` → `LogLineEvent` with a `Source` field, so brew/npm subprocess output streams through the TUI with a `brew | ...` / `npm | ...` prefix.

### Tests

- Unit tests for install method detection (`classifyPath`) and npm project dir resolution
- Integration tests for all three update paths (binary in-place, Homebrew, npm local install)

[FLC-413](https://linear.app/localstack/issue/FLC-413/add-update-command)