### PR TITLE
Use checkmark for success message

### DIFF
--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -151,7 +151,7 @@ func formatErrorEvent(e ErrorEvent) string {
 
 func formatInstanceInfo(e InstanceInfoEvent) string {
 	var sb strings.Builder
-	sb.WriteString("✓ " + e.EmulatorName + " is running (" + e.Host + ")")
+	sb.WriteString(SuccessMarkerText() + " " + e.EmulatorName + " is running (" + e.Host + ")")
 	var meta []string
 	if e.Uptime > 0 {
 		meta = append(meta, "UPTIME: "+formatUptime(e.Uptime))

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -49,9 +49,9 @@ func formatStatusLine(e ContainerStatusEvent) (string, bool) {
 		return "Waiting for LocalStack to be ready...", true
 	case "ready":
 		if e.Detail != "" {
-			return fmt.Sprintf("LocalStack ready (%s)", e.Detail), true
+			return fmt.Sprintf("%s LocalStack ready (%s)", SuccessMarkerText(), e.Detail), true
 		}
-		return "LocalStack ready", true
+		return SuccessMarkerText() + " LocalStack ready", true
 	default:
 		if e.Detail != "" {
 			return fmt.Sprintf("LocalStack: %s (%s)", e.Phase, e.Detail), true
@@ -116,7 +116,7 @@ func formatAuthEvent(e AuthEvent) string {
 func formatMessageEvent(e MessageEvent) string {
 	switch e.Severity {
 	case SeveritySuccess:
-		return "> Success: " + e.Text
+		return SuccessMarkerText() + " " + e.Text
 	case SeverityNote:
 		return "> Note: " + e.Text
 	case SeverityWarning:

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -49,9 +49,9 @@ func formatStatusLine(e ContainerStatusEvent) (string, bool) {
 		return "Waiting for LocalStack to be ready...", true
 	case "ready":
 		if e.Detail != "" {
-			return fmt.Sprintf("%s LocalStack ready (%s)", SuccessMarkerText(), e.Detail), true
+			return fmt.Sprintf("%s LocalStack ready (%s)", SuccessMarker(), e.Detail), true
 		}
-		return SuccessMarkerText() + " LocalStack ready", true
+		return SuccessMarker() + " LocalStack ready", true
 	default:
 		if e.Detail != "" {
 			return fmt.Sprintf("LocalStack: %s (%s)", e.Phase, e.Detail), true
@@ -116,7 +116,7 @@ func formatAuthEvent(e AuthEvent) string {
 func formatMessageEvent(e MessageEvent) string {
 	switch e.Severity {
 	case SeveritySuccess:
-		return SuccessMarkerText() + " " + e.Text
+		return SuccessMarker() + " " + e.Text
 	case SeverityNote:
 		return "> Note: " + e.Text
 	case SeverityWarning:
@@ -151,7 +151,7 @@ func formatErrorEvent(e ErrorEvent) string {
 
 func formatInstanceInfo(e InstanceInfoEvent) string {
 	var sb strings.Builder
-	sb.WriteString(SuccessMarkerText() + " " + e.EmulatorName + " is running (" + e.Host + ")")
+	sb.WriteString(SuccessMarker() + " " + e.EmulatorName + " is running (" + e.Host + ")")
 	var meta []string
 	if e.Uptime > 0 {
 		meta = append(meta, "UPTIME: "+formatUptime(e.Uptime))

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -120,7 +120,7 @@ func TestFormatEventLine(t *testing.T) {
 				ContainerName: "localstack-aws",
 				Uptime:        4*time.Minute + 23*time.Second,
 			},
-			want:   "✓ LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1",
+			want:   SuccessMarkerText() + " LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1",
 			wantOK: true,
 		},
 		{
@@ -129,7 +129,7 @@ func TestFormatEventLine(t *testing.T) {
 				EmulatorName: "LocalStack AWS Emulator",
 				Host:         "127.0.0.1:4566",
 			},
-			want:   "✓ LocalStack AWS Emulator is running (127.0.0.1:4566)",
+			want:   SuccessMarkerText() + " LocalStack AWS Emulator is running (127.0.0.1:4566)",
 			wantOK: true,
 		},
 		{

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -24,7 +24,7 @@ func TestFormatEventLine(t *testing.T) {
 		{
 			name:   "message event success",
 			event:  MessageEvent{Severity: SeveritySuccess, Text: "done"},
-			want:   SuccessMarkerText() + " done",
+			want:   SuccessMarker() + " done",
 			wantOK: true,
 		},
 		{
@@ -60,7 +60,7 @@ func TestFormatEventLine(t *testing.T) {
 		{
 			name:   "status ready with detail",
 			event:  ContainerStatusEvent{Phase: "ready", Container: "localstack-aws", Detail: "abc123"},
-			want:   SuccessMarkerText() + " LocalStack ready (abc123)",
+			want:   SuccessMarker() + " LocalStack ready (abc123)",
 			wantOK: true,
 		},
 		{
@@ -120,7 +120,7 @@ func TestFormatEventLine(t *testing.T) {
 				ContainerName: "localstack-aws",
 				Uptime:        4*time.Minute + 23*time.Second,
 			},
-			want:   SuccessMarkerText() + " LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1",
+			want:   SuccessMarker() + " LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1",
 			wantOK: true,
 		},
 		{
@@ -129,7 +129,7 @@ func TestFormatEventLine(t *testing.T) {
 				EmulatorName: "LocalStack AWS Emulator",
 				Host:         "127.0.0.1:4566",
 			},
-			want:   SuccessMarkerText() + " LocalStack AWS Emulator is running (127.0.0.1:4566)",
+			want:   SuccessMarker() + " LocalStack AWS Emulator is running (127.0.0.1:4566)",
 			wantOK: true,
 		},
 		{
@@ -237,4 +237,3 @@ func TestFormatTableWidth(t *testing.T) {
 		}
 	})
 }
-

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -24,7 +24,7 @@ func TestFormatEventLine(t *testing.T) {
 		{
 			name:   "message event success",
 			event:  MessageEvent{Severity: SeveritySuccess, Text: "done"},
-			want:   "> Success: done",
+			want:   SuccessMarkerText() + " done",
 			wantOK: true,
 		},
 		{
@@ -60,7 +60,7 @@ func TestFormatEventLine(t *testing.T) {
 		{
 			name:   "status ready with detail",
 			event:  ContainerStatusEvent{Phase: "ready", Container: "localstack-aws", Detail: "abc123"},
-			want:   "LocalStack ready (abc123)",
+			want:   SuccessMarkerText() + " LocalStack ready (abc123)",
 			wantOK: true,
 		},
 		{

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -163,7 +163,7 @@ func TestPlainSink_EmitsInstanceInfoEvent(t *testing.T) {
 			Uptime:        4*time.Minute + 23*time.Second,
 		})
 
-		expected := "✓ LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1\n"
+		expected := SuccessMarkerText() + " LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1\n"
 		assert.Equal(t, expected, out.String())
 		assert.NoError(t, sink.Err())
 	})
@@ -177,7 +177,7 @@ func TestPlainSink_EmitsInstanceInfoEvent(t *testing.T) {
 			Host:         "127.0.0.1:4566",
 		})
 
-		expected := "✓ LocalStack AWS Emulator is running (127.0.0.1:4566)\n"
+		expected := SuccessMarkerText() + " LocalStack AWS Emulator is running (127.0.0.1:4566)\n"
 		assert.Equal(t, expected, out.String())
 		assert.NoError(t, sink.Err())
 	})

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -61,12 +61,12 @@ func TestPlainSink_EmitsStatusEvent(t *testing.T) {
 		{
 			name:     "ready phase with detail",
 			event:    ContainerStatusEvent{Phase: "ready", Container: "localstack-aws", Detail: "abc123"},
-			expected: fmt.Sprintf("%s LocalStack ready (abc123)\n", SuccessMarkerText()),
+			expected: fmt.Sprintf("%s LocalStack ready (abc123)\n", SuccessMarker()),
 		},
 		{
 			name:     "ready phase without detail",
 			event:    ContainerStatusEvent{Phase: "ready", Container: "localstack-aws"},
-			expected: fmt.Sprintf("%s LocalStack ready\n", SuccessMarkerText()),
+			expected: fmt.Sprintf("%s LocalStack ready\n", SuccessMarker()),
 		},
 		{
 			name:     "unknown phase with detail",
@@ -163,7 +163,7 @@ func TestPlainSink_EmitsInstanceInfoEvent(t *testing.T) {
 			Uptime:        4*time.Minute + 23*time.Second,
 		})
 
-		expected := SuccessMarkerText() + " LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1\n"
+		expected := SuccessMarker() + " LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1\n"
 		assert.Equal(t, expected, out.String())
 		assert.NoError(t, sink.Err())
 	})
@@ -177,7 +177,7 @@ func TestPlainSink_EmitsInstanceInfoEvent(t *testing.T) {
 			Host:         "127.0.0.1:4566",
 		})
 
-		expected := SuccessMarkerText() + " LocalStack AWS Emulator is running (127.0.0.1:4566)\n"
+		expected := SuccessMarker() + " LocalStack AWS Emulator is running (127.0.0.1:4566)\n"
 		assert.Equal(t, expected, out.String())
 		assert.NoError(t, sink.Err())
 	})

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -61,12 +61,12 @@ func TestPlainSink_EmitsStatusEvent(t *testing.T) {
 		{
 			name:     "ready phase with detail",
 			event:    ContainerStatusEvent{Phase: "ready", Container: "localstack-aws", Detail: "abc123"},
-			expected: "LocalStack ready (abc123)\n",
+			expected: fmt.Sprintf("%s LocalStack ready (abc123)\n", SuccessMarkerText()),
 		},
 		{
 			name:     "ready phase without detail",
 			event:    ContainerStatusEvent{Phase: "ready", Container: "localstack-aws"},
-			expected: "LocalStack ready\n",
+			expected: fmt.Sprintf("%s LocalStack ready\n", SuccessMarkerText()),
 		},
 		{
 			name:     "unknown phase with detail",

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -1,7 +1,0 @@
-package output
-
-const SuccessColorHex = "#B7C95C"
-
-func SuccessMarkerText() string {
-	return "✔︎"
-}

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -1,0 +1,13 @@
+package output
+
+import "fmt"
+
+const SuccessColorHex = "#B7C95C"
+
+func SuccessMarker() string {
+	return fmt.Sprintf("\x1b[38;2;183;201;92m%s\x1b[0m", SuccessMarkerText())
+}
+
+func SuccessMarkerText() string {
+	return "✔︎"
+}

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -1,12 +1,6 @@
 package output
 
-import "fmt"
-
 const SuccessColorHex = "#B7C95C"
-
-func SuccessMarker() string {
-	return fmt.Sprintf("\x1b[38;2;183;201;92m%s\x1b[0m", SuccessMarkerText())
-}
 
 func SuccessMarkerText() string {
 	return "✔︎"

--- a/internal/output/symbols.go
+++ b/internal/output/symbols.go
@@ -1,0 +1,5 @@
+package output
+
+func SuccessMarker() string {
+	return "✔︎"
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -182,6 +182,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.pullProgress = a.pullProgress.Hide()
 		}
 		if line, ok := output.FormatEventLine(msg); ok {
+			if msg.Phase == "ready" {
+				line = strings.Replace(line, output.SuccessMarkerText(), styles.Success.Render(output.SuccessMarkerText()), 1)
+			}
 			a.lines = appendLine(a.lines, styledLine{text: line})
 		}
 		return a, nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -183,7 +183,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if line, ok := output.FormatEventLine(msg); ok {
 			if msg.Phase == "ready" {
-				line = strings.Replace(line, output.SuccessMarkerText(), styles.Success.Render(output.SuccessMarkerText()), 1)
+				line = strings.Replace(line, output.SuccessMarker(), styles.Success.Render(output.SuccessMarker()), 1)
 			}
 			a.lines = appendLine(a.lines, styledLine{text: line})
 		}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -176,7 +176,7 @@ func TestAppMessageEventRendering(t *testing.T) {
 	if len(app.lines) != 1 {
 		t.Fatalf("expected 1 line, got %d", len(app.lines))
 	}
-	if !strings.Contains(app.lines[0].text, "Success:") || !strings.Contains(app.lines[0].text, "Done") {
+	if !strings.Contains(app.lines[0].text, output.SuccessMarkerText()) || !strings.Contains(app.lines[0].text, "Done") {
 		t.Fatalf("expected rendered success message, got: %q", app.lines[0].text)
 	}
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -176,7 +176,7 @@ func TestAppMessageEventRendering(t *testing.T) {
 	if len(app.lines) != 1 {
 		t.Fatalf("expected 1 line, got %d", len(app.lines))
 	}
-	if !strings.Contains(app.lines[0].text, output.SuccessMarkerText()) || !strings.Contains(app.lines[0].text, "Done") {
+	if !strings.Contains(app.lines[0].text, output.SuccessMarker()) || !strings.Contains(app.lines[0].text, "Done") {
 		t.Fatalf("expected rendered success message, got: %q", app.lines[0].text)
 	}
 }

--- a/internal/ui/components/message.go
+++ b/internal/ui/components/message.go
@@ -45,7 +45,7 @@ func messagePrefix(e output.MessageEvent) (string, string) {
 	prefix := styles.Secondary.Render("> ")
 	switch e.Severity {
 	case output.SeveritySuccess:
-		checkmark := output.SuccessMarkerText()
+		checkmark := output.SuccessMarker()
 		return checkmark, styles.Success.Render(checkmark)
 	case output.SeverityNote:
 		return "> Note:", prefix + styles.Note.Render("Note:")

--- a/internal/ui/components/message.go
+++ b/internal/ui/components/message.go
@@ -45,7 +45,8 @@ func messagePrefix(e output.MessageEvent) (string, string) {
 	prefix := styles.Secondary.Render("> ")
 	switch e.Severity {
 	case output.SeveritySuccess:
-		return "> Success:", prefix + styles.Success.Render("Success:")
+		checkmark := output.SuccessMarkerText()
+		return "> " + checkmark, prefix + styles.Success.Render(checkmark)
 	case output.SeverityNote:
 		return "> Note:", prefix + styles.Note.Render("Note:")
 	case output.SeverityWarning:

--- a/internal/ui/components/message.go
+++ b/internal/ui/components/message.go
@@ -46,7 +46,7 @@ func messagePrefix(e output.MessageEvent) (string, string) {
 	switch e.Severity {
 	case output.SeveritySuccess:
 		checkmark := output.SuccessMarkerText()
-		return "> " + checkmark, prefix + styles.Success.Render(checkmark)
+		return checkmark, styles.Success.Render(checkmark)
 	case output.SeverityNote:
 		return "> Note:", prefix + styles.Note.Render("Note:")
 	case output.SeverityWarning:

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -1,6 +1,9 @@
 package styles
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/localstack/lstk/internal/output"
+)
 
 const (
 	NimboDarkColor  = "#3F51C7"
@@ -39,7 +42,7 @@ var (
 
 	// Message severity styles
 	Success = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("42"))
+		Foreground(lipgloss.Color(output.SuccessColorHex))
 
 	Note = lipgloss.NewStyle().
 		Foreground(lipgloss.Color("33"))

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -2,13 +2,13 @@ package styles
 
 import (
 	"github.com/charmbracelet/lipgloss"
-	"github.com/localstack/lstk/internal/output"
 )
 
 const (
 	NimboDarkColor  = "#3F51C7"
 	NimboMidColor   = "#5E6AD2"
 	NimboLightColor = "#7E88EC"
+	SuccessColor    = "#B7C95C"
 )
 
 var (
@@ -42,7 +42,7 @@ var (
 
 	// Message severity styles
 	Success = lipgloss.NewStyle().
-		Foreground(lipgloss.Color(output.SuccessColorHex))
+		Foreground(lipgloss.Color(SuccessColor))
 
 	Note = lipgloss.NewStyle().
 		Foreground(lipgloss.Color("33"))


### PR DESCRIPTION
This will changes success messages rendering from text to a shared checkmark marker. ✔️ 

This makes success output more compact and visually consistent across renderers. 💄 

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="340" alt="Screenshot 2026-03-13 at 15 09 24" src="https://github.com/user-attachments/assets/e94d4dc2-6f8e-40fb-9ab5-e39efc67b7c6" /> | <img width="669" height="340" alt="Screenshot 2026-03-13 at 15 03 16" src="https://github.com/user-attachments/assets/82da5807-a523-48e4-bbfe-589fc3e99b93" /> | 