### PR TITLE
Remove version command and simplify version output

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X github.com/localstack/lstk/internal/version.version={{ .Version }} -X github.com/localstack/lstk/internal/version.commit={{ .Commit }} -X github.com/localstack/lstk/internal/version.buildDate={{ .Date }}
+      - -s -w -X github.com/localstack/lstk/internal/version.version={{ .Version }}
 
 archives:
   - id: lstk

--- a/README.md
+++ b/README.md
@@ -172,8 +172,6 @@ lstk update
 # Show resolved config file path
 lstk config path
 
-# Show version info
-lstk version
 ```
 
 ## Reporting bugs

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -35,6 +35,7 @@ func TestRootHelpOutputTemplate(t *testing.T) {
 	assertContains(t, out, "Options:")
 	assertNotContains(t, out, "Available Commands:")
 	assertNotContains(t, out, `Use "lstk [command] --help" for more information about a command.`)
+	assertNotContains(t, out, "\n  version ")
 }
 
 func TestSubcommandHelpUsesSubcommandUsageLine(t *testing.T) {

--- a/cmd/non_interactive_test.go
+++ b/cmd/non_interactive_test.go
@@ -48,7 +48,7 @@ func TestNonInteractiveFlagAppearsInStopHelp(t *testing.T) {
 func TestNonInteractiveFlagBindsToCfg(t *testing.T) {
 	cfg := &env.Env{}
 	root := NewRootCmd(cfg, telemetry.New("", true), log.Nop())
-	root.SetArgs([]string{"--non-interactive", "version"})
+	root.SetArgs([]string{"--non-interactive", "--version"})
 	_ = root.Execute()
 
 	if !cfg.NonInteractive {
@@ -59,7 +59,7 @@ func TestNonInteractiveFlagBindsToCfg(t *testing.T) {
 func TestNonInteractiveFlagDefaultIsOff(t *testing.T) {
 	cfg := &env.Env{}
 	root := NewRootCmd(cfg, telemetry.New("", true), log.Nop())
-	root.SetArgs([]string{"version"})
+	root.SetArgs([]string{"--version"})
 	_ = root.Execute()
 
 	if cfg.NonInteractive {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,6 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 	}
 
 	root.Version = version.Version()
-	root.SetVersionTemplate(versionLine() + "\n")
 	root.SilenceErrors = true
 	root.SilenceUsage = true
 
@@ -46,6 +45,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 
 	root.InitDefaultVersionFlag()
 	root.Flags().Lookup("version").Usage = "Show version"
+	root.SetVersionTemplate(versionTemplate())
 
 	root.AddCommand(
 		newStartCmd(cfg, tel, logger),
@@ -55,7 +55,6 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 		newStatusCmd(cfg),
 		newLogsCmd(),
 		newConfigCmd(),
-		newVersionCmd(),
 		newUpdateCmd(cfg),
 	)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 	configureHelp(root)
 
 	root.InitDefaultVersionFlag()
+	root.Flags().Lookup("version").Shorthand = "v"
 	root.Flags().Lookup("version").Usage = "Show version"
 	root.SetVersionTemplate(versionTemplate())
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 	root.InitDefaultVersionFlag()
 	root.Flags().Lookup("version").Shorthand = "v"
 	root.Flags().Lookup("version").Usage = "Show version"
-	root.SetVersionTemplate(versionTemplate())
+	root.SetVersionTemplate(versionLine() + "\n")
 
 	root.AddCommand(
 		newStartCmd(cfg, tel, logger),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,10 +6,6 @@ import (
 	"github.com/localstack/lstk/internal/version"
 )
 
-func versionTemplate() string {
-	return versionLine() + "\n"
-}
-
 func versionLine() string {
 	return fmt.Sprintf("lstk %s", version.Version())
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,21 +4,12 @@ import (
 	"fmt"
 
 	"github.com/localstack/lstk/internal/version"
-	"github.com/spf13/cobra"
 )
 
-func newVersionCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "Show version",
-		Long:  "Print version information for the lstk binary.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := fmt.Fprintln(cmd.OutOrStdout(), versionLine())
-			return err
-		},
-	}
+func versionTemplate() string {
+	return versionLine() + "\n"
 }
 
 func versionLine() string {
-	return fmt.Sprintf("lstk %s (%s, %s)", version.Version(), version.Commit(), version.BuildDate())
+	return fmt.Sprintf("lstk %s", version.Version())
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -5,9 +5,6 @@ import "testing"
 func TestVersionLine(t *testing.T) {
 	got := versionLine()
 
-	if got == "" {
-		t.Fatal("versionLine() should not be empty")
-	}
 	if got != "lstk dev" {
 		t.Fatalf("versionLine() = %q, want %q", got, "lstk dev")
 	}
@@ -24,8 +21,9 @@ func TestVersionFlagsPrintSameOutput(t *testing.T) {
 		t.Fatalf("expected no error from -v, got %v", err)
 	}
 
-	if longOut != versionTemplate() {
-		t.Fatalf("--version output = %q, want %q", longOut, versionTemplate())
+	want := versionLine() + "\n"
+	if longOut != want {
+		t.Fatalf("--version output = %q, want %q", longOut, want)
 	}
 	if shortOut != longOut {
 		t.Fatalf("-v output = %q, want %q", shortOut, longOut)

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,17 +1,33 @@
 package cmd
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
 func TestVersionLine(t *testing.T) {
 	got := versionLine()
 
-	if !strings.HasPrefix(got, "lstk ") {
-		t.Fatalf("versionLine() = %q, should start with 'lstk '", got)
+	if got == "" {
+		t.Fatal("versionLine() should not be empty")
 	}
-	if !strings.Contains(got, "(") || !strings.Contains(got, ")") {
-		t.Fatalf("versionLine() = %q, should contain parentheses with commit and date", got)
+	if got != "lstk dev" {
+		t.Fatalf("versionLine() = %q, want %q", got, "lstk dev")
+	}
+}
+
+func TestVersionFlagsPrintSameOutput(t *testing.T) {
+	longOut, err := executeWithArgs(t, "--version")
+	if err != nil {
+		t.Fatalf("expected no error from --version, got %v", err)
+	}
+
+	shortOut, err := executeWithArgs(t, "-v")
+	if err != nil {
+		t.Fatalf("expected no error from -v, got %v", err)
+	}
+
+	if longOut != versionTemplate() {
+		t.Fatalf("--version output = %q, want %q", longOut, versionTemplate())
+	}
+	if shortOut != longOut {
+		t.Fatalf("-v output = %q, want %q", shortOut, longOut)
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,12 +6,7 @@ var (
 	version   = "dev"
 	commit    = "none"
 	buildDate = "unknown"
+	_, _      = commit, buildDate
 )
 
 func Version() string { return version }
-
-// Keep linker-populated build metadata embedded for release tooling,
-// even though user-facing version output only exposes the version string.
-func metadata() (string, string) {
-	return commit, buildDate
-}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,3 +9,9 @@ var (
 )
 
 func Version() string { return version }
+
+// Keep linker-populated build metadata embedded for release tooling,
+// even though user-facing version output only exposes the version string.
+func metadata() (string, string) {
+	return commit, buildDate
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,12 +1,7 @@
 package version
 
-// Set via ldflags at build time. Must be variables, not constants,
+// Set via ldflags at build time. Must be a variable, not a constant,
 // because the linker can only modify variables at link time.
-var (
-	version   = "dev"
-	commit    = "none"
-	buildDate = "unknown"
-	_, _      = commit, buildDate
-)
+var version = "dev"
 
 func Version() string { return version }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,6 +8,4 @@ var (
 	buildDate = "unknown"
 )
 
-func Version() string   { return version }
-func Commit() string    { return commit }
-func BuildDate() string { return buildDate }
+func Version() string { return version }

--- a/test/integration/logging_test.go
+++ b/test/integration/logging_test.go
@@ -14,7 +14,7 @@ func TestLogging_NonTTY_WritesToLogFile(t *testing.T) {
 	_ = os.Remove(logPath)
 
 	ctx := testContext(t)
-	_, _, err := runLstk(t, ctx, "", nil, "version")
+	_, _, err := runLstk(t, ctx, "", nil, "--version")
 	require.NoError(t, err)
 
 	logContents, err := os.ReadFile(logPath)
@@ -28,7 +28,7 @@ func TestLogging_TTY_WritesToLogFile(t *testing.T) {
 	_ = os.Remove(logPath)
 
 	ctx := testContext(t)
-	_, err := runLstkInPTY(t, ctx, nil, "version")
+	_, err := runLstkInPTY(t, ctx, nil, "--version")
 	require.NoError(t, err)
 
 	logContents, err := os.ReadFile(logPath)

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"os/exec"
 	"runtime"
 	"testing"
@@ -81,16 +80,12 @@ func TestDeviceFlowSuccess(t *testing.T) {
 		t.Skip("PTY not supported on Windows")
 	}
 
-	// Use env token if set, otherwise fall back to a synthetic test token
-	licenseToken := os.Getenv(string(env.AuthToken))
-	if licenseToken == "" {
-		licenseToken = "test-license-token"
-	}
-
 	cleanup()
 	t.Cleanup(cleanup)
 
-	// Create mock API server that returns the real token
+	licenseToken := "test-license-token"
+
+	// Create mock API server that returns a synthetic token
 	mockServer := createMockAPIServer(t, licenseToken, true)
 	defer mockServer.Close()
 

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -81,10 +81,10 @@ func TestDeviceFlowSuccess(t *testing.T) {
 		t.Skip("PTY not supported on Windows")
 	}
 
-	// Skip if no auth token available
+	// Use env token if set, otherwise fall back to a synthetic test token
 	licenseToken := os.Getenv(string(env.AuthToken))
 	if licenseToken == "" {
-		t.Skip("LOCALSTACK_AUTH_TOKEN not set")
+		licenseToken = "test-license-token"
 	}
 
 	cleanup()

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"runtime"
 	"testing"
@@ -80,11 +81,14 @@ func TestDeviceFlowSuccess(t *testing.T) {
 		t.Skip("PTY not supported on Windows")
 	}
 
+	// Skip if no auth token available
+	licenseToken := os.Getenv(string(env.AuthToken))
+	if licenseToken == "" {
+		t.Skip("LOCALSTACK_AUTH_TOKEN not set")
+	}
+
 	cleanup()
 	t.Cleanup(cleanup)
-
-	// Require valid token from environment
-	licenseToken := env.Require(t, env.AuthToken)
 
 	// Create mock API server that returns the real token
 	mockServer := createMockAPIServer(t, licenseToken, true)

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -120,7 +120,7 @@ func TestUpdateBinaryInPlace(t *testing.T) {
 	require.NoError(t, err, "go build failed: %s", string(out))
 
 	// Verify it reports the fake version
-	verCmd := exec.CommandContext(ctx, tmpBinary, "version")
+	verCmd := exec.CommandContext(ctx, tmpBinary, "--version")
 	verOut, err := verCmd.CombinedOutput()
 	require.NoError(t, err)
 	assert.Contains(t, string(verOut), "0.0.1")
@@ -136,7 +136,7 @@ func TestUpdateBinaryInPlace(t *testing.T) {
 	assert.Contains(t, updateStr, "Updated to", "should complete the update")
 
 	// Verify the binary was actually replaced
-	verCmd2 := exec.CommandContext(ctx, tmpBinary, "version")
+	verCmd2 := exec.CommandContext(ctx, tmpBinary, "--version")
 	verOut2, err := verCmd2.CombinedOutput()
 	require.NoError(t, err)
 	assert.NotContains(t, string(verOut2), "0.0.1", "binary should no longer be the old version")
@@ -187,7 +187,7 @@ func TestUpdateHomebrew(t *testing.T) {
 	require.NoError(t, err, "go build failed: %s", string(out))
 
 	// Verify it reports the fake version
-	verCmd := exec.CommandContext(ctx, caskBinary, "version")
+	verCmd := exec.CommandContext(ctx, caskBinary, "--version")
 	verOut, err := verCmd.CombinedOutput()
 	require.NoError(t, err)
 	assert.Contains(t, string(verOut), "0.0.1")


### PR DESCRIPTION
This PR simplifies version reporting in `lstk` and aligns it with common CLI conventions.
1. Removes the `version` subcommand
1. Keeps `-v` and `--version` as the supported version entry points
1. Simplifies version output to a single plain line, `lstk 0.4.1` for production and `lstk dev` for development

The previous setup exposed _**three different version entry points**_ and printed extra build metadata by default. That added surface area without much user value. This change narrows the interface to the standard flag-based pattern most CLIs use, which is simpler for both humans and automation:
1. Easier to discover and remember
1. Less output parsing ambiguity
1. Cleaner default UX
1. Better fit for agent-readiness, where deterministic plain output matters more than decorative metadata (PRO-236)

| BEFORE | AFTER |
|--------|--------|
| <img width="806" height="195" alt="Screenshot 2026-03-12 at 16 04 50" src="https://github.com/user-attachments/assets/77cde421-5b75-4239-988e-dd0b245ae2e9" /> | <img width="806" height="195" alt="Screenshot 2026-03-12 at 16 04 38" src="https://github.com/user-attachments/assets/679d9889-492e-41ee-a70f-d8b917a02b00" /> |

This will also remove the version.Commit and version.BuildDate. I know `uv` includes commit and build metadata in a compact format, but for `lstk` the current output structure adds noise and makes the binary feel more like a development build than a polished release.

For reference:

| `lstk --version` | `uv --version` |
|--------|--------|
| <img width="806" height="195" alt="Screenshot 2026-03-12 at 16 04 58" src="https://github.com/user-attachments/assets/01b7b600-c013-44d2-8da2-dea04db9b06a" /> | <img width="806" height="195" alt="Screenshot 2026-03-12 at 16 14 02" src="https://github.com/user-attachments/assets/0a313d03-2410-4540-add6-4065ca7cd1e3" /> | 