### PR TITLE
fix: correct port binding for non-default ports

### DIFF
--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -31,10 +31,6 @@ var emulatorHealthPaths = map[EmulatorType]string{
 	EmulatorAWS: "/_localstack/health",
 }
 
-var emulatorContainerPorts = map[EmulatorType]string{
-	EmulatorAWS: "4566/tcp",
-}
-
 type ContainerConfig struct {
 	Type EmulatorType `mapstructure:"type"`
 	Tag  string       `mapstructure:"tag"`
@@ -89,11 +85,12 @@ func (c *ContainerConfig) HealthPath() (string, error) {
 }
 
 func (c *ContainerConfig) ContainerPort() (string, error) {
-	port, ok := emulatorContainerPorts[c.Type]
-	if !ok {
+	switch c.Type {
+	case EmulatorAWS:
+		return "4566/tcp", nil
+	default:
 		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
 	}
-	return port, nil
 }
 
 func (c *ContainerConfig) DisplayName() string {

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -31,6 +31,10 @@ var emulatorHealthPaths = map[EmulatorType]string{
 	EmulatorAWS: "/_localstack/health",
 }
 
+var emulatorContainerPorts = map[EmulatorType]string{
+	EmulatorAWS: "4566/tcp",
+}
+
 type ContainerConfig struct {
 	Type EmulatorType `mapstructure:"type"`
 	Tag  string       `mapstructure:"tag"`
@@ -82,6 +86,14 @@ func (c *ContainerConfig) HealthPath() (string, error) {
 		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
 	}
 	return path, nil
+}
+
+func (c *ContainerConfig) ContainerPort() (string, error) {
+	port, ok := emulatorContainerPorts[c.Type]
+	if !ok {
+		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
+	}
+	return port, nil
 }
 
 func (c *ContainerConfig) DisplayName() string {

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	stdruntime "runtime"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/containerd/errdefs"
@@ -75,9 +74,6 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			return err
 		}
 		env := append(resolvedEnv, "LOCALSTACK_AUTH_TOKEN="+token)
-		if needsGatewayListen(c.Port, resolvedEnv) {
-			env = append(env, "GATEWAY_LISTEN=:"+c.Port)
-		}
 		containers[i] = runtime.ContainerConfig{
 			Image:       image,
 			Name:        c.Name(),
@@ -321,12 +317,4 @@ func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {
 		seen[c.Type] = true
 	}
 	return false
-}
-
-func needsGatewayListen(port string, env []string) bool {
-	// LocalStack only binds to the configured port when GATEWAY_LISTEN is set explicitly;
-	// without it, non-default ports cause the emulator to never become ready.
-	return port != "4566" && !slices.ContainsFunc(env, func(e string) bool {
-		return strings.HasPrefix(e, "GATEWAY_LISTEN=")
-	})
 }

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	stdruntime "runtime"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/containerd/errdefs"
@@ -74,6 +75,9 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			return err
 		}
 		env := append(resolvedEnv, "LOCALSTACK_AUTH_TOKEN="+token)
+		if needsGatewayListen(c.Port, resolvedEnv) {
+			env = append(env, "GATEWAY_LISTEN=:"+c.Port)
+		}
 		containers[i] = runtime.ContainerConfig{
 			Image:       image,
 			Name:        c.Name(),
@@ -317,4 +321,12 @@ func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {
 		seen[c.Type] = true
 	}
 	return false
+}
+
+func needsGatewayListen(port string, env []string) bool {
+	// LocalStack only binds to the configured port when GATEWAY_LISTEN is set explicitly;
+	// without it, non-default ports cause the emulator to never become ready.
+	return port != "4566" && !slices.ContainsFunc(env, func(e string) bool {
+		return strings.HasPrefix(e, "GATEWAY_LISTEN=")
+	})
 }

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -69,19 +69,25 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			return err
 		}
 
+		containerPort, err := c.ContainerPort()
+		if err != nil {
+			return err
+		}
+
 		resolvedEnv, err := c.ResolvedEnv(opts.Env)
 		if err != nil {
 			return err
 		}
 		env := append(resolvedEnv, "LOCALSTACK_AUTH_TOKEN="+token)
 		containers[i] = runtime.ContainerConfig{
-			Image:       image,
-			Name:        c.Name(),
-			Port:        c.Port,
-			HealthPath:  healthPath,
-			Env:         env,
-			Tag:         c.Tag,
-			ProductName: productName,
+			Image:         image,
+			Name:          c.Name(),
+			Port:          c.Port,
+			ContainerPort: containerPort,
+			HealthPath:    healthPath,
+			Env:           env,
+			Tag:           c.Tag,
+			ProductName:   productName,
 		}
 	}
 

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -107,10 +107,8 @@ func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progres
 	return nil
 }
 
