### PR TITLE
Fix keyring tests

### DIFF
--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -97,8 +97,9 @@ func TestMain(m *testing.M) {
 	}
 
 	keyringConfig := keyring.Config{
-		ServiceName: keyringService,
-		FileDir:     filepath.Join(configDir(), keyringFilename),
+		ServiceName:             keyringService,
+		FileDir:                 filepath.Join(configDir(), keyringFilename),
+		LibSecretCollectionName: "login",
 		FilePasswordFunc: func(prompt string) (string, error) {
 			return keyringPassword, nil
 		},


### PR DESCRIPTION
Integrations tests relying on keyring on linux+gnome keyring started failing after this PR was merged https://github.com/localstack/lstk/pull/87
We need to set the default wallet in tests as well.