### PR TITLE
Mount Docker socket and add service port range

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ lstk --non-interactive
 |---|---|
 | `LOCALSTACK_AUTH_TOKEN` | Auth token used for non-interactive runs or to skip browser login |
 | `LOCALSTACK_DISABLE_EVENTS=1` | Disables telemetry event reporting |
+| `DOCKER_HOST` | Override the Docker daemon socket (e.g. `unix:///home/user/.colima/default/docker.sock`). When unset, lstk tries the default socket and then probes common alternatives (Colima, OrbStack). |
 
 ## Usage
 

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -29,7 +29,7 @@ func newLogoutCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
 				return fmt.Errorf("failed to get config: %w", err)
 			}
 			var rt runtime.Runtime
-			if dockerRuntime, err := runtime.NewDockerRuntime(); err == nil {
+			if dockerRuntime, err := runtime.NewDockerRuntime(cfg.DockerHost); err == nil {
 				rt = dockerRuntime
 			}
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
 
-func newLogsCmd() *cobra.Command {
+func newLogsCmd(cfg *env.Env) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "logs",
 		Short:   "Show emulator logs",
@@ -22,7 +23,7 @@ func newLogsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			rt, err := runtime.NewDockerRuntime()
+			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 		Long:    "lstk is the command-line interface for LocalStack.",
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rt, err := runtime.NewDockerRuntime()
+			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
 			}
@@ -53,7 +53,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 		newLoginCmd(cfg, logger),
 		newLogoutCmd(cfg, logger),
 		newStatusCmd(cfg),
-		newLogsCmd(),
+		newLogsCmd(cfg),
 		newConfigCmd(),
 		newVersionCmd(),
 		newUpdateCmd(cfg),

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -15,7 +15,7 @@ func newStartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 		Long:    "Start emulator and services.",
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rt, err := runtime.NewDockerRuntime()
+			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
 			}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -22,7 +22,7 @@ func newStatusCmd(cfg *env.Env) *cobra.Command {
 		Long:    "Show the status of a running emulator and its deployed resources",
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rt, err := runtime.NewDockerRuntime()
+			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
 			}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -20,7 +20,7 @@ func newStopCmd(cfg *env.Env) *cobra.Command {
 		Long:    "Stop emulator and services",
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rt, err := runtime.NewDockerRuntime()
+			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
 			}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -87,7 +87,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		containerName := c.Name()
 		env := append(resolvedEnv,
 			"LOCALSTACK_AUTH_TOKEN="+token,
-			"GATEWAY_LISTEN=:"+c.Port,
+			"GATEWAY_LISTEN=:4566",
 			"MAIN_CONTAINER_NAME="+containerName,
 		)
 

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	stdruntime "runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -82,16 +83,31 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		if err != nil {
 			return err
 		}
-		env := append(resolvedEnv, "LOCALSTACK_AUTH_TOKEN="+token)
+
+		containerName := c.Name()
+		env := append(resolvedEnv,
+			"LOCALSTACK_AUTH_TOKEN="+token,
+			"GATEWAY_LISTEN=:"+c.Port,
+			"MAIN_CONTAINER_NAME="+containerName,
+		)
+
+		var binds []runtime.BindMount
+		if socketPath := rt.SocketPath(); socketPath != "" {
+			binds = append(binds, runtime.BindMount{HostPath: socketPath, ContainerPath: "/var/run/docker.sock"})
+			env = append(env, "DOCKER_HOST=unix:///var/run/docker.sock")
+		}
+
 		containers[i] = runtime.ContainerConfig{
 			Image:         image,
-			Name:          c.Name(),
+			Name:          containerName,
 			Port:          c.Port,
 			ContainerPort: containerPort,
 			HealthPath:    healthPath,
 			Env:           env,
 			Tag:           c.Tag,
 			ProductName:   productName,
+			Binds:         binds,
+			ExtraPorts:    servicePortRange(),
 		}
 	}
 
@@ -340,4 +356,15 @@ func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {
 		seen[c.Type] = true
 	}
 	return false
+}
+
+func servicePortRange() []runtime.PortMapping {
+	const start = 4510
+	const end = 4559
+	var ports []runtime.PortMapping
+	for p := start; p <= end; p++ {
+		ps := strconv.Itoa(p)
+		ports = append(ports, runtime.PortMapping{ContainerPort: ps, HostPort: ps})
+	}
+	return ports
 }

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strconv"
 	"testing"
 
 	"github.com/localstack/lstk/internal/log"
