### PR TITLE
Fix npm update not fetching the latest package version

### DIFF
--- a/internal/update/npm.go
+++ b/internal/update/npm.go
@@ -10,10 +10,10 @@ import (
 func updateNPM(ctx context.Context, sink output.Sink, projectDir string) error {
 	var cmd *exec.Cmd
 	if projectDir != "" {
-		cmd = exec.CommandContext(ctx, "npm", "install", "@localstack/lstk")
+		cmd = exec.CommandContext(ctx, "npm", "install", "@localstack/lstk@latest")
 		cmd.Dir = projectDir
 	} else {
-		cmd = exec.CommandContext(ctx, "npm", "install", "-g", "@localstack/lstk")
+		cmd = exec.CommandContext(ctx, "npm", "install", "-g", "@localstack/lstk@latest")
 	}
 	w := newLogLineWriter(sink, output.LogSourceNPM)
 	cmd.Stdout = w


### PR DESCRIPTION
This will change to `npm install @localstack/lstk@latest` to force npm to always resolve the newest published version. previously, `lstk update` via npm ran `npm install @localstack/lstk` which could be a no-op if npm considered the installed version satisfactory. 

Fix DES-173