### PR TITLE
Warn unsupported multiple containers of the same type

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -40,7 +40,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, platformCl
 	}
 
 	if hasDuplicateContainerTypes(cfg.Containers) {
-		output.EmitWarning(sink, "multiple emulators of the same type are defined in your config; this setup is not supported yet")
+		output.EmitWarning(sink, "Multiple emulators of the same type are defined in your config; this setup is not supported yet")
 	}
 
 	containers := make([]runtime.ContainerConfig, len(cfg.Containers))

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -39,6 +39,10 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, platformCl
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
+	if hasDuplicateContainerTypes(cfg.Containers) {
+		output.EmitWarning(sink, "multiple emulators of the same type are defined in your config; this setup is not supported yet")
+	}
+
 	containers := make([]runtime.ContainerConfig, len(cfg.Containers))
 	for i, c := range cfg.Containers {
 		image, err := c.Image()
@@ -246,4 +250,15 @@ func awaitStartup(ctx context.Context, rt runtime.Runtime, sink output.Sink, con
 		case <-time.After(1 * time.Second):
 		}
 	}
+}
+
+func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {
+	seen := make(map[config.EmulatorType]bool)
+	for _, c := range containers {
+		if seen[c.Type] {
+			return true
+		}
+		seen[c.Type] = true
+	}
+	return false
 }


### PR DESCRIPTION
Show a warning to users that have multiple containers of the same type defined in their config to avoid confusion when they start lstk:
<img width="941" height="247" alt="image" src="https://github.com/user-attachments/assets/2e211d7a-6338-4aff-8b57-f2e416125e3c" />