@@ -55,4 +56,20 @@ func TestEmitPostStartPointers_WithoutWebApp(t *testing.T) {
 		"> Tip: View emulator logs: lstk logs --follow\n",
 		out.String(),
 	)
+}
+
+func TestServicePortRange_Returns50Entries(t *testing.T) {
+	ports := servicePortRange()
+
+	require.Len(t, ports, 50)
+	assert.Equal(t, "4510", ports[0].ContainerPort)
+	assert.Equal(t, "4510", ports[0].HostPort)
+	assert.Equal(t, "4559", ports[49].ContainerPort)
+	assert.Equal(t, "4559", ports[49].HostPort)
+
+	for i, p := range ports {
+		expected := strconv.Itoa(4510 + i)
+		assert.Equal(t, expected, p.ContainerPort)
+		assert.Equal(t, expected, p.HostPort)
+	}
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -10,6 +10,7 @@ import (
 type Env struct {
 	AuthToken      string
 	LocalStackHost string
+	DockerHost     string
 	DisableEvents  bool
 
 	APIEndpoint       string
@@ -35,6 +36,7 @@ func Init() *Env {
 	return &Env{
 		AuthToken:         os.Getenv("LOCALSTACK_AUTH_TOKEN"),
 		LocalStackHost:    os.Getenv("LOCALSTACK_HOST"),
+		DockerHost:        os.Getenv("DOCKER_HOST"),
 		DisableEvents:     os.Getenv("LOCALSTACK_DISABLE_EVENTS") == "1",
 		APIEndpoint:       viper.GetString("api_endpoint"),
 		WebAppURL:         viper.GetString("web_app_url"),

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
+	"path/filepath"
 	stdruntime "runtime"
 	"strconv"
 	"strings"
@@ -25,12 +27,47 @@ type DockerRuntime struct {
 	client *client.Client
 }
 
-func NewDockerRuntime() (*DockerRuntime, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+func NewDockerRuntime(dockerHost string) (*DockerRuntime, error) {
+	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
+
+	// When DOCKER_HOST is not set, the Docker SDK defaults to /var/run/docker.sock.
+	// If that socket doesn't exist, probe known alternative locations (e.g. Colima).
+	if dockerHost == "" {
+		if sock := findDockerSocket(); sock != "" {
+			opts = append(opts, client.WithHost("unix://"+sock))
+		}
+	}
+
+	cli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, err
 	}
 	return &DockerRuntime{client: cli}, nil
+}
+
+func findDockerSocket() string {
+	home, _ := os.UserHomeDir()
+	return probeSocket(
+		filepath.Join(home, ".colima", "default", "docker.sock"),
+		filepath.Join(home, ".colima", "docker.sock"),
+	)
+}
+
+func probeSocket(candidates ...string) string {
+	for _, sock := range candidates {
+		if _, err := os.Stat(sock); err == nil {
+			return sock
+		}
+	}
+	return ""
+}
+
+func (d *DockerRuntime) SocketPath() string {
+	host := d.client.DaemonHost()
+	if strings.HasPrefix(host, "unix://") {
+		return strings.TrimPrefix(host, "unix://")
+	}
+	return ""
 }
 
 func (d *DockerRuntime) IsHealthy(ctx context.Context) error {
@@ -113,6 +150,25 @@ func (d *DockerRuntime) Start(ctx context.Context, config ContainerConfig) (stri
 	exposedPorts := nat.PortSet{containerPort: struct{}{}}
 	portBindings := nat.PortMap{containerPort: []nat.PortBinding{{HostPort: config.Port}}}
 
+	for _, ep := range config.ExtraPorts {
+		proto := ep.Protocol
+		if proto == "" {
+			proto = "tcp"
+		}
+		p := nat.Port(ep.ContainerPort + "/" + proto)
+		exposedPorts[p] = struct{}{}
+		portBindings[p] = []nat.PortBinding{{HostPort: ep.HostPort}}
+	}
+
+	var binds []string
+	for _, b := range config.Binds {
+		bind := b.HostPath + ":" + b.ContainerPath
+		if b.ReadOnly {
+			bind += ":ro"
+		}
+		binds = append(binds, bind)
+	}
+
 	resp, err := d.client.ContainerCreate(ctx,
 		&container.Config{
 			Image:        config.Image,
@@ -121,6 +177,7 @@ func (d *DockerRuntime) Start(ctx context.Context, config ContainerConfig) (stri
 		},
 		&container.HostConfig{
 			PortBindings: portBindings,
+			Binds:        binds,
 		},
 		nil, nil, config.Name,
 	)

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -50,6 +50,7 @@ func findDockerSocket() string {
 	return probeSocket(
 		filepath.Join(home, ".colima", "default", "docker.sock"),
 		filepath.Join(home, ".colima", "docker.sock"),
+		filepath.Join(home, ".orbstack", "run", "docker.sock"),
 	)
 }
 

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProbeSocket_ReturnsFirstExisting(t *testing.T) {
+	dir := t.TempDir()
+	sock1 := filepath.Join(dir, "first.sock")
+	sock2 := filepath.Join(dir, "second.sock")
+
+	require.NoError(t, os.WriteFile(sock1, nil, 0o600))
+	require.NoError(t, os.WriteFile(sock2, nil, 0o600))
+
+	assert.Equal(t, sock1, probeSocket(sock1, sock2))
+}
+
+func TestProbeSocket_SkipsMissingAndReturnsExisting(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "missing.sock")
+	existing := filepath.Join(dir, "existing.sock")
+
+	require.NoError(t, os.WriteFile(existing, nil, 0o600))
+
+	assert.Equal(t, existing, probeSocket(missing, existing))
+}
+
+func TestProbeSocket_ReturnsEmptyWhenNoneExist(t *testing.T) {
+	assert.Equal(t, "", probeSocket("/no/such/path.sock", "/also/missing.sock"))
+}
+
+func TestProbeSocket_ReturnsEmptyForNoCandidates(t *testing.T) {
+	assert.Equal(t, "", probeSocket())
+}
+
+func TestSocketPath_ExtractsUnixPath(t *testing.T) {
+	cli, err := client.NewClientWithOpts(client.WithHost("unix:///home/user/.colima/default/docker.sock"))
+	require.NoError(t, err)
+	rt := &DockerRuntime{client: cli}
+
+	assert.Equal(t, "/home/user/.colima/default/docker.sock", rt.SocketPath())
+}
+
+func TestSocketPath_ReturnsEmptyForTCPHost(t *testing.T) {
+	cli, err := client.NewClientWithOpts(client.WithHost("tcp://192.168.1.100:2375"))
+	require.NoError(t, err)
+	rt := &DockerRuntime{client: cli}
+
+	assert.Equal(t, "", rt.SocketPath())
+}

--- a/internal/runtime/mock_runtime.go
+++ b/internal/runtime/mock_runtime.go
@@ -157,6 +157,20 @@ func (mr *MockRuntimeMockRecorder) Remove(ctx, containerName any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockRuntime)(nil).Remove), ctx, containerName)
 }
 
+// SocketPath mocks base method.
+func (m *MockRuntime) SocketPath() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SocketPath")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// SocketPath indicates an expected call of SocketPath.
+func (mr *MockRuntimeMockRecorder) SocketPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SocketPath", reflect.TypeOf((*MockRuntime)(nil).SocketPath))
+}
+
 // Start mocks base method.
 func (m *MockRuntime) Start(ctx context.Context, config ContainerConfig) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -8,6 +8,20 @@ import (
 	"github.com/localstack/lstk/internal/output"
 )
 
+// BindMount represents a host-to-container bind mount.
+type BindMount struct {
+	HostPath      string
+	ContainerPath string
+	ReadOnly      bool
+}
+
+// PortMapping represents a container-to-host port mapping.
+type PortMapping struct {
+	ContainerPort string
+	HostPort      string
+	Protocol      string // "tcp" (default) or "udp"
+}
+
 type ContainerConfig struct {
 	Image         string
 	Name          string
@@ -17,6 +31,8 @@ type ContainerConfig struct {
 	Env           []string // e.g., ["KEY=value", "FOO=bar"]
 	Tag           string
 	ProductName   string
+	Binds         []BindMount
+	ExtraPorts    []PortMapping
 }
 
 type PullProgress struct {
@@ -39,4 +55,5 @@ type Runtime interface {
 	Logs(ctx context.Context, containerID string, tail int) (string, error)
 	StreamLogs(ctx context.Context, containerID string, out io.Writer, follow bool) error
 	GetImageVersion(ctx context.Context, imageName string) (string, error)
+	SocketPath() string
 }

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -2,12 +2,16 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
 	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,6 +128,81 @@ port = "4567"
 	ctx := testContext(t)
 	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
 	require.NoError(t, err, "lstk start failed: %s", stderr)
+}
+
+func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
+	require.NoError(t, err, "failed to inspect container")
+	require.True(t, inspect.State.Running)
+
+	t.Run("environment variables", func(t *testing.T) {
+		envVars := containerEnvToMap(inspect.Config.Env)
+		assert.Equal(t, ":4566", envVars["GATEWAY_LISTEN"])
+		assert.Equal(t, containerName, envVars["MAIN_CONTAINER_NAME"])
+		assert.NotEmpty(t, envVars["LOCALSTACK_AUTH_TOKEN"])
+	})
+
+	t.Run("docker socket mount", func(t *testing.T) {
+		if !strings.HasPrefix(dockerClient.DaemonHost(), "unix://") {
+			t.Skip("Docker daemon is not reachable via unix socket")
+		}
+
+		assert.True(t, hasBindTarget(inspect.HostConfig.Binds, "/var/run/docker.sock"),
+			"expected Docker socket bind mount to /var/run/docker.sock, got: %v", inspect.HostConfig.Binds)
+
+		envVars := containerEnvToMap(inspect.Config.Env)
+		assert.Equal(t, "unix:///var/run/docker.sock", envVars["DOCKER_HOST"])
+	})
+
+	t.Run("service port range", func(t *testing.T) {
+		for p := 4510; p <= 4559; p++ {
+			port := nat.Port(fmt.Sprintf("%d/tcp", p))
+			bindings := inspect.HostConfig.PortBindings[port]
+			if assert.NotEmpty(t, bindings, "port %d/tcp should be bound", p) {
+				assert.Equal(t, strconv.Itoa(p), bindings[0].HostPort)
+			}
+		}
+	})
+
+	t.Run("main port", func(t *testing.T) {
+		mainBindings := inspect.HostConfig.PortBindings[nat.Port("4566/tcp")]
+		require.NotEmpty(t, mainBindings, "port 4566/tcp should be bound")
+		assert.Equal(t, "4566", mainBindings[0].HostPort)
+	})
+}
+
+// containerEnvToMap converts a Docker container's []string env to a map.
+func containerEnvToMap(envList []string) map[string]string {
+	m := make(map[string]string, len(envList))
+	for _, e := range envList {
+		k, v, _ := strings.Cut(e, "=")
+		m[k] = v
+	}
+	return m
+}
+
+// hasBindTarget checks if any bind mount targets the given container path.
+func hasBindTarget(binds []string, containerPath string) bool {
+	for _, b := range binds {
+		parts := strings.Split(b, ":")
+		if len(parts) >= 2 && parts[1] == containerPath {
+			return true
+		}
+	}
+	return false
 }
 
 func cleanup() {


### PR DESCRIPTION
The container was missing critical configuration that the old CLI provides. This adds:

- **Docker socket mount** — mounts the host Docker socket into the container so LocalStack can manage sibling containers (Lambda, ECS, etc.). Socket path is derived from the Docker client connection, supporting `DOCKER_HOST` and fallback probing for Colima/OrbStack.
- **Service port range** — maps ports 4510-4559 for external service ports (Lambda, ECS container port binding).
- **Container env vars** — sets `GATEWAY_LISTEN`, `MAIN_CONTAINER_NAME`, and `DOCKER_HOST` inside the container.
- **Runtime interface** — adds `BindMount`, `PortMapping`, `ExtraPorts` to `ContainerConfig` and `SocketPath()` to the `Runtime` interface.

Also addresses [DRG-573](https://linear.app/localstack/issue/DRG-573/fallback-to-colima-socket-when-docker-host-is-unset) by probing `~/.colima/default/docker.sock` when `DOCKER_HOST` is unset and the default socket doesn't exist.

### Todo

- [x] Volume mount for persistence (will work differently in the new CLI)

### Related

- [FLC-501](https://linear.app/localstack/issue/FLC-501/mount-docker-socket)
- [DRG-573](https://linear.app/localstack/issue/DRG-573/fallback-to-colima-socket-when-docker-host-is-unset)