### PR TITLE
Validate container port at config load time

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,5 +80,10 @@ func Get() (*Config, error) {
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
+	for i := range cfg.Containers {
+		if err := cfg.Containers[i].Validate(); err != nil {
+			return nil, fmt.Errorf("invalid container config: %w", err)
+		}
+	}
 	return &cfg, nil
 }

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -37,6 +38,20 @@ type ContainerConfig struct {
 	Port string       `mapstructure:"port"`
 	// Env is a list of named environment references defined in the top-level [env.*] config sections.
 	Env []string `mapstructure:"env"`
+}
+
+func (c *ContainerConfig) Validate() error {
+	if c.Port == "" {
+		return fmt.Errorf("port is required for %s emulator", c.Type)
+	}
+	port, err := strconv.Atoi(c.Port)
+	if err != nil {
+		return fmt.Errorf("port %q is not a valid number", c.Port)
+	}
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("port %d is out of range (must be 1–65535)", port)
+	}
+	return nil
 }
 
 // ResolvedEnv resolves the container's named environment references into KEY=value pairs.

--- a/internal/config/containers_test.go
+++ b/internal/config/containers_test.go
@@ -48,3 +48,46 @@ func TestResolvedEnv_EmptyWhenNoEnvRefs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, resolved)
 }
+
+func TestValidate_ValidPort(t *testing.T) {
+	c := &ContainerConfig{Type: EmulatorAWS, Port: "4566"}
+	assert.NoError(t, c.Validate())
+}
+
+func TestValidate_MinMaxPorts(t *testing.T) {
+	c := &ContainerConfig{Type: EmulatorAWS, Port: "1"}
+	assert.NoError(t, c.Validate())
+
+	c.Port = "65535"
+	assert.NoError(t, c.Validate())
+}
+
+func TestValidate_EmptyPort(t *testing.T) {
+	c := &ContainerConfig{Type: EmulatorAWS, Port: ""}
+	err := c.Validate()
+	assert.ErrorContains(t, err, "port is required")
+}
+
+func TestValidate_NonNumericPort(t *testing.T) {
+	c := &ContainerConfig{Type: EmulatorAWS, Port: "abc"}
+	err := c.Validate()
+	assert.ErrorContains(t, err, "not a valid number")
+}
+
+func TestValidate_PortZero(t *testing.T) {
+	c := &ContainerConfig{Type: EmulatorAWS, Port: "0"}
+	err := c.Validate()
+	assert.ErrorContains(t, err, "out of range")
+}
+
+func TestValidate_PortTooHigh(t *testing.T) {
+	c := &ContainerConfig{Type: EmulatorAWS, Port: "65536"}
+	err := c.Validate()
+	assert.ErrorContains(t, err, "out of range")
+}
+
+func TestValidate_NegativePort(t *testing.T) {
+	c := &ContainerConfig{Type: EmulatorAWS, Port: "-1"}
+	err := c.Validate()
+	assert.ErrorContains(t, err, "out of range")
+}


### PR DESCRIPTION
Ports like "abc" or "99999" previously passed through config loading silently and only failed at runtime. 

This will check port is numeric and within 1–65535, etc.

Fix DES-171