### PR TITLE
Add volume mount for emulator persistence

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,11 +14,17 @@ type Config struct {
 }
 
 func setDefaults() {
+	defaultVolume := ""
+	if cacheDir, err := os.UserCacheDir(); err == nil {
+		defaultVolume = filepath.Join(cacheDir, "lstk", "volume", "localstack-aws")
+	}
+
 	viper.SetDefault("containers", []map[string]any{
 		{
-			"type": "aws",
-			"tag":  "latest",
-			"port": "4566",
+			"type":   "aws",
+			"tag":    "latest",
+			"port":   "4566",
+			"volume": defaultVolume,
 		},
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,17 +14,11 @@ type Config struct {
 }
 
 func setDefaults() {
-	defaultVolume := ""
-	if cacheDir, err := os.UserCacheDir(); err == nil {
-		defaultVolume = filepath.Join(cacheDir, "lstk", "volume", "localstack-aws")
-	}
-
 	viper.SetDefault("containers", []map[string]any{
 		{
-			"type":   "aws",
-			"tag":    "latest",
-			"port":   "4566",
-			"volume": defaultVolume,
+			"type": "aws",
+			"tag":  "latest",
+			"port": "4566",
 		},
 	})
 }

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -33,11 +35,26 @@ var emulatorHealthPaths = map[EmulatorType]string{
 }
 
 type ContainerConfig struct {
-	Type EmulatorType `mapstructure:"type"`
-	Tag  string       `mapstructure:"tag"`
-	Port string       `mapstructure:"port"`
+	Type   EmulatorType `mapstructure:"type"`
+	Tag    string       `mapstructure:"tag"`
+	Port   string       `mapstructure:"port"`
+	Volume string       `mapstructure:"volume"`
 	// Env is a list of named environment references defined in the top-level [env.*] config sections.
 	Env []string `mapstructure:"env"`
+}
+
+// VolumeDir returns the host directory to mount into the container for persistence/caching.
+// If Volume is set in the config, it is returned as-is. Otherwise, a default is computed
+// from os.UserCacheDir()/lstk/volume/<container-name>.
+func (c *ContainerConfig) VolumeDir() (string, error) {
+	if c.Volume != "" {
+		return c.Volume, nil
+	}
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine cache directory: %w", err)
+	}
+	return filepath.Join(cacheDir, "lstk", "volume", c.Name()), nil
 }
 
 func (c *ContainerConfig) Validate() error {

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -97,6 +97,15 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			env = append(env, "DOCKER_HOST=unix:///var/run/docker.sock")
 		}
 
+		volumeDir, err := c.VolumeDir()
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(volumeDir, 0755); err != nil {
+			return fmt.Errorf("failed to create volume directory %s: %w", volumeDir, err)
+		}
+		binds = append(binds, runtime.BindMount{HostPath: volumeDir, ContainerPath: "/var/lib/localstack"})
+
 		containers[i] = runtime.ContainerConfig{
 			Image:         image,
 			Name:          containerName,

--- a/test/integration/awsconfig_test.go
+++ b/test/integration/awsconfig_test.go
@@ -22,6 +22,16 @@ import (
 func awsConfigEnv(t *testing.T) (env.Environ, string) {
 	t.Helper()
 	tmpHome := t.TempDir()
+	// Runs before t.TempDir() cleanup (LIFO order). The emulator runs as root
+	// inside the container, so files it writes into the volume are root-owned on
+	// Linux. Go's TempDir cleanup can't delete them, so we use a Docker container
+	// to remove them first.
+	t.Cleanup(func() {
+		volumeDir := filepath.Join(tmpHome, ".cache", "lstk", "volume")
+		if _, err := os.Stat(volumeDir); err == nil {
+			_ = exec.Command("docker", "run", "--rm", "-v", volumeDir+":/d", "alpine", "sh", "-c", "rm -rf /d/*").Run()
+		}
+	})
 	e := env.With(env.AuthToken, env.Get(env.AuthToken)).With(env.Home, tmpHome)
 	return e, tmpHome
 }

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -182,6 +182,11 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 		require.NotEmpty(t, mainBindings, "port 4566/tcp should be bound")
 		assert.Equal(t, "4566", mainBindings[0].HostPort)
 	})
+
+	t.Run("volume mount", func(t *testing.T) {
+		assert.True(t, hasBindTarget(inspect.HostConfig.Binds, "/var/lib/localstack"),
+			"expected volume bind mount to /var/lib/localstack, got: %v", inspect.HostConfig.Binds)
+	})
 }
 
 // containerEnvToMap converts a Docker container's []string env to a map.


### PR DESCRIPTION
Mount a host directory into `/var/lib/localstack` for caching and opt-in persistence (`PERSISTENCE=1`).

## Changes

- Add `Volume` field to `ContainerConfig` and `VolumeDir()` method for resolving the host path
- Default path: `os.UserCacheDir()/lstk/volume/<container-name>` (e.g. `~/Library/Caches/lstk/volume/localstack-aws`)
- Configurable via `volume` field in `[[containers]]` config
- Include `volume` in default config written on first run
- Create directory automatically (`os.MkdirAll`) before container start
- Add bind mount `volumeDir:/var/lib/localstack`

## Tests

- Integration subtest in `TestStartCommandSetsUpContainerCorrectly` verifying the volume bind mount targets `/var/lib/localstack`

## Related

- Closes [FLC-473](https://linear.app/localstack/issue/FLC-473)
- Closes [FLC-474](https://linear.app/localstack/issue/FLC-474)