### PR TITLE
Change one-time code auth hint colors

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -158,7 +158,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.Code != "" {
 			a.lines = appendLine(a.lines, styledLine{text: ""})
-			a.lines = appendLine(a.lines, styledLine{text: styles.Secondary.Render("One-time code: ") + styles.NimboMid.Render(msg.Code)})
+			a.lines = appendLine(a.lines, styledLine{text: styles.SecondaryMessage.Render("One-time code: ") + styles.NimboMid.Render(msg.Code)})
 			a.lines = appendLine(a.lines, styledLine{text: ""})
 		}
 		return a, nil


### PR DESCRIPTION
Change one-time code auth hint colors to improve grouping[[1](https://en.wikipedia.org/wiki/Principles_of_grouping)] and information hierarchy. 🟣 

Minor follow up from https://github.com/localstack/lstk/pull/102.

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="355" alt="Screenshot 2026-03-12 at 16 20 56" src="https://github.com/user-attachments/assets/0997d559-1090-4271-a19f-8d05815536ef" /> | <img width="669" height="355" alt="Screenshot 2026-03-12 at 16 23 52" src="https://github.com/user-attachments/assets/ea8b3231-1a4b-4755-89b5-6be2b6c863da" /> | 