-const emulatorContainerPort = nat.Port("4566/tcp")
-
 func (d *DockerRuntime) Start(ctx context.Context, config ContainerConfig) (string, error) {
-	containerPort := emulatorContainerPort
+	containerPort := nat.Port(config.ContainerPort)
 	exposedPorts := nat.PortSet{containerPort: struct{}{}}
 	portBindings := nat.PortMap{containerPort: []nat.PortBinding{{HostPort: config.Port}}}
 

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -108,9 +108,9 @@ func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progres
 }
 
 func (d *DockerRuntime) Start(ctx context.Context, config ContainerConfig) (string, error) {
-	port := nat.Port(config.Port + "/tcp")
-	exposedPorts := nat.PortSet{port: struct{}{}}
-	portBindings := nat.PortMap{port: []nat.PortBinding{{HostPort: config.Port}}}
+	containerPort := nat.Port("4566/tcp")
+	exposedPorts := nat.PortSet{containerPort: struct{}{}}
+	portBindings := nat.PortMap{containerPort: []nat.PortBinding{{HostPort: config.Port}}}
 
 	resp, err := d.client.ContainerCreate(ctx,
 		&container.Config{

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -107,8 +107,10 @@ func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progres
 	return nil
 }
 
+const emulatorContainerPort = nat.Port("4566/tcp")
+
 func (d *DockerRuntime) Start(ctx context.Context, config ContainerConfig) (string, error) {
-	containerPort := nat.Port("4566/tcp")
+	containerPort := emulatorContainerPort
 	exposedPorts := nat.PortSet{containerPort: struct{}{}}
 	portBindings := nat.PortMap{containerPort: []nat.PortBinding{{HostPort: config.Port}}}
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -8,13 +8,14 @@ import (
 )
 
 type ContainerConfig struct {
-	Image       string
-	Name        string
-	Port        string
-	HealthPath  string
-	Env         []string // e.g., ["KEY=value", "FOO=bar"]
-	Tag         string
-	ProductName string
+	Image         string
+	Name          string
+	Port          string
+	ContainerPort string // internal port the emulator listens on inside the container (e.g. "4566/tcp")
+	HealthPath    string
+	Env           []string // e.g., ["KEY=value", "FOO=bar"]
+	Tag           string
+	ProductName   string
 }
 
 type PullProgress struct {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -3,6 +3,9 @@ package integration_test
 import (
 	"context"
 	"net"
+	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
@@ -98,6 +101,37 @@ func TestStartCommandFailsWhenPortInUse(t *testing.T) {
 	assert.Contains(t, stdout, "Port 4566 already in use")
 	assert.Contains(t, stdout, "LocalStack may already be running.")
 	assert.Contains(t, stdout, "lstk stop")
+}
+
+func TestStartCommandSucceedsWithNonDefaultPort(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	configContent := `
+[[containers]]
+type = "aws"
+tag = "latest"
+port = "4567"
+`
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+
+	// lstk start only returns once the health check passes, but verify directly
+	// that LocalStack is reachable on the non-default port.
+	resp, err := http.Get("http://localhost:4567/_localstack/health")
+	require.NoError(t, err, "LocalStack health endpoint not reachable on port 4567")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "LocalStack should be ready on port 4567")
 }
 
 func cleanup() {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"context"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -125,13 +124,6 @@ port = "4567"
 	ctx := testContext(t)
 	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
 	require.NoError(t, err, "lstk start failed: %s", stderr)
-
-	// lstk start only returns once the health check passes, but verify directly
-	// that LocalStack is reachable on the non-default port.
-	resp, err := http.Get("http://localhost:4567/_localstack/health")
-	require.NoError(t, err, "LocalStack health endpoint not reachable on port 4567")
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "LocalStack should be ready on port 4567")
 }
 
 func cleanup() {


### PR DESCRIPTION
When configuring a non-default port (e.g. 4567), the Docker binding was 4567:4567 instead of 4567:4566, so the health check could not reach localstack and lstk would hang.

Fix port binding for non-default ports so the emulator actually becomes ready.                