### PR TITLE
Track telemetry events

### DIFF
--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -96,9 +96,9 @@ Create `test/integration/<name>_test.go` with:
 
 ## Telemetry
 
-Every new command must emit an `lstk_command` telemetry event. Wrap the command's `RunE` with `withCommandTelemetry(name, tel, func() string { return cfg.AuthToken }, fn)` — this handles timing, exit code, and error message automatically. The token resolver is called after the command runs, allowing commands like `login` to resolve the post-execution token.
+Every new command must emit an `lstk_command` telemetry event. Wrap the command's `RunE` with `commandWithTelemetry(name, tel, func() string { return cfg.AuthToken }, fn)` — this handles timing, exit code, and error message automatically. The token resolver is called after the command runs, allowing commands like `login` to resolve the post-execution token.
 
-Start and stop are exceptions: they emit `lstk_lifecycle` events in addition to `lstk_command`, so they manage their own telemetry manually instead of using `withCommandTelemetry`.
+Start and stop are exceptions: they emit `lstk_lifecycle` events in addition to `lstk_command`, so they manage their own telemetry manually instead of using `commandWithTelemetry`.
 
 ## Anti-patterns to avoid
 

--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -100,6 +100,8 @@ Every new command must emit an `lstk_command` telemetry event. Wrap the command'
 
 Start and stop are exceptions: they emit `lstk_lifecycle` events in addition to `lstk_command`, so they manage their own telemetry manually instead of using `commandWithTelemetry`.
 
+In the corresponding integration test, add an assertion that the `lstk_command` event was emitted.
+
 ## Anti-patterns to avoid
 
 - Do NOT put business logic in `cmd/` — the command file should be thin wiring only

--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -96,7 +96,7 @@ Create `test/integration/<name>_test.go` with:
 
 ## Telemetry
 
-Every new command must emit an `lstk_command` telemetry event. Wrap the command's `RunE` with `commandWithTelemetry(name, tel, func() string { return cfg.AuthToken }, fn)` — this handles timing, exit code, and error message automatically. The token resolver is called after the command runs, allowing commands like `login` to resolve the post-execution token.
+Every new command must emit an `lstk_command` telemetry event. Wrap the command's `RunE` with `commandWithTelemetry(name, tel, fn)` — this handles timing, exit code, and error message automatically.
 
 Start and stop are exceptions: they emit `lstk_lifecycle` events in addition to `lstk_command`, so they manage their own telemetry manually instead of using `commandWithTelemetry`.
 

--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -94,6 +94,12 @@ Create `test/integration/<name>_test.go` with:
 - Use `cleanup()` and `t.Cleanup(cleanup)` for container state
 - Use `context.WithTimeout` for all tests
 
+## Telemetry
+
+Every new command must emit an `lstk_command` telemetry event. Wrap the command's `RunE` with `withCommandTelemetry(name, tel, cfg.AuthToken, fn)` — this handles timing, exit code, and error message automatically. Pass `cfg.AuthToken` as the auth token; it is pre-resolved from keyring/env at startup.
+
+Start and stop are exceptions: they manage their own `commandEventID` for cross-event correlation with `lstk_lifecycle` events, so they emit the `lstk_command` event manually.
+
 ## Anti-patterns to avoid
 
 - Do NOT put business logic in `cmd/` — the command file should be thin wiring only

--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -96,9 +96,9 @@ Create `test/integration/<name>_test.go` with:
 
 ## Telemetry
 
-Every new command must emit an `lstk_command` telemetry event. Wrap the command's `RunE` with `withCommandTelemetry(name, tel, cfg.AuthToken, fn)` — this handles timing, exit code, and error message automatically. Pass `cfg.AuthToken` as the auth token; it is pre-resolved from keyring/env at startup.
+Every new command must emit an `lstk_command` telemetry event. Wrap the command's `RunE` with `withCommandTelemetry(name, tel, func() string { return cfg.AuthToken }, fn)` — this handles timing, exit code, and error message automatically. The token resolver is called after the command runs, allowing commands like `login` to resolve the post-execution token.
 
-Start and stop are exceptions: they manage their own `commandEventID` for cross-event correlation with `lstk_lifecycle` events, so they emit the `lstk_command` event manually.
+Start and stop are exceptions: they emit `lstk_lifecycle` events in addition to `lstk_command`, so they manage their own telemetry manually instead of using `withCommandTelemetry`.
 
 ## Anti-patterns to avoid
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,23 +4,25 @@ import (
 	"fmt"
 
 	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/env"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
-func newConfigCmd() *cobra.Command {
+func newConfigCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage configuration",
 	}
-	cmd.AddCommand(newConfigPathCmd())
+	cmd.AddCommand(newConfigPathCmd(cfg, tel))
 	return cmd
 }
 
-func newConfigPathCmd() *cobra.Command {
+func newConfigPathCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "path",
 		Short: "Print the configuration file path",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("config path", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
 			path, err := cmd.Flags().GetString("config")
 			if err != nil {
 				return err
@@ -37,6 +39,6 @@ func newConfigPathCmd() *cobra.Command {
 
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), configPath)
 			return err
-		},
+		}),
 	}
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -22,7 +22,7 @@ func newConfigPathCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "path",
 		Short: "Print the configuration file path",
-		RunE: commandWithTelemetry("config path", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("config path", tel, func(cmd *cobra.Command, args []string) error {
 			path, err := cmd.Flags().GetString("config")
 			if err != nil {
 				return err

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -19,22 +19,20 @@ func newLoginCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 		Short:   "Manage login",
 		Long:    "Manage login and store credentials in system keyring",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("login", tel, func() string {
-			tokenStorage, err := auth.NewTokenStorage(cfg.ForceFileKeyring, logger)
-			if err != nil {
-				return cfg.AuthToken
-			}
-			token, err := tokenStorage.GetAuthToken()
-			if err != nil {
-				return cfg.AuthToken
-			}
-			return token
-		}, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("login", tel, func(cmd *cobra.Command, args []string) error {
 			if !isInteractiveMode(cfg) {
 				return fmt.Errorf("login requires an interactive terminal")
 			}
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
-			return ui.RunLogin(cmd.Context(), version.Version(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL, logger)
+			if err := ui.RunLogin(cmd.Context(), version.Version(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL, logger); err != nil {
+				return err
+			}
+			if tokenStorage, err := auth.NewTokenStorage(cfg.ForceFileKeyring, logger); err == nil {
+				if token, err := tokenStorage.GetAuthToken(); err == nil && token != "" {
+					tel.SetAuthToken(token)
+				}
+			}
+			return nil
 		}),
 	}
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/localstack/lstk/internal/api"
+	"github.com/localstack/lstk/internal/auth"
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/log"
 	"github.com/localstack/lstk/internal/telemetry"
@@ -18,7 +19,17 @@ func newLoginCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 		Short:   "Manage login",
 		Long:    "Manage login and store credentials in system keyring",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("login", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("login", tel, func() string {
+			tokenStorage, err := auth.NewTokenStorage(cfg.ForceFileKeyring, logger)
+			if err != nil {
+				return cfg.AuthToken
+			}
+			token, err := tokenStorage.GetAuthToken()
+			if err != nil {
+				return cfg.AuthToken
+			}
+			return token
+		}, func(cmd *cobra.Command, args []string) error {
 			if !isInteractiveMode(cfg) {
 				return fmt.Errorf("login requires an interactive terminal")
 			}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -19,7 +19,7 @@ func newLoginCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 		Short:   "Manage login",
 		Long:    "Manage login and store credentials in system keyring",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("login", tel, func() string {
+		RunE: commandWithTelemetry("login", tel, func() string {
 			tokenStorage, err := auth.NewTokenStorage(cfg.ForceFileKeyring, logger)
 			if err != nil {
 				return cfg.AuthToken

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -6,23 +6,24 @@ import (
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/log"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/localstack/lstk/internal/version"
 	"github.com/spf13/cobra"
 )
 
-func newLoginCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
+func newLoginCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:     "login",
 		Short:   "Manage login",
 		Long:    "Manage login and store credentials in system keyring",
 		PreRunE: initConfig,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("login", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
 			if !isInteractiveMode(cfg) {
 				return fmt.Errorf("login requires an interactive terminal")
 			}
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
 			return ui.RunLogin(cmd.Context(), version.Version(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL, logger)
-		},
+		}),
 	}
 }

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -23,7 +23,7 @@ func newLogoutCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra
 		Use:     "logout",
 		Short:   "Remove stored authentication credentials",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("logout", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("logout", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
 			appConfig, err := config.Get()
 			if err != nil {

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -23,7 +23,7 @@ func newLogoutCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra
 		Use:     "logout",
 		Short:   "Remove stored authentication credentials",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("logout", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("logout", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
 			appConfig, err := config.Get()
 			if err != nil {

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -13,16 +13,17 @@ import (
 	"github.com/localstack/lstk/internal/log"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newLogoutCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
+func newLogoutCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:     "logout",
 		Short:   "Remove stored authentication credentials",
 		PreRunE: initConfig,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("logout", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
 			appConfig, err := config.Get()
 			if err != nil {
@@ -56,6 +57,6 @@ func newLogoutCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
 				}
 			}
 			return nil
-		},
+		}),
 	}
 }

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -23,7 +23,7 @@ func newLogoutCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra
 		Use:     "logout",
 		Short:   "Remove stored authentication credentials",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("logout", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("logout", tel, func(cmd *cobra.Command, args []string) error {
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
 			appConfig, err := config.Get()
 			if err != nil {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -19,7 +19,7 @@ func newLogsCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Show emulator logs",
 		Long:    "Show logs from the emulator. Use --follow to stream in real-time.",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("logs", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("logs", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
 			follow, err := cmd.Flags().GetBool("follow")
 			if err != nil {
 				return err

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -9,16 +9,17 @@ import (
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
-func newLogsCmd(cfg *env.Env) *cobra.Command {
+func newLogsCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "logs",
 		Short:   "Show emulator logs",
 		Long:    "Show logs from the emulator. Use --follow to stream in real-time.",
 		PreRunE: initConfig,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("logs", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
 			follow, err := cmd.Flags().GetBool("follow")
 			if err != nil {
 				return err
@@ -32,7 +33,7 @@ func newLogsCmd(cfg *env.Env) *cobra.Command {
 				return fmt.Errorf("failed to get config: %w", err)
 			}
 			return container.Logs(cmd.Context(), rt, output.NewPlainSink(os.Stdout), appConfig.Containers, follow)
-		},
+		}),
 	}
 	cmd.Flags().BoolP("follow", "f", false, "Follow log output")
 	return cmd

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -19,7 +19,7 @@ func newLogsCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Show emulator logs",
 		Long:    "Show logs from the emulator. Use --follow to stream in real-time.",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("logs", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("logs", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
 			follow, err := cmd.Flags().GetBool("follow")
 			if err != nil {
 				return err

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -19,7 +19,7 @@ func newLogsCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Show emulator logs",
 		Long:    "Show logs from the emulator. Use --follow to stream in real-time.",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("logs", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("logs", tel, func(cmd *cobra.Command, args []string) error {
 			follow, err := cmd.Flags().GetBool("follow")
 			if err != nil {
 				return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -146,10 +146,8 @@ func runStart(ctx context.Context, cmdFlags *pflag.FlagSet, rt runtime.Runtime, 
 	return runErr
 }
 
-// commandWithTelemetry wraps a RunE function so that an lstk_command event is
-// emitted after every invocation. Use this for commands that do not emit
-// lstk_lifecycle events (i.e. everything except start/stop, which manage their
-// own telemetry).
+// wraps a RunE function so that an lstk_command event is emitted after every invocation
+// used for commands that do not emit lstk_lifecycle events (i.e. status, logs, config path, etc)
 func commandWithTelemetry(name string, tel *telemetry.Client, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		startTime := time.Now()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 		newLogoutCmd(cfg, tel, logger),
 		newStatusCmd(cfg, tel),
 		newLogsCmd(cfg, tel),
-		newConfigCmd(),
+		newConfigCmd(cfg, tel),
 		newUpdateCmd(cfg, tel),
 	)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,6 +145,7 @@ func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemet
 		}
 	}
 	tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
+		EventID:     commandEventID,
 		Environment: tel.GetEnvironment(cfg.AuthToken),
 		Parameters:  telemetry.CommandParameters{Command: "start", Flags: flags},
 		Result: telemetry.CommandResult{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/config"
@@ -17,6 +18,7 @@ import (
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/localstack/lstk/internal/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
@@ -30,7 +32,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 			if err != nil {
 				return err
 			}
-			return runStart(cmd.Context(), rt, cfg, tel, logger)
+			return runStart(cmd, rt, cfg, tel, logger)
 		},
 	}
 
@@ -50,13 +52,13 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 
 	root.AddCommand(
 		newStartCmd(cfg, tel, logger),
-		newStopCmd(cfg),
-		newLoginCmd(cfg, logger),
-		newLogoutCmd(cfg, logger),
-		newStatusCmd(cfg),
-		newLogsCmd(cfg),
+		newStopCmd(cfg, tel),
+		newLoginCmd(cfg, tel, logger),
+		newLogoutCmd(cfg, tel, logger),
+		newStatusCmd(cfg, tel),
+		newLogsCmd(cfg, tel),
 		newConfigCmd(),
-		newUpdateCmd(cfg),
+		newUpdateCmd(cfg, tel),
 	)
 
 	return root
@@ -87,9 +89,7 @@ func Execute(ctx context.Context) error {
 	return nil
 }
 
-func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {
-	// TODO: replace map with a typed payload struct once event schema is finalised
-	tel.Emit(ctx, "cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
+func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, commandEventID string, logger log.Logger) error {
 
 	appConfig, err := config.Get()
 	if err != nil {
@@ -105,12 +105,82 @@ func runStart(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *teleme
 		Containers:       appConfig.Containers,
 		Env:              appConfig.Env,
 		Logger:           logger,
+		Telemetry:        tel,
+		TriggerEventID:   commandEventID,
 	}
 
 	if isInteractiveMode(cfg) {
 		return ui.Run(ctx, rt, version.Version(), opts)
 	}
 	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout), opts, false)
+}
+
+func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {
+	startTime := time.Now()
+	commandEventID := telemetry.NewEventID()
+
+	var flags []string
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		flags = append(flags, "--"+f.Name)
+	})
+
+	runErr := startEmulator(cmd.Context(), rt, cfg, tel, commandEventID, logger)
+
+	exitCode := 0
+	errorMsg := ""
+	if runErr != nil {
+		exitCode = 1
+		if !output.IsSilent(runErr) {
+			errorMsg = runErr.Error()
+		}
+	}
+	tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
+		Environment: tel.GetEnvironment(cfg.AuthToken),
+		Parameters:  telemetry.CommandParameters{Command: "start", Flags: flags},
+		Result: telemetry.CommandResult{
+			DurationMS: time.Since(startTime).Milliseconds(),
+			ExitCode:   exitCode,
+			ErrorMsg:   errorMsg,
+		},
+	}))
+
+	return runErr
+}
+
+// withCommandTelemetry wraps a RunE function so that an lstk_command event is
+// emitted after every invocation. Use this for commands that do not emit
+// lstk_lifecycle events (i.e. everything except start/stop, which manage their
+// own commandEventID for cross-event correlation).
+func withCommandTelemetry(name string, tel *telemetry.Client, authToken string, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		startTime := time.Now()
+		runErr := fn(cmd, args)
+
+		var flags []string
+		cmd.Flags().Visit(func(f *pflag.Flag) {
+			flags = append(flags, "--"+f.Name)
+		})
+
+		exitCode := 0
+		errorMsg := ""
+		if runErr != nil {
+			exitCode = 1
+			if !output.IsSilent(runErr) {
+				errorMsg = runErr.Error()
+			}
+		}
+		tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
+			Environment: tel.GetEnvironment(authToken),
+			Parameters:  telemetry.CommandParameters{Command: name, Flags: flags},
+			Result: telemetry.CommandResult{
+				DurationMS: time.Since(startTime).Milliseconds(),
+				ExitCode:   exitCode,
+				ErrorMsg:   errorMsg,
+			},
+		}))
+
+		return runErr
+	}
 }
 
 func isInteractiveMode(cfg *env.Env) bool {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,7 @@ func Execute(ctx context.Context) error {
 		}
 	}
 	cfg.AuthToken = resolvedToken
+	tel.SetAuthToken(resolvedToken)
 
 	root := NewRootCmd(cfg, tel, logger)
 	root.SilenceErrors = true
@@ -141,7 +142,7 @@ func runStart(ctx context.Context, cmdFlags *pflag.FlagSet, rt runtime.Runtime, 
 		errorMsg = runErr.Error()
 	}
 	tel.Emit(ctx, "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
-		Environment: tel.GetEnvironment(cfg.AuthToken),
+		Environment: tel.GetEnvironment(),
 		Parameters:  telemetry.CommandParameters{Command: "start", Flags: flags},
 		Result: telemetry.CommandResult{
 			DurationMS: time.Since(startTime).Milliseconds(),
@@ -157,7 +158,7 @@ func runStart(ctx context.Context, cmdFlags *pflag.FlagSet, rt runtime.Runtime, 
 // emitted after every invocation. Use this for commands that do not emit
 // lstk_lifecycle events (i.e. everything except start/stop, which manage their
 // own telemetry).
-func commandWithTelemetry(name string, tel *telemetry.Client, resolveAuthToken func() string, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
+func commandWithTelemetry(name string, tel *telemetry.Client, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		startTime := time.Now()
 		runErr := fn(cmd, args)
@@ -174,7 +175,7 @@ func commandWithTelemetry(name string, tel *telemetry.Client, resolveAuthToken f
 			errorMsg = runErr.Error()
 		}
 		tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
-			Environment: tel.GetEnvironment(resolveAuthToken()),
+			Environment: tel.GetEnvironment(),
 			Parameters:  telemetry.CommandParameters{Command: name, Flags: flags},
 			Result: telemetry.CommandResult{
 				DurationMS: time.Since(startTime).Milliseconds(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/localstack/lstk/internal/api"
+	"github.com/localstack/lstk/internal/auth"
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/container"
 	"github.com/localstack/lstk/internal/env"
@@ -75,6 +76,15 @@ func Execute(ctx context.Context) error {
 	}
 	defer cleanup()
 	logger.Info("lstk %s starting", version.Version())
+
+	// Resolve auth token for telemetry: keyring first, then env var.
+	resolvedToken := cfg.AuthToken
+	if tokenStorage, err := auth.NewTokenStorage(cfg.ForceFileKeyring, logger); err == nil {
+		if token, err := tokenStorage.GetAuthToken(); err == nil && token != "" {
+			resolvedToken = token
+		}
+	}
+	cfg.AuthToken = resolvedToken
 
 	root := NewRootCmd(cfg, tel, logger)
 	root.SilenceErrors = true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,15 +141,7 @@ func runStart(ctx context.Context, cmdFlags *pflag.FlagSet, rt runtime.Runtime, 
 		exitCode = 1
 		errorMsg = runErr.Error()
 	}
-	tel.Emit(ctx, "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
-		Environment: tel.GetEnvironment(),
-		Parameters:  telemetry.CommandParameters{Command: "start", Flags: flags},
-		Result: telemetry.CommandResult{
-			DurationMS: time.Since(startTime).Milliseconds(),
-			ExitCode:   exitCode,
-			ErrorMsg:   errorMsg,
-		},
-	}))
+	tel.EmitCommand(ctx, "start", flags, time.Since(startTime).Milliseconds(), exitCode, errorMsg)
 
 	return runErr
 }
@@ -174,15 +166,7 @@ func commandWithTelemetry(name string, tel *telemetry.Client, fn func(*cobra.Com
 			exitCode = 1
 			errorMsg = runErr.Error()
 		}
-		tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
-			Environment: tel.GetEnvironment(),
-			Parameters:  telemetry.CommandParameters{Command: name, Flags: flags},
-			Result: telemetry.CommandResult{
-				DurationMS: time.Since(startTime).Milliseconds(),
-				ExitCode:   exitCode,
-				ErrorMsg:   errorMsg,
-			},
-		}))
+		tel.EmitCommand(cmd.Context(), name, flags, time.Since(startTime).Milliseconds(), exitCode, errorMsg)
 
 		return runErr
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,11 +153,11 @@ func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemet
 	return runErr
 }
 
-// withCommandTelemetry wraps a RunE function so that an lstk_command event is
+// commandWithTelemetry wraps a RunE function so that an lstk_command event is
 // emitted after every invocation. Use this for commands that do not emit
 // lstk_lifecycle events (i.e. everything except start/stop, which manage their
 // own telemetry).
-func withCommandTelemetry(name string, tel *telemetry.Client, resolveAuthToken func() string, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
+func commandWithTelemetry(name string, tel *telemetry.Client, resolveAuthToken func() string, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		startTime := time.Now()
 		runErr := fn(cmd, args)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 			if err != nil {
 				return err
 			}
-			return runStart(cmd, rt, cfg, tel, logger)
+			return runStart(cmd.Context(), cmd.Flags(), rt, cfg, tel, logger)
 		},
 	}
 
@@ -124,15 +124,15 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout), opts, false)
 }
 
-func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {
+func runStart(ctx context.Context, cmdFlags *pflag.FlagSet, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {
 	startTime := time.Now()
 
 	var flags []string
-	cmd.Flags().Visit(func(f *pflag.Flag) {
+	cmdFlags.Visit(func(f *pflag.Flag) {
 		flags = append(flags, "--"+f.Name)
 	})
 
-	runErr := startEmulator(cmd.Context(), rt, cfg, tel, logger)
+	runErr := startEmulator(ctx, rt, cfg, tel, logger)
 
 	exitCode := 0
 	errorMsg := ""
@@ -140,7 +140,7 @@ func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemet
 		exitCode = 1
 		errorMsg = runErr.Error()
 	}
-	tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
+	tel.Emit(ctx, "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
 		Environment: tel.GetEnvironment(cfg.AuthToken),
 		Parameters:  telemetry.CommandParameters{Command: "start", Flags: flags},
 		Result: telemetry.CommandResult{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,9 +138,7 @@ func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemet
 	errorMsg := ""
 	if runErr != nil {
 		exitCode = 1
-		if !output.IsSilent(runErr) {
-			errorMsg = runErr.Error()
-		}
+		errorMsg = runErr.Error()
 	}
 	tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
 		Environment: tel.GetEnvironment(cfg.AuthToken),
@@ -173,9 +171,7 @@ func withCommandTelemetry(name string, tel *telemetry.Client, resolveAuthToken f
 		errorMsg := ""
 		if runErr != nil {
 			exitCode = 1
-			if !output.IsSilent(runErr) {
-				errorMsg = runErr.Error()
-			}
+			errorMsg = runErr.Error()
 		}
 		tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
 			Environment: tel.GetEnvironment(resolveAuthToken()),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,7 +99,7 @@ func Execute(ctx context.Context) error {
 	return nil
 }
 
-func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, commandEventID string, logger log.Logger) error {
+func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {
 
 	appConfig, err := config.Get()
 	if err != nil {
@@ -116,7 +116,6 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 		Env:              appConfig.Env,
 		Logger:           logger,
 		Telemetry:        tel,
-		TriggerEventID:   commandEventID,
 	}
 
 	if isInteractiveMode(cfg) {
@@ -127,14 +126,13 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 
 func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {
 	startTime := time.Now()
-	commandEventID := telemetry.NewEventID()
 
 	var flags []string
 	cmd.Flags().Visit(func(f *pflag.Flag) {
 		flags = append(flags, "--"+f.Name)
 	})
 
-	runErr := startEmulator(cmd.Context(), rt, cfg, tel, commandEventID, logger)
+	runErr := startEmulator(cmd.Context(), rt, cfg, tel, logger)
 
 	exitCode := 0
 	errorMsg := ""
@@ -145,7 +143,6 @@ func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemet
 		}
 	}
 	tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
-		EventID:     commandEventID,
 		Environment: tel.GetEnvironment(cfg.AuthToken),
 		Parameters:  telemetry.CommandParameters{Command: "start", Flags: flags},
 		Result: telemetry.CommandResult{
@@ -161,7 +158,7 @@ func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemet
 // withCommandTelemetry wraps a RunE function so that an lstk_command event is
 // emitted after every invocation. Use this for commands that do not emit
 // lstk_lifecycle events (i.e. everything except start/stop, which manage their
-// own commandEventID for cross-event correlation).
+// own telemetry).
 func withCommandTelemetry(name string, tel *telemetry.Client, resolveAuthToken func() string, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		startTime := time.Now()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,7 +161,7 @@ func runStart(cmd *cobra.Command, rt runtime.Runtime, cfg *env.Env, tel *telemet
 // emitted after every invocation. Use this for commands that do not emit
 // lstk_lifecycle events (i.e. everything except start/stop, which manage their
 // own commandEventID for cross-event correlation).
-func withCommandTelemetry(name string, tel *telemetry.Client, authToken string, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
+func withCommandTelemetry(name string, tel *telemetry.Client, resolveAuthToken func() string, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		startTime := time.Now()
 		runErr := fn(cmd, args)
@@ -180,7 +180,7 @@ func withCommandTelemetry(name string, tel *telemetry.Client, authToken string, 
 			}
 		}
 		tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
-			Environment: tel.GetEnvironment(authToken),
+			Environment: tel.GetEnvironment(resolveAuthToken()),
 			Parameters:  telemetry.CommandParameters{Command: name, Flags: flags},
 			Result: telemetry.CommandResult{
 				DurationMS: time.Since(startTime).Milliseconds(),

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -19,7 +19,7 @@ func newStartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 			if err != nil {
 				return err
 			}
-			return runStart(cmd, rt, cfg, tel, logger)
+			return runStart(cmd.Context(), cmd.Flags(), rt, cfg, tel, logger)
 		},
 	}
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -19,7 +19,7 @@ func newStartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 			if err != nil {
 				return err
 			}
-			return runStart(cmd.Context(), rt, cfg, tel, logger)
+			return runStart(cmd, rt, cfg, tel, logger)
 		},
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -11,17 +11,18 @@ import (
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newStatusCmd(cfg *env.Env) *cobra.Command {
+func newStatusCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:     "status",
 		Short:   "Show emulator status and deployed resources",
 		Long:    "Show the status of a running emulator and its deployed resources",
 		PreRunE: initConfig,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("status", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
@@ -38,6 +39,6 @@ func newStatusCmd(cfg *env.Env) *cobra.Command {
 				return ui.RunStatus(cmd.Context(), rt, appCfg.Containers, cfg.LocalStackHost, awsClient)
 			}
 			return container.Status(cmd.Context(), rt, appCfg.Containers, cfg.LocalStackHost, awsClient, output.NewPlainSink(os.Stdout))
-		},
+		}),
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -22,7 +22,7 @@ func newStatusCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Show emulator status and deployed resources",
 		Long:    "Show the status of a running emulator and its deployed resources",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("status", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("status", tel, func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -22,7 +22,7 @@ func newStatusCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Show emulator status and deployed resources",
 		Long:    "Show the status of a running emulator and its deployed resources",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("status", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("status", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -22,7 +22,7 @@ func newStatusCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Show emulator status and deployed resources",
 		Long:    "Show the status of a running emulator and its deployed resources",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("status", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("status", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -3,23 +3,27 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/container"
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
-func newStopCmd(cfg *env.Env) *cobra.Command {
+func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:     "stop",
 		Short:   "Stop emulator",
 		Long:    "Stop emulator and services",
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			startTime := time.Now()
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
@@ -29,11 +33,45 @@ func newStopCmd(cfg *env.Env) *cobra.Command {
 				return fmt.Errorf("failed to get config: %w", err)
 			}
 
-			if isInteractiveMode(cfg) {
-				return ui.RunStop(cmd.Context(), rt, appConfig.Containers)
+			commandEventID := telemetry.NewEventID()
+			stopOpts := container.StopOptions{
+				Telemetry:      tel,
+				TriggerEventID: commandEventID,
+				AuthToken:      cfg.AuthToken,
 			}
 
-			return container.Stop(cmd.Context(), rt, output.NewPlainSink(os.Stdout), appConfig.Containers)
+			var runErr error
+
+			if isInteractiveMode(cfg) {
+				runErr = ui.RunStop(cmd.Context(), rt, appConfig.Containers, stopOpts)
+			} else {
+				runErr = container.Stop(cmd.Context(), rt, output.NewPlainSink(os.Stdout), appConfig.Containers, stopOpts)
+			}
+
+			exitCode := 0
+			errorMsg := ""
+			if runErr != nil {
+				exitCode = 1
+				if !output.IsSilent(runErr) {
+					errorMsg = runErr.Error()
+				}
+			}
+
+			var flags []string
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				flags = append(flags, "--"+f.Name)
+			})
+			tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
+				Environment: tel.GetEnvironment(cfg.AuthToken),
+				Parameters:  telemetry.CommandParameters{Command: "stop", Flags: flags},
+				Result: telemetry.CommandResult{
+					DurationMS: time.Since(startTime).Milliseconds(),
+					ExitCode:   exitCode,
+					ErrorMsg:   errorMsg,
+				},
+			}))
+
+			return runErr
 		},
 	}
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -62,6 +62,7 @@ func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 				flags = append(flags, "--"+f.Name)
 			})
 			tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
+				EventID:     commandEventID,
 				Environment: tel.GetEnvironment(cfg.AuthToken),
 				Parameters:  telemetry.CommandParameters{Command: "stop", Flags: flags},
 				Result: telemetry.CommandResult{

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -56,15 +56,7 @@ func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 			cmd.Flags().Visit(func(f *pflag.Flag) {
 				flags = append(flags, "--"+f.Name)
 			})
-			tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
-				Environment: tel.GetEnvironment(),
-				Parameters:  telemetry.CommandParameters{Command: "stop", Flags: flags},
-				Result: telemetry.CommandResult{
-					DurationMS: time.Since(startTime).Milliseconds(),
-					ExitCode:   exitCode,
-					ErrorMsg:   errorMsg,
-				},
-			}))
+			tel.EmitCommand(cmd.Context(), "stop", flags, time.Since(startTime).Milliseconds(), exitCode, errorMsg)
 
 			return runErr
 		},

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -33,11 +33,9 @@ func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 				return fmt.Errorf("failed to get config: %w", err)
 			}
 
-			commandEventID := telemetry.NewEventID()
 			stopOpts := container.StopOptions{
-				Telemetry:      tel,
-				TriggerEventID: commandEventID,
-				AuthToken:      cfg.AuthToken,
+				Telemetry: tel,
+				AuthToken: cfg.AuthToken,
 			}
 
 			var runErr error
@@ -62,7 +60,6 @@ func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 				flags = append(flags, "--"+f.Name)
 			})
 			tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
-				EventID:     commandEventID,
 				Environment: tel.GetEnvironment(cfg.AuthToken),
 				Parameters:  telemetry.CommandParameters{Command: "stop", Flags: flags},
 				Result: telemetry.CommandResult{

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -35,7 +35,6 @@ func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 
 			stopOpts := container.StopOptions{
 				Telemetry: tel,
-				AuthToken: cfg.AuthToken,
 			}
 
 			var runErr error
@@ -58,7 +57,7 @@ func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 				flags = append(flags, "--"+f.Name)
 			})
 			tel.Emit(cmd.Context(), "lstk_command", telemetry.ToMap(telemetry.CommandEvent{
-				Environment: tel.GetEnvironment(cfg.AuthToken),
+				Environment: tel.GetEnvironment(),
 				Parameters:  telemetry.CommandParameters{Command: "stop", Flags: flags},
 				Result: telemetry.CommandResult{
 					DurationMS: time.Since(startTime).Milliseconds(),

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -50,9 +50,7 @@ func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 			errorMsg := ""
 			if runErr != nil {
 				exitCode = 1
-				if !output.IsSilent(runErr) {
-					errorMsg = runErr.Error()
-				}
+				errorMsg = runErr.Error()
 			}
 
 			var flags []string

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/localstack/lstk/internal/update"
 	"github.com/spf13/cobra"
 )
 
-func newUpdateCmd(cfg *env.Env) *cobra.Command {
+func newUpdateCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	var checkOnly bool
 
 	cmd := &cobra.Command{
@@ -18,12 +19,12 @@ func newUpdateCmd(cfg *env.Env) *cobra.Command {
 		Short:   "Update lstk to the latest version",
 		Long:    "Check for and apply updates to the lstk CLI. Respects the original installation method (Homebrew, npm, or direct binary).",
 		PreRunE: initConfig,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("update", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
 			if isInteractiveMode(cfg) {
 				return ui.RunUpdate(cmd.Context(), checkOnly, cfg.GitHubToken)
 			}
 			return update.Update(cmd.Context(), output.NewPlainSink(os.Stdout), checkOnly, cfg.GitHubToken)
-		},
+		}),
 	}
 
 	cmd.Flags().BoolVar(&checkOnly, "check", false, "Only check for updates without applying them")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -19,7 +19,7 @@ func newUpdateCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Update lstk to the latest version",
 		Long:    "Check for and apply updates to the lstk CLI. Respects the original installation method (Homebrew, npm, or direct binary).",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("update", tel, cfg.AuthToken, func(cmd *cobra.Command, args []string) error {
+		RunE: withCommandTelemetry("update", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
 			if isInteractiveMode(cfg) {
 				return ui.RunUpdate(cmd.Context(), checkOnly, cfg.GitHubToken)
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -19,7 +19,7 @@ func newUpdateCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Update lstk to the latest version",
 		Long:    "Check for and apply updates to the lstk CLI. Respects the original installation method (Homebrew, npm, or direct binary).",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("update", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("update", tel, func(cmd *cobra.Command, args []string) error {
 			if isInteractiveMode(cfg) {
 				return ui.RunUpdate(cmd.Context(), checkOnly, cfg.GitHubToken)
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -19,7 +19,7 @@ func newUpdateCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Update lstk to the latest version",
 		Long:    "Check for and apply updates to the lstk CLI. Respects the original installation method (Homebrew, npm, or direct binary).",
 		PreRunE: initConfig,
-		RunE: withCommandTelemetry("update", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
+		RunE: commandWithTelemetry("update", tel, func() string { return cfg.AuthToken }, func(cmd *cobra.Command, args []string) error {
 			if isInteractiveMode(cfg) {
 				return ui.RunUpdate(cmd.Context(), checkOnly, cfg.GitHubToken)
 			}

--- a/internal/container/info.go
+++ b/internal/container/info.go
@@ -1,0 +1,33 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/localstack/lstk/internal/telemetry"
+)
+
+func fetchLocalStackInfo(ctx context.Context, port string) (*telemetry.LocalStackInfo, error) {
+	url := fmt.Sprintf("http://localhost:%s/_localstack/info", port)
+	client := &http.Client{Timeout: 2 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	var info telemetry.LocalStackInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -23,6 +23,7 @@ import (
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/ports"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 )
 
 type postStartSetupFunc func(ctx context.Context, sink output.Sink, interactive bool, resolvedHost string) error
@@ -37,6 +38,47 @@ type StartOptions struct {
 	Containers       []config.ContainerConfig
 	Env              map[string]map[string]string
 	Logger           log.Logger
+	Telemetry        *telemetry.Client
+	TriggerEventID   string
+}
+
+// telCtx carries telemetry context for emitting per-container lifecycle events.
+type telCtx struct {
+	tel            *telemetry.Client
+	triggerEventID string
+	authToken      string
+}
+
+func (t telCtx) emitStartError(ctx context.Context, c runtime.ContainerConfig, errorCode, errorMsg string) {
+	if t.tel == nil {
+		return
+	}
+	t.tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
+		EventType:      telemetry.LifecycleStartError,
+		TriggerEventID: t.triggerEventID,
+		Environment:    t.tel.GetEnvironment(t.authToken),
+		Emulator:       c.EmulatorType,
+		Image:          c.Image,
+		ErrorCode:      errorCode,
+		ErrorMsg:       errorMsg,
+	}))
+}
+
+func (t telCtx) emitStartSuccess(ctx context.Context, c runtime.ContainerConfig, containerID string, durationMS int64, info *telemetry.LocalStackInfo) {
+	if t.tel == nil {
+		return
+	}
+	t.tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
+		EventType:      telemetry.LifecycleStartSuccess,
+		TriggerEventID: t.triggerEventID,
+		Environment:    t.tel.GetEnvironment(t.authToken),
+		Emulator:       c.EmulatorType,
+		Image:          c.Image,
+		ContainerID:    containerID,
+		DurationMS:     durationMS,
+		Pulled:         true, // TODO: track actual pull status from pullImages instead of hardcoding
+		LocalStackInfo: info,
+	}))
 }
 
 func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, interactive bool) error {
@@ -58,6 +100,12 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 
 	if hasDuplicateContainerTypes(opts.Containers) {
 		output.EmitWarning(sink, "Multiple emulators of the same type are defined in your config; this setup is not supported yet")
+	}
+
+	tel := telCtx{
+		tel:            opts.Telemetry,
+		triggerEventID: opts.TriggerEventID,
+		authToken:      opts.AuthToken,
 	}
 
 	containers := make([]runtime.ContainerConfig, len(opts.Containers))
@@ -110,6 +158,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		containers[i] = runtime.ContainerConfig{
 			Image:         image,
 			Name:          containerName,
+			EmulatorType:  string(c.Type),
 			Port:          c.Port,
 			ContainerPort: containerPort,
 			HealthPath:    healthPath,
@@ -121,7 +170,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		}
 	}
 
-	containers, err = selectContainersToStart(ctx, rt, sink, containers)
+	containers, err = selectContainersToStart(ctx, rt, sink, tel, containers)
 	if err != nil {
 		return err
 	}
@@ -131,15 +180,15 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 
 	// TODO validate license for tag "latest" without resolving the actual image version,
 	// and avoid pulling all images first
-	if err := pullImages(ctx, rt, sink, containers); err != nil {
+	if err := pullImages(ctx, rt, sink, tel, containers); err != nil {
 		return err
 	}
 
-	if err := validateLicenses(ctx, rt, sink, opts, containers, token); err != nil {
+	if err := validateLicenses(ctx, rt, sink, opts, tel, containers, token); err != nil {
 		return err
 	}
 
-	if err := startContainers(ctx, rt, sink, containers); err != nil {
+	if err := startContainers(ctx, rt, sink, tel, containers); err != nil {
 		return err
 	}
 
@@ -188,7 +237,7 @@ func emitPostStartPointers(sink output.Sink, resolvedHost, webAppURL string) {
 	output.EmitSecondary(sink, tips[rand.IntN(len(tips))])
 }
 
-func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []runtime.ContainerConfig) error {
+func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel telCtx, containers []runtime.ContainerConfig) error {
 	for _, c := range containers {
 		// Remove any existing stopped container with the same name
 		if err := rt.Remove(ctx, c.Name); err != nil && !errdefs.IsNotFound(err) {
@@ -209,6 +258,7 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, conta
 				Title:   fmt.Sprintf("Failed to pull %s", c.Image),
 				Summary: err.Error(),
 			})
+			tel.emitStartError(ctx, c, telemetry.ErrCodeImagePullFailed, err.Error())
 			return output.NewSilentError(fmt.Errorf("failed to pull image %s: %w", c.Image, err))
 		}
 		output.EmitSpinnerStop(sink)
@@ -217,35 +267,41 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, conta
 	return nil
 }
 
-func validateLicenses(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, containers []runtime.ContainerConfig, token string) error {
+func validateLicenses(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel telCtx, containers []runtime.ContainerConfig, token string) error {
 	for _, c := range containers {
-		if err := validateLicense(ctx, rt, sink, opts, c, token); err != nil {
+		if err := validateLicense(ctx, rt, sink, opts, tel, c, token); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func startContainers(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []runtime.ContainerConfig) error {
+func startContainers(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel telCtx, containers []runtime.ContainerConfig) error {
 	for _, c := range containers {
+		startTime := time.Now()
 		output.EmitStatus(sink, "starting", c.Name, "")
 		containerID, err := rt.Start(ctx, c)
 		if err != nil {
+			tel.emitStartError(ctx, c, telemetry.ErrCodeStartFailed, err.Error())
 			return fmt.Errorf("failed to start LocalStack: %w", err)
 		}
 
 		output.EmitStatus(sink, "waiting", c.Name, "")
 		healthURL := fmt.Sprintf("http://localhost:%s%s", c.Port, c.HealthPath)
 		if err := awaitStartup(ctx, rt, sink, containerID, "LocalStack", healthURL); err != nil {
+			tel.emitStartError(ctx, c, telemetry.ErrCodeStartFailed, err.Error())
 			return err
 		}
 
 		output.EmitStatus(sink, "ready", c.Name, fmt.Sprintf("containerId: %s", containerID[:12]))
+
+		lsInfo, _ := fetchLocalStackInfo(ctx, c.Port)
+		tel.emitStartSuccess(ctx, c, containerID[:12], time.Since(startTime).Milliseconds(), lsInfo)
 	}
 	return nil
 }
 
-func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []runtime.ContainerConfig) ([]runtime.ContainerConfig, error) {
+func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel telCtx, containers []runtime.ContainerConfig) ([]runtime.ContainerConfig, error) {
 	var filtered []runtime.ContainerConfig
 	for _, c := range containers {
 		running, err := rt.IsRunning(ctx, c.Name)
@@ -258,6 +314,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 		}
 		if err := ports.CheckAvailable(c.Port); err != nil {
 			emitPortInUseError(sink, c.Port)
+			tel.emitStartError(ctx, c, telemetry.ErrCodePortConflict, fmt.Sprintf("port %s already in use", c.Port))
 			return nil, output.NewSilentError(err)
 		}
 		filtered = append(filtered, c)
@@ -280,7 +337,7 @@ func emitPortInUseError(sink output.Sink, port string) {
 	})
 }
 
-func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, containerConfig runtime.ContainerConfig, token string) error {
+func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel telCtx, containerConfig runtime.ContainerConfig, token string) error {
 	version := containerConfig.Tag
 	if version == "" || version == "latest" {
 		actualVersion, err := rt.GetImageVersion(ctx, containerConfig.Image)
@@ -313,6 +370,7 @@ func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, 
 		if errors.As(err, &licErr) && licErr.Detail != "" {
 			opts.Logger.Error("license server response (HTTP %d): %s", licErr.Status, licErr.Detail)
 		}
+		tel.emitStartError(ctx, containerConfig, telemetry.ErrCodeLicenseInvalid, err.Error())
 		return fmt.Errorf("license validation failed for %s:%s: %w", containerConfig.ProductName, version, err)
 	}
 

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -41,19 +41,13 @@ type StartOptions struct {
 	Telemetry        *telemetry.Client
 }
 
-// telCtx carries telemetry context for emitting per-container lifecycle events.
-type telCtx struct {
-	tel       *telemetry.Client
-	authToken string
-}
-
-func (t telCtx) emitEmulatorStartError(ctx context.Context, c runtime.ContainerConfig, errorCode, errorMsg string) {
-	if t.tel == nil {
+func emitEmulatorStartError(ctx context.Context, tel *telemetry.Client, c runtime.ContainerConfig, errorCode, errorMsg string) {
+	if tel == nil {
 		return
 	}
-	t.tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
+	tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
 		EventType:   telemetry.LifecycleStartError,
-		Environment: t.tel.GetEnvironment(t.authToken),
+		Environment: tel.GetEnvironment(),
 		Emulator:    c.EmulatorType,
 		Image:       c.Image,
 		ErrorCode:   errorCode,
@@ -61,13 +55,13 @@ func (t telCtx) emitEmulatorStartError(ctx context.Context, c runtime.ContainerC
 	}))
 }
 
-func (t telCtx) emitEmulatorStartSuccess(ctx context.Context, c runtime.ContainerConfig, containerID string, durationMS int64, info *telemetry.LocalStackInfo) {
-	if t.tel == nil {
+func emitEmulatorStartSuccess(ctx context.Context, tel *telemetry.Client, c runtime.ContainerConfig, containerID string, durationMS int64, info *telemetry.LocalStackInfo) {
+	if tel == nil {
 		return
 	}
-	t.tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
+	tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
 		EventType:      telemetry.LifecycleStartSuccess,
-		Environment:    t.tel.GetEnvironment(t.authToken),
+		Environment:    tel.GetEnvironment(),
 		Emulator:       c.EmulatorType,
 		Image:          c.Image,
 		ContainerID:    containerID,
@@ -94,14 +88,15 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		return err
 	}
 
+	if opts.Telemetry != nil {
+		opts.Telemetry.SetAuthToken(token)
+	}
+
 	if hasDuplicateContainerTypes(opts.Containers) {
 		output.EmitWarning(sink, "Multiple emulators of the same type are defined in your config; this setup is not supported yet")
 	}
 
-	tel := telCtx{
-		tel:       opts.Telemetry,
-		authToken: token,
-	}
+	tel := opts.Telemetry
 
 	containers := make([]runtime.ContainerConfig, len(opts.Containers))
 	for i, c := range opts.Containers {
@@ -232,7 +227,7 @@ func emitPostStartPointers(sink output.Sink, resolvedHost, webAppURL string) {
 	output.EmitSecondary(sink, tips[rand.IntN(len(tips))])
 }
 
-func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel telCtx, containers []runtime.ContainerConfig) error {
+func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig) error {
 	for _, c := range containers {
 		// Remove any existing stopped container with the same name
 		if err := rt.Remove(ctx, c.Name); err != nil && !errdefs.IsNotFound(err) {
@@ -253,7 +248,7 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel t
 				Title:   fmt.Sprintf("Failed to pull %s", c.Image),
 				Summary: err.Error(),
 			})
-			tel.emitEmulatorStartError(ctx, c, telemetry.ErrCodeImagePullFailed, err.Error())
+			emitEmulatorStartError(ctx, tel, c, telemetry.ErrCodeImagePullFailed, err.Error())
 			return output.NewSilentError(fmt.Errorf("failed to pull image %s: %w", c.Image, err))
 		}
 		output.EmitSpinnerStop(sink)
@@ -262,7 +257,7 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel t
 	return nil
 }
 
-func validateLicenses(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel telCtx, containers []runtime.ContainerConfig, token string) error {
+func validateLicenses(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel *telemetry.Client, containers []runtime.ContainerConfig, token string) error {
 	for _, c := range containers {
 		if err := validateLicense(ctx, rt, sink, opts, tel, c, token); err != nil {
 			return err
@@ -271,32 +266,32 @@ func validateLicenses(ctx context.Context, rt runtime.Runtime, sink output.Sink,
 	return nil
 }
 
-func startContainers(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel telCtx, containers []runtime.ContainerConfig) error {
+func startContainers(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig) error {
 	for _, c := range containers {
 		startTime := time.Now()
 		output.EmitStatus(sink, "starting", c.Name, "")
 		containerID, err := rt.Start(ctx, c)
 		if err != nil {
-			tel.emitEmulatorStartError(ctx, c, telemetry.ErrCodeStartFailed, err.Error())
+			emitEmulatorStartError(ctx, tel, c, telemetry.ErrCodeStartFailed, err.Error())
 			return fmt.Errorf("failed to start LocalStack: %w", err)
 		}
 
 		output.EmitStatus(sink, "waiting", c.Name, "")
 		healthURL := fmt.Sprintf("http://localhost:%s%s", c.Port, c.HealthPath)
 		if err := awaitStartup(ctx, rt, sink, containerID, "LocalStack", healthURL); err != nil {
-			tel.emitEmulatorStartError(ctx, c, telemetry.ErrCodeStartFailed, err.Error())
+			emitEmulatorStartError(ctx, tel, c, telemetry.ErrCodeStartFailed, err.Error())
 			return err
 		}
 
 		output.EmitStatus(sink, "ready", c.Name, fmt.Sprintf("containerId: %s", containerID[:12]))
 
 		lsInfo, _ := fetchLocalStackInfo(ctx, c.Port)
-		tel.emitEmulatorStartSuccess(ctx, c, containerID[:12], time.Since(startTime).Milliseconds(), lsInfo)
+		emitEmulatorStartSuccess(ctx, tel, c, containerID[:12], time.Since(startTime).Milliseconds(), lsInfo)
 	}
 	return nil
 }
 
-func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel telCtx, containers []runtime.ContainerConfig) ([]runtime.ContainerConfig, error) {
+func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig) ([]runtime.ContainerConfig, error) {
 	var filtered []runtime.ContainerConfig
 	for _, c := range containers {
 		running, err := rt.IsRunning(ctx, c.Name)
@@ -309,7 +304,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 		}
 		if err := ports.CheckAvailable(c.Port); err != nil {
 			emitPortInUseError(sink, c.Port)
-			tel.emitEmulatorStartError(ctx, c, telemetry.ErrCodePortConflict, err.Error())
+			emitEmulatorStartError(ctx, tel, c, telemetry.ErrCodePortConflict, err.Error())
 			return nil, output.NewSilentError(err)
 		}
 		filtered = append(filtered, c)
@@ -332,7 +327,7 @@ func emitPortInUseError(sink output.Sink, port string) {
 	})
 }
 
-func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel telCtx, containerConfig runtime.ContainerConfig, token string) error {
+func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel *telemetry.Client, containerConfig runtime.ContainerConfig, token string) error {
 	version := containerConfig.Tag
 	if version == "" || version == "latest" {
 		actualVersion, err := rt.GetImageVersion(ctx, containerConfig.Image)
@@ -365,7 +360,7 @@ func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, 
 		if errors.As(err, &licErr) && licErr.Detail != "" {
 			opts.Logger.Error("license server response (HTTP %d): %s", licErr.Status, licErr.Detail)
 		}
-		tel.emitEmulatorStartError(ctx, containerConfig, telemetry.ErrCodeLicenseInvalid, err.Error())
+		emitEmulatorStartError(ctx, tel, containerConfig, telemetry.ErrCodeLicenseInvalid, err.Error())
 		return fmt.Errorf("license validation failed for %s:%s: %w", containerConfig.ProductName, version, err)
 	}
 

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -38,15 +38,13 @@ type StartOptions struct {
 	Containers       []config.ContainerConfig
 	Env              map[string]map[string]string
 	Logger           log.Logger
-	Telemetry        *telemetry.Client
-	TriggerEventID   string
+	Telemetry *telemetry.Client
 }
 
 // telCtx carries telemetry context for emitting per-container lifecycle events.
 type telCtx struct {
-	tel            *telemetry.Client
-	triggerEventID string
-	authToken      string
+	tel       *telemetry.Client
+	authToken string
 }
 
 func (t telCtx) emitStartError(ctx context.Context, c runtime.ContainerConfig, errorCode, errorMsg string) {
@@ -54,9 +52,8 @@ func (t telCtx) emitStartError(ctx context.Context, c runtime.ContainerConfig, e
 		return
 	}
 	t.tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
-		EventType:      telemetry.LifecycleStartError,
-		TriggerEventID: t.triggerEventID,
-		Environment:    t.tel.GetEnvironment(t.authToken),
+		EventType:   telemetry.LifecycleStartError,
+		Environment: t.tel.GetEnvironment(t.authToken),
 		Emulator:       c.EmulatorType,
 		Image:          c.Image,
 		ErrorCode:      errorCode,
@@ -69,9 +66,8 @@ func (t telCtx) emitStartSuccess(ctx context.Context, c runtime.ContainerConfig,
 		return
 	}
 	t.tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
-		EventType:      telemetry.LifecycleStartSuccess,
-		TriggerEventID: t.triggerEventID,
-		Environment:    t.tel.GetEnvironment(t.authToken),
+		EventType:   telemetry.LifecycleStartSuccess,
+		Environment: t.tel.GetEnvironment(t.authToken),
 		Emulator:       c.EmulatorType,
 		Image:          c.Image,
 		ContainerID:    containerID,
@@ -103,9 +99,8 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 	}
 
 	tel := telCtx{
-		tel:            opts.Telemetry,
-		triggerEventID: opts.TriggerEventID,
-		authToken:      token,
+		tel:       opts.Telemetry,
+		authToken: token,
 	}
 
 	containers := make([]runtime.ContainerConfig, len(opts.Containers))

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -38,7 +38,7 @@ type StartOptions struct {
 	Containers       []config.ContainerConfig
 	Env              map[string]map[string]string
 	Logger           log.Logger
-	Telemetry *telemetry.Client
+	Telemetry        *telemetry.Client
 }
 
 // telCtx carries telemetry context for emitting per-container lifecycle events.
@@ -47,27 +47,27 @@ type telCtx struct {
 	authToken string
 }
 
-func (t telCtx) emitStartError(ctx context.Context, c runtime.ContainerConfig, errorCode, errorMsg string) {
+func (t telCtx) emitEmulatorStartError(ctx context.Context, c runtime.ContainerConfig, errorCode, errorMsg string) {
 	if t.tel == nil {
 		return
 	}
 	t.tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
 		EventType:   telemetry.LifecycleStartError,
 		Environment: t.tel.GetEnvironment(t.authToken),
-		Emulator:       c.EmulatorType,
-		Image:          c.Image,
-		ErrorCode:      errorCode,
-		ErrorMsg:       errorMsg,
+		Emulator:    c.EmulatorType,
+		Image:       c.Image,
+		ErrorCode:   errorCode,
+		ErrorMsg:    errorMsg,
 	}))
 }
 
-func (t telCtx) emitStartSuccess(ctx context.Context, c runtime.ContainerConfig, containerID string, durationMS int64, info *telemetry.LocalStackInfo) {
+func (t telCtx) emitEmulatorStartSuccess(ctx context.Context, c runtime.ContainerConfig, containerID string, durationMS int64, info *telemetry.LocalStackInfo) {
 	if t.tel == nil {
 		return
 	}
 	t.tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
-		EventType:   telemetry.LifecycleStartSuccess,
-		Environment: t.tel.GetEnvironment(t.authToken),
+		EventType:      telemetry.LifecycleStartSuccess,
+		Environment:    t.tel.GetEnvironment(t.authToken),
 		Emulator:       c.EmulatorType,
 		Image:          c.Image,
 		ContainerID:    containerID,
@@ -253,7 +253,7 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel t
 				Title:   fmt.Sprintf("Failed to pull %s", c.Image),
 				Summary: err.Error(),
 			})
-			tel.emitStartError(ctx, c, telemetry.ErrCodeImagePullFailed, err.Error())
+			tel.emitEmulatorStartError(ctx, c, telemetry.ErrCodeImagePullFailed, err.Error())
 			return output.NewSilentError(fmt.Errorf("failed to pull image %s: %w", c.Image, err))
 		}
 		output.EmitSpinnerStop(sink)
@@ -277,21 +277,21 @@ func startContainers(ctx context.Context, rt runtime.Runtime, sink output.Sink, 
 		output.EmitStatus(sink, "starting", c.Name, "")
 		containerID, err := rt.Start(ctx, c)
 		if err != nil {
-			tel.emitStartError(ctx, c, telemetry.ErrCodeStartFailed, err.Error())
+			tel.emitEmulatorStartError(ctx, c, telemetry.ErrCodeStartFailed, err.Error())
 			return fmt.Errorf("failed to start LocalStack: %w", err)
 		}
 
 		output.EmitStatus(sink, "waiting", c.Name, "")
 		healthURL := fmt.Sprintf("http://localhost:%s%s", c.Port, c.HealthPath)
 		if err := awaitStartup(ctx, rt, sink, containerID, "LocalStack", healthURL); err != nil {
-			tel.emitStartError(ctx, c, telemetry.ErrCodeStartFailed, err.Error())
+			tel.emitEmulatorStartError(ctx, c, telemetry.ErrCodeStartFailed, err.Error())
 			return err
 		}
 
 		output.EmitStatus(sink, "ready", c.Name, fmt.Sprintf("containerId: %s", containerID[:12]))
 
 		lsInfo, _ := fetchLocalStackInfo(ctx, c.Port)
-		tel.emitStartSuccess(ctx, c, containerID[:12], time.Since(startTime).Milliseconds(), lsInfo)
+		tel.emitEmulatorStartSuccess(ctx, c, containerID[:12], time.Since(startTime).Milliseconds(), lsInfo)
 	}
 	return nil
 }
@@ -309,7 +309,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 		}
 		if err := ports.CheckAvailable(c.Port); err != nil {
 			emitPortInUseError(sink, c.Port)
-			tel.emitStartError(ctx, c, telemetry.ErrCodePortConflict, fmt.Sprintf("port %s already in use", c.Port))
+			tel.emitEmulatorStartError(ctx, c, telemetry.ErrCodePortConflict, err.Error())
 			return nil, output.NewSilentError(err)
 		}
 		filtered = append(filtered, c)
@@ -365,7 +365,7 @@ func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, 
 		if errors.As(err, &licErr) && licErr.Detail != "" {
 			opts.Logger.Error("license server response (HTTP %d): %s", licErr.Status, licErr.Detail)
 		}
-		tel.emitStartError(ctx, containerConfig, telemetry.ErrCodeLicenseInvalid, err.Error())
+		tel.emitEmulatorStartError(ctx, containerConfig, telemetry.ErrCodeLicenseInvalid, err.Error())
 		return fmt.Errorf("license validation failed for %s:%s: %w", containerConfig.ProductName, version, err)
 	}
 

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -45,30 +45,28 @@ func emitEmulatorStartError(ctx context.Context, tel *telemetry.Client, c runtim
 	if tel == nil {
 		return
 	}
-	tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
-		EventType:   telemetry.LifecycleStartError,
-		Environment: tel.GetEnvironment(),
-		Emulator:    c.EmulatorType,
-		Image:       c.Image,
-		ErrorCode:   errorCode,
-		ErrorMsg:    errorMsg,
-	}))
+	tel.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
+		EventType: telemetry.LifecycleStartError,
+		Emulator:  c.EmulatorType,
+		Image:     c.Image,
+		ErrorCode: errorCode,
+		ErrorMsg:  errorMsg,
+	})
 }
 
 func emitEmulatorStartSuccess(ctx context.Context, tel *telemetry.Client, c runtime.ContainerConfig, containerID string, durationMS int64, info *telemetry.LocalStackInfo) {
 	if tel == nil {
 		return
 	}
-	tel.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
+	tel.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
 		EventType:      telemetry.LifecycleStartSuccess,
-		Environment:    tel.GetEnvironment(),
 		Emulator:       c.EmulatorType,
 		Image:          c.Image,
 		ContainerID:    containerID,
 		DurationMS:     durationMS,
 		Pulled:         true, // TODO: track actual pull status from pullImages instead of hardcoding
 		LocalStackInfo: info,
-	}))
+	})
 }
 
 func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, interactive bool) error {

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -54,7 +54,7 @@ func emitEmulatorStartError(ctx context.Context, tel *telemetry.Client, c runtim
 	})
 }
 
-func emitEmulatorStartSuccess(ctx context.Context, tel *telemetry.Client, c runtime.ContainerConfig, containerID string, durationMS int64, info *telemetry.LocalStackInfo) {
+func emitEmulatorStartSuccess(ctx context.Context, tel *telemetry.Client, c runtime.ContainerConfig, containerID string, durationMS int64, pulled bool, info *telemetry.LocalStackInfo) {
 	if tel == nil {
 		return
 	}
@@ -64,7 +64,7 @@ func emitEmulatorStartSuccess(ctx context.Context, tel *telemetry.Client, c runt
 		Image:          c.Image,
 		ContainerID:    containerID,
 		DurationMS:     durationMS,
-		Pulled:         true, // TODO: track actual pull status from pullImages instead of hardcoding
+		Pulled:         pulled,
 		LocalStackInfo: info,
 	})
 }
@@ -168,7 +168,8 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 
 	// TODO validate license for tag "latest" without resolving the actual image version,
 	// and avoid pulling all images first
-	if err := pullImages(ctx, rt, sink, tel, containers); err != nil {
+	pulled, err := pullImages(ctx, rt, sink, tel, containers)
+	if err != nil {
 		return err
 	}
 
@@ -176,7 +177,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		return err
 	}
 
-	if err := startContainers(ctx, rt, sink, tel, containers); err != nil {
+	if err := startContainers(ctx, rt, sink, tel, containers, pulled); err != nil {
 		return err
 	}
 
@@ -225,11 +226,12 @@ func emitPostStartPointers(sink output.Sink, resolvedHost, webAppURL string) {
 	output.EmitSecondary(sink, tips[rand.IntN(len(tips))])
 }
 
-func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig) error {
+func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig) (map[string]bool, error) {
+	pulled := make(map[string]bool, len(containers))
 	for _, c := range containers {
 		// Remove any existing stopped container with the same name
 		if err := rt.Remove(ctx, c.Name); err != nil && !errdefs.IsNotFound(err) {
-			return fmt.Errorf("failed to remove existing container %s: %w", c.Name, err)
+			return nil, fmt.Errorf("failed to remove existing container %s: %w", c.Name, err)
 		}
 
 		output.EmitSpinnerStart(sink, fmt.Sprintf("Pulling %s", c.Image))
@@ -247,12 +249,13 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *
 				Summary: err.Error(),
 			})
 			emitEmulatorStartError(ctx, tel, c, telemetry.ErrCodeImagePullFailed, err.Error())
-			return output.NewSilentError(fmt.Errorf("failed to pull image %s: %w", c.Image, err))
+			return nil, output.NewSilentError(fmt.Errorf("failed to pull image %s: %w", c.Image, err))
 		}
 		output.EmitSpinnerStop(sink)
 		output.EmitSuccess(sink, fmt.Sprintf("Pulled %s", c.Image))
+		pulled[c.Name] = true
 	}
-	return nil
+	return pulled, nil
 }
 
 func validateLicenses(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel *telemetry.Client, containers []runtime.ContainerConfig, token string) error {
@@ -264,7 +267,7 @@ func validateLicenses(ctx context.Context, rt runtime.Runtime, sink output.Sink,
 	return nil
 }
 
-func startContainers(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig) error {
+func startContainers(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig, pulled map[string]bool) error {
 	for _, c := range containers {
 		startTime := time.Now()
 		output.EmitStatus(sink, "starting", c.Name, "")
@@ -284,7 +287,7 @@ func startContainers(ctx context.Context, rt runtime.Runtime, sink output.Sink, 
 		output.EmitStatus(sink, "ready", c.Name, fmt.Sprintf("containerId: %s", containerID[:12]))
 
 		lsInfo, _ := fetchLocalStackInfo(ctx, c.Port)
-		emitEmulatorStartSuccess(ctx, tel, c, containerID[:12], time.Since(startTime).Milliseconds(), lsInfo)
+		emitEmulatorStartSuccess(ctx, tel, c, containerID[:12], time.Since(startTime).Milliseconds(), pulled[c.Name], lsInfo)
 	}
 	return nil
 }

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -105,7 +105,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 	tel := telCtx{
 		tel:            opts.Telemetry,
 		triggerEventID: opts.TriggerEventID,
-		authToken:      opts.AuthToken,
+		authToken:      token,
 	}
 
 	containers := make([]runtime.ContainerConfig, len(opts.Containers))

--- a/internal/container/stop.go
+++ b/internal/container/stop.go
@@ -8,11 +8,18 @@ import (
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 )
 
-func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []config.ContainerConfig) error {
-	const stopTimeout = 30 * time.Second
+// StopOptions carries optional telemetry context for the stop command.
+type StopOptions struct {
+	Telemetry      *telemetry.Client
+	TriggerEventID string
+	AuthToken      string
+}
 
+func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []config.ContainerConfig, opts StopOptions) error {
+	const stopTimeout = 30 * time.Second
 	for _, c := range containers {
 		name := c.Name()
 
@@ -25,6 +32,12 @@ func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 		if !running {
 			return fmt.Errorf("LocalStack is not running")
 		}
+
+		// Fetch localstack info before stopping so it can be included in telemetry.
+		lsInfo, _ := fetchLocalStackInfo(ctx, c.Port)
+
+		stopStart := time.Now()
+
 		output.EmitSpinnerStart(sink, "Stopping LocalStack...")
 		stopCtx, stopCancel := context.WithTimeout(ctx, stopTimeout)
 		if err := rt.Stop(stopCtx, name); err != nil {
@@ -35,6 +48,17 @@ func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 		stopCancel()
 		output.EmitSpinnerStop(sink)
 		output.EmitSuccess(sink, "LocalStack stopped")
+
+		if opts.Telemetry != nil {
+			opts.Telemetry.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
+				EventType:      telemetry.LifecycleStop,
+				TriggerEventID: opts.TriggerEventID,
+				Environment:    opts.Telemetry.GetEnvironment(opts.AuthToken),
+				Emulator:       string(c.Type),
+				DurationMS:     time.Since(stopStart).Milliseconds(),
+				LocalStackInfo: lsInfo,
+			}))
+		}
 	}
 
 	return nil

--- a/internal/container/stop.go
+++ b/internal/container/stop.go
@@ -48,13 +48,12 @@ func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 		output.EmitSuccess(sink, "LocalStack stopped")
 
 		if opts.Telemetry != nil {
-			opts.Telemetry.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
+			opts.Telemetry.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
 				EventType:      telemetry.LifecycleStop,
-				Environment:    opts.Telemetry.GetEnvironment(),
 				Emulator:       string(c.Type),
 				DurationMS:     time.Since(stopStart).Milliseconds(),
 				LocalStackInfo: lsInfo,
-			}))
+			})
 		}
 	}
 

--- a/internal/container/stop.go
+++ b/internal/container/stop.go
@@ -14,7 +14,6 @@ import (
 // StopOptions carries optional telemetry context for the stop command.
 type StopOptions struct {
 	Telemetry *telemetry.Client
-	AuthToken string
 }
 
 func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []config.ContainerConfig, opts StopOptions) error {
@@ -51,7 +50,7 @@ func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 		if opts.Telemetry != nil {
 			opts.Telemetry.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
 				EventType:      telemetry.LifecycleStop,
-				Environment:    opts.Telemetry.GetEnvironment(opts.AuthToken),
+				Environment:    opts.Telemetry.GetEnvironment(),
 				Emulator:       string(c.Type),
 				DurationMS:     time.Since(stopStart).Milliseconds(),
 				LocalStackInfo: lsInfo,

--- a/internal/container/stop.go
+++ b/internal/container/stop.go
@@ -13,9 +13,8 @@ import (
 
 // StopOptions carries optional telemetry context for the stop command.
 type StopOptions struct {
-	Telemetry      *telemetry.Client
-	TriggerEventID string
-	AuthToken      string
+	Telemetry *telemetry.Client
+	AuthToken string
 }
 
 func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []config.ContainerConfig, opts StopOptions) error {
@@ -52,7 +51,6 @@ func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 		if opts.Telemetry != nil {
 			opts.Telemetry.Emit(ctx, "lstk_lifecycle", telemetry.ToMap(telemetry.LifecycleEvent{
 				EventType:      telemetry.LifecycleStop,
-				TriggerEventID: opts.TriggerEventID,
 				Environment:    opts.Telemetry.GetEnvironment(opts.AuthToken),
 				Emulator:       string(c.Type),
 				DurationMS:     time.Since(stopStart).Milliseconds(),

--- a/internal/container/telemetry_test.go
+++ b/internal/container/telemetry_test.go
@@ -48,9 +48,8 @@ func TestStop_EmitsLifecycleStopEvent(t *testing.T) {
 	sink := output.NewPlainSink(io.Discard)
 
 	err := Stop(context.Background(), mockRT, sink, containers, StopOptions{
-		Telemetry:      tel,
-		TriggerEventID: "trigger-123",
-		AuthToken:      "ls-abc",
+		Telemetry: tel,
+		AuthToken: "ls-abc",
 	})
 	require.NoError(t, err)
 	tel.Close()
@@ -65,7 +64,6 @@ func TestStop_EmitsLifecycleStopEvent(t *testing.T) {
 	assert.Equal(t, "lstk_lifecycle", got["name"])
 	payload := got["payload"].(map[string]any)
 	assert.Equal(t, telemetry.LifecycleStop, payload["event_type"])
-	assert.Equal(t, "trigger-123", payload["trigger_event_id"])
 	assert.Equal(t, "aws", payload["emulator"])
 
 	env := payload["environment"].(map[string]any)
@@ -94,7 +92,7 @@ func TestTelCtx_EmitStartError_IsNoOpWhenTelNil(t *testing.T) {
 
 func TestTelCtx_EmitStartError_SendsLifecycleEvent(t *testing.T) {
 	tel, ch := newCapturingTelClient(t)
-	tc := telCtx{tel: tel, triggerEventID: "cmd-456", authToken: "ls-xyz"}
+	tc := telCtx{tel: tel, authToken: "ls-xyz"}
 
 	c := runtime.ContainerConfig{
 		EmulatorType: "aws",
@@ -113,7 +111,6 @@ func TestTelCtx_EmitStartError_SendsLifecycleEvent(t *testing.T) {
 	assert.Equal(t, "lstk_lifecycle", got["name"])
 	payload := got["payload"].(map[string]any)
 	assert.Equal(t, telemetry.LifecycleStartError, payload["event_type"])
-	assert.Equal(t, "cmd-456", payload["trigger_event_id"])
 	assert.Equal(t, "aws", payload["emulator"])
 	assert.Equal(t, telemetry.ErrCodePortConflict, payload["error_code"])
 	assert.Equal(t, "port 4566 already in use", payload["error_msg"])

--- a/internal/container/telemetry_test.go
+++ b/internal/container/telemetry_test.go
@@ -47,9 +47,9 @@ func TestStop_EmitsLifecycleStopEvent(t *testing.T) {
 	containers := []config.ContainerConfig{{Type: config.EmulatorAWS, Port: "4566"}}
 	sink := output.NewPlainSink(io.Discard)
 
+	tel.SetAuthToken("ls-abc")
 	err := Stop(context.Background(), mockRT, sink, containers, StopOptions{
 		Telemetry: tel,
-		AuthToken: "ls-abc",
 	})
 	require.NoError(t, err)
 	tel.Close()
@@ -83,22 +83,21 @@ func TestStop_SkipsTelemetryWhenNil(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestTelCtx_EmitStartError_IsNoOpWhenTelNil(t *testing.T) {
-	tc := telCtx{tel: nil}
+func TestEmitEmulatorStartError_IsNoOpWhenTelNil(t *testing.T) {
 	c := runtime.ContainerConfig{EmulatorType: "aws", Image: "localstack/localstack-pro:latest"}
 	// Must not panic.
-	tc.emitEmulatorStartError(context.Background(), c, telemetry.ErrCodePortConflict, "port 4566 in use")
+	emitEmulatorStartError(context.Background(), nil, c, telemetry.ErrCodePortConflict, "port 4566 in use")
 }
 
-func TestTelCtx_EmitStartError_SendsLifecycleEvent(t *testing.T) {
+func TestEmitEmulatorStartError_SendsLifecycleEvent(t *testing.T) {
 	tel, ch := newCapturingTelClient(t)
-	tc := telCtx{tel: tel, authToken: "ls-xyz"}
+	tel.SetAuthToken("ls-xyz")
 
 	c := runtime.ContainerConfig{
 		EmulatorType: "aws",
 		Image:        "localstack/localstack-pro:latest",
 	}
-	tc.emitEmulatorStartError(context.Background(), c, telemetry.ErrCodePortConflict, "port 4566 already in use")
+	emitEmulatorStartError(context.Background(), tel, c, telemetry.ErrCodePortConflict, "port 4566 already in use")
 	tel.Close()
 
 	var got map[string]any

--- a/internal/container/telemetry_test.go
+++ b/internal/container/telemetry_test.go
@@ -1,0 +1,120 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// newCapturingTelClient starts an httptest server that captures emitted events.
+func newCapturingTelClient(t *testing.T) (*telemetry.Client, <-chan map[string]any) {
+	t.Helper()
+	ch := make(chan map[string]any, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		var req struct {
+			Events []map[string]any `json:"events"`
+		}
+		if assert.NoError(t, json.Unmarshal(body, &req)) && len(req.Events) > 0 {
+			ch <- req.Events[0]
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return telemetry.New(srv.URL, false), ch
+}
+
+func TestStop_EmitsLifecycleStopEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsRunning(gomock.Any(), "localstack-aws").Return(true, nil)
+	mockRT.EXPECT().Stop(gomock.Any(), "localstack-aws").Return(nil)
+
+	tel, ch := newCapturingTelClient(t)
+
+	containers := []config.ContainerConfig{{Type: config.EmulatorAWS, Port: "4566"}}
+	sink := output.NewPlainSink(io.Discard)
+
+	err := Stop(context.Background(), mockRT, sink, containers, StopOptions{
+		Telemetry:      tel,
+		TriggerEventID: "trigger-123",
+		AuthToken:      "ls-abc",
+	})
+	require.NoError(t, err)
+	tel.Close()
+
+	var got map[string]any
+	select {
+	case got = <-ch:
+	default:
+		t.Fatal("no lifecycle event received")
+	}
+
+	assert.Equal(t, "lstk_lifecycle", got["name"])
+	payload := got["payload"].(map[string]any)
+	assert.Equal(t, telemetry.LifecycleStop, payload["event_type"])
+	assert.Equal(t, "trigger-123", payload["trigger_event_id"])
+	assert.Equal(t, "aws", payload["emulator"])
+
+	env := payload["environment"].(map[string]any)
+	assert.Equal(t, "ls-abc", env["auth_token_id"])
+}
+
+func TestStop_SkipsTelemetryWhenNil(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsRunning(gomock.Any(), "localstack-aws").Return(true, nil)
+	mockRT.EXPECT().Stop(gomock.Any(), "localstack-aws").Return(nil)
+
+	containers := []config.ContainerConfig{{Type: config.EmulatorAWS, Port: "4566"}}
+	sink := output.NewPlainSink(io.Discard)
+
+	err := Stop(context.Background(), mockRT, sink, containers, StopOptions{})
+	require.NoError(t, err)
+}
+
+func TestTelCtx_EmitStartError_IsNoOpWhenTelNil(t *testing.T) {
+	tc := telCtx{tel: nil}
+	c := runtime.ContainerConfig{EmulatorType: "aws", Image: "localstack/localstack-pro:latest"}
+	// Must not panic.
+	tc.emitStartError(context.Background(), c, telemetry.ErrCodePortConflict, "port 4566 in use")
+}
+
+func TestTelCtx_EmitStartError_SendsLifecycleEvent(t *testing.T) {
+	tel, ch := newCapturingTelClient(t)
+	tc := telCtx{tel: tel, triggerEventID: "cmd-456", authToken: "ls-xyz"}
+
+	c := runtime.ContainerConfig{
+		EmulatorType: "aws",
+		Image:        "localstack/localstack-pro:latest",
+	}
+	tc.emitStartError(context.Background(), c, telemetry.ErrCodePortConflict, "port 4566 already in use")
+	tel.Close()
+
+	var got map[string]any
+	select {
+	case got = <-ch:
+	default:
+		t.Fatal("no event received")
+	}
+
+	assert.Equal(t, "lstk_lifecycle", got["name"])
+	payload := got["payload"].(map[string]any)
+	assert.Equal(t, telemetry.LifecycleStartError, payload["event_type"])
+	assert.Equal(t, "cmd-456", payload["trigger_event_id"])
+	assert.Equal(t, "aws", payload["emulator"])
+	assert.Equal(t, telemetry.ErrCodePortConflict, payload["error_code"])
+	assert.Equal(t, "port 4566 already in use", payload["error_msg"])
+}

--- a/internal/container/telemetry_test.go
+++ b/internal/container/telemetry_test.go
@@ -87,7 +87,7 @@ func TestTelCtx_EmitStartError_IsNoOpWhenTelNil(t *testing.T) {
 	tc := telCtx{tel: nil}
 	c := runtime.ContainerConfig{EmulatorType: "aws", Image: "localstack/localstack-pro:latest"}
 	// Must not panic.
-	tc.emitStartError(context.Background(), c, telemetry.ErrCodePortConflict, "port 4566 in use")
+	tc.emitEmulatorStartError(context.Background(), c, telemetry.ErrCodePortConflict, "port 4566 in use")
 }
 
 func TestTelCtx_EmitStartError_SendsLifecycleEvent(t *testing.T) {
@@ -98,7 +98,7 @@ func TestTelCtx_EmitStartError_SendsLifecycleEvent(t *testing.T) {
 		EmulatorType: "aws",
 		Image:        "localstack/localstack-pro:latest",
 	}
-	tc.emitStartError(context.Background(), c, telemetry.ErrCodePortConflict, "port 4566 already in use")
+	tc.emitEmulatorStartError(context.Background(), c, telemetry.ErrCodePortConflict, "port 4566 already in use")
 	tel.Close()
 
 	var got map[string]any

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -25,6 +25,7 @@ type PortMapping struct {
 type ContainerConfig struct {
 	Image         string
 	Name          string
+	EmulatorType  string // e.g., "aws", "snowflake" — used for telemetry
 	Port          string
 	ContainerPort string // internal port the emulator listens on inside the container (e.g. "4566/tcp")
 	HealthPath    string

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -23,6 +23,7 @@ type Client struct {
 	enabled   bool
 	sessionID string
 	machineID string
+	authToken string
 
 	httpClient *http.Client
 	endpoint   string
@@ -30,6 +31,12 @@ type Client struct {
 	events    chan eventBody
 	done      chan struct{}
 	closeOnce sync.Once
+}
+
+// SetAuthToken stores the resolved auth token for inclusion in telemetry events.
+// Call this once the token is known (e.g. after keyring resolution or interactive login).
+func (c *Client) SetAuthToken(token string) {
+	c.authToken = token
 }
 
 func New(endpoint string, disabled bool) *Client {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 func userAgent() string {
-	return fmt.Sprintf("localstack lstk/%s", version.Version())
+	return fmt.Sprintf("localstack lstk/%s (%s; %s)", version.Version(), runtime.GOOS, runtime.GOARCH)
 }
 
 type Client struct {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 func userAgent() string {
-	return fmt.Sprintf("localstack lstk/%s (%s; %s)", version.Version(), runtime.GOOS, runtime.GOARCH)
+	return fmt.Sprintf("localstack lstk/%s", version.Version())
 }
 
 type Client struct {
@@ -74,11 +74,10 @@ func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) 
 		return
 	}
 
-	enriched := make(map[string]any, len(payload)+6)
+	enriched := make(map[string]any, len(payload)+5)
 	for k, v := range payload {
 		enriched[k] = v
 	}
-	enriched["version"] = version.Version()
 	enriched["os"] = runtime.GOOS
 	enriched["arch"] = runtime.GOARCH
 	_, enriched["is_ci"] = os.LookupEnv("CI")
@@ -95,7 +94,6 @@ func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) 
 		},
 		Payload: enriched,
 	}
-
 	select {
 	case c.events <- body:
 	default:

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/localstack/lstk/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,13 +64,12 @@ func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
 	assert.Equal(t, c.sessionID, metadata["session_id"])
 	_, err := time.Parse("2006-01-02 15:04:05.000000", metadata["client_time"].(string))
 	assert.NoError(t, err, "client_time should match expected format")
-	assert.Nil(t, metadata["version"], "version should be in payload, not metadata")
-	assert.Nil(t, metadata["machine_id"], "machine_id should be in payload, not metadata")
+	assert.Nil(t, metadata["version"], "version should not be in metadata")
+	assert.Nil(t, metadata["machine_id"], "machine_id should not be in metadata")
 
 	payload, ok := got.event["payload"].(map[string]any)
 	require.True(t, ok, "payload should be an object")
 	assert.Equal(t, "lstk start", payload["cmd"])
-	assert.Equal(t, version.Version(), payload["version"])
 	assert.Equal(t, runtime.GOOS, payload["os"])
 	assert.Equal(t, runtime.GOARCH, payload["arch"])
 	_, isCI := os.LookupEnv("CI")

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -86,11 +86,12 @@ func ToMap(v any) map[string]any {
 	return m
 }
 
-// GetEnvironment returns the common environment payload for telemetry events.
-func (c *Client) GetEnvironment(authTokenID string) Environment {
+// GetEnvironment returns the common environment payload for telemetry events,
+// using the auth token set via SetAuthToken.
+func (c *Client) GetEnvironment() Environment {
 	env := Environment{
 		LstkVersion: version.Version(),
-		AuthTokenID: authTokenID,
+		AuthTokenID: c.authToken,
 		OS:          runtime.GOOS,
 		Arch:        runtime.GOARCH,
 	}

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"runtime"
 
-	"github.com/google/uuid"
 	"github.com/localstack/lstk/internal/version"
 )
 
@@ -32,7 +31,6 @@ type LocalStackInfo struct {
 
 // CommandEvent is the payload for an lstk_command telemetry event.
 type CommandEvent struct {
-	EventID     string           `json:"event_id,omitempty"`
 	Environment Environment      `json:"environment"`
 	Parameters  CommandParameters `json:"parameters"`
 	Result      CommandResult    `json:"result"`
@@ -54,7 +52,6 @@ type CommandResult struct {
 // LifecycleEvent is the payload for an lstk_lifecycle telemetry event.
 type LifecycleEvent struct {
 	EventType      string          `json:"event_type"`
-	TriggerEventID string          `json:"trigger_event_id,omitempty"`
 	Environment    Environment     `json:"environment"`
 	Emulator       string          `json:"emulator"`
 	Image          string          `json:"image,omitempty"`
@@ -87,11 +84,6 @@ func ToMap(v any) map[string]any {
 	m := map[string]any{}
 	_ = json.Unmarshal(b, &m)
 	return m
-}
-
-// NewEventID generates a new unique event ID for correlating telemetry events.
-func NewEventID() string {
-	return uuid.NewString()
 }
 
 // GetEnvironment returns the common environment payload for telemetry events.

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -1,0 +1,108 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"runtime"
+
+	"github.com/google/uuid"
+	"github.com/localstack/lstk/internal/version"
+)
+
+// Environment is the common environment block included in all telemetry events.
+type Environment struct {
+	LstkVersion string `json:"lstk_version"`
+	AuthTokenID string `json:"auth_token_id,omitempty"`
+	MachineID   string `json:"machine_id,omitempty"`
+	OS          string `json:"os"`
+	Arch        string `json:"arch"`
+}
+
+// LocalStackInfo mirrors the /_localstack/info response.
+type LocalStackInfo struct {
+	Version            string `json:"version"`
+	Edition            string `json:"edition"`
+	IsLicenseActivated bool   `json:"is_license_activated"`
+	SessionID          string `json:"session_id"`
+	MachineID          string `json:"machine_id"`
+	System             string `json:"system"`
+	IsDocker           bool   `json:"is_docker"`
+	ServerTimeUTC      string `json:"server_time_utc"`
+	Uptime             int    `json:"uptime"`
+}
+
+// CommandEvent is the payload for an lstk_command telemetry event.
+type CommandEvent struct {
+	Environment Environment      `json:"environment"`
+	Parameters  CommandParameters `json:"parameters"`
+	Result      CommandResult    `json:"result"`
+}
+
+// CommandParameters holds the command name and set flags.
+type CommandParameters struct {
+	Command string   `json:"command"`
+	Flags   []string `json:"flags"`
+}
+
+// CommandResult holds the outcome of a command invocation.
+type CommandResult struct {
+	DurationMS int64  `json:"duration_ms"`
+	ExitCode   int    `json:"exit_code"`
+	ErrorMsg   string `json:"error_msg,omitempty"`
+}
+
+// LifecycleEvent is the payload for an lstk_lifecycle telemetry event.
+type LifecycleEvent struct {
+	EventType      string          `json:"event_type"`
+	TriggerEventID string          `json:"trigger_event_id,omitempty"`
+	Environment    Environment     `json:"environment"`
+	Emulator       string          `json:"emulator"`
+	Image          string          `json:"image,omitempty"`
+	ContainerID    string          `json:"container_id,omitempty"`
+	DurationMS     int64           `json:"duration_ms,omitempty"`
+	Pulled         bool            `json:"pulled,omitempty"`
+	LocalStackInfo *LocalStackInfo `json:"localstack_info,omitempty"`
+	ErrorCode      string          `json:"error_code,omitempty"`
+	ErrorMsg       string          `json:"error_msg,omitempty"`
+}
+
+// Lifecycle event type constants.
+const (
+	LifecycleStartSuccess = "start_success"
+	LifecycleStop         = "stop"
+	LifecycleStartError   = "start_error"
+)
+
+// Error codes for start_error lifecycle events.
+const (
+	ErrCodePortConflict    = "port_conflict"
+	ErrCodeImagePullFailed = "image_pull_failed"
+	ErrCodeLicenseInvalid  = "license_invalid"
+	ErrCodeStartFailed     = "start_failed"
+)
+
+// ToMap converts a telemetry event struct to a map[string]any for use with Emit.
+func ToMap(v any) map[string]any {
+	b, _ := json.Marshal(v)
+	m := map[string]any{}
+	_ = json.Unmarshal(b, &m)
+	return m
+}
+
+// NewEventID generates a new unique event ID for correlating telemetry events.
+func NewEventID() string {
+	return uuid.NewString()
+}
+
+// GetEnvironment returns the common environment payload for telemetry events.
+func (c *Client) GetEnvironment(authTokenID string) Environment {
+	env := Environment{
+		LstkVersion: version.Version(),
+		AuthTokenID: authTokenID,
+		OS:          runtime.GOOS,
+		Arch:        runtime.GOARCH,
+	}
+	if c.machineID != "" {
+		env.MachineID = c.machineID
+	}
+	return env
+}

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -51,6 +51,7 @@ type CommandResult struct {
 }
 
 // LifecycleEvent is the payload for an lstk_lifecycle telemetry event.
+// TODO: verify that trigger_event_id always matches the id of the lstk_command event that triggered it.
 type LifecycleEvent struct {
 	EventType      string          `json:"event_type"`
 	TriggerEventID string          `json:"trigger_event_id,omitempty"`

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/json"
 	"runtime"
 
@@ -99,4 +100,26 @@ func (c *Client) GetEnvironment() Environment {
 		env.MachineID = c.machineID
 	}
 	return env
+}
+
+// EmitCommand emits an lstk_command telemetry event. The Environment block is
+// populated automatically from the client state.
+func (c *Client) EmitCommand(ctx context.Context, command string, flags []string, durationMS int64, exitCode int, errorMsg string) {
+	c.Emit(ctx, "lstk_command", ToMap(CommandEvent{
+		Environment: c.GetEnvironment(),
+		Parameters:  CommandParameters{Command: command, Flags: flags},
+		Result: CommandResult{
+			DurationMS: durationMS,
+			ExitCode:   exitCode,
+			ErrorMsg:   errorMsg,
+		},
+	}))
+}
+
+// EmitEmulatorLifecycleEvent emits an lstk_lifecycle telemetry event. The
+// Environment field is populated automatically from the client state; any
+// value set by the caller is overwritten.
+func (c *Client) EmitEmulatorLifecycleEvent(ctx context.Context, event LifecycleEvent) {
+	event.Environment = c.GetEnvironment()
+	c.Emit(ctx, "lstk_lifecycle", ToMap(event))
 }

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -32,6 +32,7 @@ type LocalStackInfo struct {
 
 // CommandEvent is the payload for an lstk_command telemetry event.
 type CommandEvent struct {
+	EventID     string           `json:"event_id,omitempty"`
 	Environment Environment      `json:"environment"`
 	Parameters  CommandParameters `json:"parameters"`
 	Result      CommandResult    `json:"result"`
@@ -51,7 +52,6 @@ type CommandResult struct {
 }
 
 // LifecycleEvent is the payload for an lstk_lifecycle telemetry event.
-// TODO: verify that trigger_event_id always matches the id of the lstk_command event that triggered it.
 type LifecycleEvent struct {
 	EventType      string          `json:"event_type"`
 	TriggerEventID string          `json:"trigger_event_id,omitempty"`

--- a/internal/telemetry/events_test.go
+++ b/internal/telemetry/events_test.go
@@ -1,0 +1,143 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/localstack/lstk/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureEvents(t *testing.T) (*Client, <-chan map[string]any) {
+	t.Helper()
+	ch := make(chan map[string]any, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		var req struct {
+			Events []map[string]any `json:"events"`
+		}
+		if assert.NoError(t, json.Unmarshal(body, &req)) && len(req.Events) > 0 {
+			ch <- req.Events[0]
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, false), ch
+}
+
+func drainEvent(t *testing.T, tel *Client, ch <-chan map[string]any) map[string]any {
+	t.Helper()
+	tel.Close()
+	select {
+	case ev := <-ch:
+		return ev
+	default:
+		t.Fatal("no telemetry event received")
+		return nil
+	}
+}
+
+func TestNewEventID_ReturnsUniqueNonEmptyStrings(t *testing.T) {
+	a := NewEventID()
+	b := NewEventID()
+	assert.NotEmpty(t, a)
+	assert.NotEmpty(t, b)
+	assert.NotEqual(t, a, b)
+}
+
+func TestGetEnvironment_PopulatesAllFields(t *testing.T) {
+	c := New("http://localhost", false)
+	env := c.GetEnvironment("ls-abc123")
+
+	assert.Equal(t, version.Version(), env.LstkVersion)
+	assert.Equal(t, "ls-abc123", env.AuthTokenID)
+	assert.Equal(t, runtime.GOOS, env.OS)
+	assert.Equal(t, runtime.GOARCH, env.Arch)
+	assert.NotEmpty(t, env.MachineID)
+}
+
+func TestGetEnvironment_OmitsAuthTokenWhenEmpty(t *testing.T) {
+	c := New("http://localhost", false)
+	env := c.GetEnvironment("")
+	assert.Empty(t, env.AuthTokenID)
+}
+
+func TestEmitCommand_SendsCorrectEventNameAndStructure(t *testing.T) {
+	tel, ch := captureEvents(t)
+
+	tel.Emit(context.Background(), "lstk_command", ToMap(CommandEvent{
+		Environment: tel.GetEnvironment("ls-token"),
+		Parameters:  CommandParameters{Command: "start", Flags: []string{"--non-interactive"}},
+		Result:      CommandResult{DurationMS: 1200, ExitCode: 0},
+	}))
+
+	got := drainEvent(t, tel, ch)
+
+	assert.Equal(t, "lstk_command", got["name"])
+
+	metadata, ok := got["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, metadata["session_id"])
+	_, err := time.Parse("2006-01-02 15:04:05.000000", metadata["client_time"].(string))
+	assert.NoError(t, err)
+
+	payload, ok := got["payload"].(map[string]any)
+	require.True(t, ok)
+
+	env, ok := payload["environment"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, version.Version(), env["lstk_version"])
+	assert.Equal(t, "ls-token", env["auth_token_id"])
+
+	params, ok := payload["parameters"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "start", params["command"])
+	assert.Equal(t, []any{"--non-interactive"}, params["flags"])
+
+	result, ok := payload["result"].(map[string]any)
+	require.True(t, ok)
+	assert.InDelta(t, 1200, result["duration_ms"], 1)
+	assert.InDelta(t, 0, result["exit_code"], 0)
+}
+
+func TestEmitCommand_IncludesErrorMsgOnFailure(t *testing.T) {
+	tel, ch := captureEvents(t)
+
+	tel.Emit(context.Background(), "lstk_command", ToMap(CommandEvent{
+		Environment: tel.GetEnvironment(""),
+		Parameters:  CommandParameters{Command: "start"},
+		Result:      CommandResult{DurationMS: 50, ExitCode: 1, ErrorMsg: "port 4566 already in use"},
+	}))
+
+	got := drainEvent(t, tel, ch)
+	payload := got["payload"].(map[string]any)
+	result := payload["result"].(map[string]any)
+	assert.Equal(t, "port 4566 already in use", result["error_msg"])
+	assert.InDelta(t, 1, result["exit_code"], 0)
+}
+
+func TestEmitCommand_IsNoOpWhenDisabled(t *testing.T) {
+	received := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- struct{}{}
+	}))
+	defer srv.Close()
+
+	tel := New(srv.URL, true) // disabled
+	tel.Emit(context.Background(), "lstk_command", ToMap(CommandEvent{}))
+	tel.Close()
+
+	select {
+	case <-received:
+		t.Fatal("disabled client should not send events")
+	default:
+	}
+}

--- a/internal/telemetry/events_test.go
+++ b/internal/telemetry/events_test.go
@@ -45,14 +45,6 @@ func drainEvent(t *testing.T, tel *Client, ch <-chan map[string]any) map[string]
 	}
 }
 
-func TestNewEventID_ReturnsUniqueNonEmptyStrings(t *testing.T) {
-	a := NewEventID()
-	b := NewEventID()
-	assert.NotEmpty(t, a)
-	assert.NotEmpty(t, b)
-	assert.NotEqual(t, a, b)
-}
-
 func TestGetEnvironment_PopulatesAllFields(t *testing.T) {
 	c := New("http://localhost", false)
 	env := c.GetEnvironment("ls-abc123")

--- a/internal/telemetry/events_test.go
+++ b/internal/telemetry/events_test.go
@@ -47,7 +47,8 @@ func drainEvent(t *testing.T, tel *Client, ch <-chan map[string]any) map[string]
 
 func TestGetEnvironment_PopulatesAllFields(t *testing.T) {
 	c := New("http://localhost", false)
-	env := c.GetEnvironment("ls-abc123")
+	c.SetAuthToken("ls-abc123")
+	env := c.GetEnvironment()
 
 	assert.Equal(t, version.Version(), env.LstkVersion)
 	assert.Equal(t, "ls-abc123", env.AuthTokenID)
@@ -58,15 +59,16 @@ func TestGetEnvironment_PopulatesAllFields(t *testing.T) {
 
 func TestGetEnvironment_OmitsAuthTokenWhenEmpty(t *testing.T) {
 	c := New("http://localhost", false)
-	env := c.GetEnvironment("")
+	env := c.GetEnvironment()
 	assert.Empty(t, env.AuthTokenID)
 }
 
 func TestEmitCommand_SendsCorrectEventNameAndStructure(t *testing.T) {
 	tel, ch := captureEvents(t)
 
+	tel.SetAuthToken("ls-token")
 	tel.Emit(context.Background(), "lstk_command", ToMap(CommandEvent{
-		Environment: tel.GetEnvironment("ls-token"),
+		Environment: tel.GetEnvironment(),
 		Parameters:  CommandParameters{Command: "start", Flags: []string{"--non-interactive"}},
 		Result:      CommandResult{DurationMS: 1200, ExitCode: 0},
 	}))
@@ -104,7 +106,7 @@ func TestEmitCommand_IncludesErrorMsgOnFailure(t *testing.T) {
 	tel, ch := captureEvents(t)
 
 	tel.Emit(context.Background(), "lstk_command", ToMap(CommandEvent{
-		Environment: tel.GetEnvironment(""),
+		Environment: tel.GetEnvironment(),
 		Parameters:  CommandParameters{Command: "start"},
 		Result:      CommandResult{DurationMS: 50, ExitCode: 1, ErrorMsg: "port 4566 already in use"},
 	}))

--- a/internal/telemetry/events_test.go
+++ b/internal/telemetry/events_test.go
@@ -67,11 +67,7 @@ func TestEmitCommand_SendsCorrectEventNameAndStructure(t *testing.T) {
 	tel, ch := captureEvents(t)
 
 	tel.SetAuthToken("ls-token")
-	tel.Emit(context.Background(), "lstk_command", ToMap(CommandEvent{
-		Environment: tel.GetEnvironment(),
-		Parameters:  CommandParameters{Command: "start", Flags: []string{"--non-interactive"}},
-		Result:      CommandResult{DurationMS: 1200, ExitCode: 0},
-	}))
+	tel.EmitCommand(context.Background(), "start", []string{"--non-interactive"}, 1200, 0, "")
 
 	got := drainEvent(t, tel, ch)
 
@@ -105,11 +101,7 @@ func TestEmitCommand_SendsCorrectEventNameAndStructure(t *testing.T) {
 func TestEmitCommand_IncludesErrorMsgOnFailure(t *testing.T) {
 	tel, ch := captureEvents(t)
 
-	tel.Emit(context.Background(), "lstk_command", ToMap(CommandEvent{
-		Environment: tel.GetEnvironment(),
-		Parameters:  CommandParameters{Command: "start"},
-		Result:      CommandResult{DurationMS: 50, ExitCode: 1, ErrorMsg: "port 4566 already in use"},
-	}))
+	tel.EmitCommand(context.Background(), "start", nil, 50, 1, "port 4566 already in use")
 
 	got := drainEvent(t, tel, ch)
 	payload := got["payload"].(map[string]any)
@@ -126,7 +118,7 @@ func TestEmitCommand_IsNoOpWhenDisabled(t *testing.T) {
 	defer srv.Close()
 
 	tel := New(srv.URL, true) // disabled
-	tel.Emit(context.Background(), "lstk_command", ToMap(CommandEvent{}))
+	tel.EmitCommand(context.Background(), "start", nil, 0, 0, "")
 	tel.Close()
 
 	select {

--- a/internal/ui/run_stop.go
+++ b/internal/ui/run_stop.go
@@ -12,7 +12,7 @@ import (
 	"github.com/localstack/lstk/internal/runtime"
 )
 
-func RunStop(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig) error {
+func RunStop(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, opts container.StopOptions) error {
 	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
@@ -21,7 +21,7 @@ func RunStop(parentCtx context.Context, rt runtime.Runtime, containers []config.
 	runErrCh := make(chan error, 1)
 
 	go func() {
-		err := container.Stop(ctx, rt, output.NewTUISink(programSender{p: p}), containers)
+		err := container.Stop(ctx, rt, output.NewTUISink(programSender{p: p}), containers, opts)
 		runErrCh <- err
 		if err != nil && !errors.Is(err, context.Canceled) {
 			p.Send(runErrMsg{err: err})

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -133,12 +133,14 @@ func TestConfigPathCommand(t *testing.T) {
 	xdgConfigFile := filepath.Join(tmpHome, ".config", "lstk", "config.toml")
 	writeConfigFile(t, xdgConfigFile)
 
-	e := testEnvWithHome(tmpHome, filepath.Join(tmpHome, "xdg-config-home"))
+	analyticsSrv, events := mockAnalyticsServer(t)
+	e := env.Environ(testEnvWithHome(tmpHome, filepath.Join(tmpHome, "xdg-config-home"))).With(env.AnalyticsEndpoint, analyticsSrv.URL)
 	stdout, stderr, err := runLstk(t, testContext(t), workDir, e, "config", "path")
 	require.NoError(t, err, stderr)
 	requireExitCode(t, 0, err)
 
 	assertSamePath(t, xdgConfigFile, stdout)
+	assertCommandTelemetry(t, events, "config path", 0)
 }
 
 func TestConfigPathCommandDoesNotCreateConfig(t *testing.T) {

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -89,11 +89,13 @@ func TestDeviceFlowSuccess(t *testing.T) {
 	mockServer := createMockAPIServer(t, licenseToken, true)
 	defer mockServer.Close()
 
+	analyticsSrv, events := mockAnalyticsServer(t)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, binaryPath(), "login")
-	cmd.Env = env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL)
+	cmd.Env = env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL).With(env.AnalyticsEndpoint, analyticsSrv.URL)
 
 	ptmx, err := pty.Start(cmd)
 	require.NoError(t, err, "failed to start command in PTY")
@@ -133,6 +135,7 @@ func TestDeviceFlowSuccess(t *testing.T) {
 	storedToken, err := GetAuthTokenFromKeyring()
 	require.NoError(t, err)
 	assert.Equal(t, licenseToken, storedToken)
+	assertCommandTelemetry(t, events, "login", 0)
 }
 
 func TestDeviceFlowFailure_RequestNotConfirmed(t *testing.T) {
@@ -146,11 +149,13 @@ func TestDeviceFlowFailure_RequestNotConfirmed(t *testing.T) {
 	mockServer := createMockAPIServer(t, "", false)
 	defer mockServer.Close()
 
+	analyticsSrv, events := mockAnalyticsServer(t)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, binaryPath(), "login")
-	cmd.Env = env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL)
+	cmd.Env = env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL).With(env.AnalyticsEndpoint, analyticsSrv.URL)
 
 	ptmx, err := pty.Start(cmd)
 	require.NoError(t, err, "failed to start command in PTY")
@@ -187,4 +192,5 @@ func TestDeviceFlowFailure_RequestNotConfirmed(t *testing.T) {
 	// Verify no token was stored in keyring
 	_, err = GetAuthTokenFromKeyring()
 	assert.Error(t, err, "no token should be stored when login fails")
+	assertCommandTelemetry(t, events, "login", 1)
 }

--- a/test/integration/logout_test.go
+++ b/test/integration/logout_test.go
@@ -17,22 +17,26 @@ func TestLogoutCommandRemovesToken(t *testing.T) {
 	err := SetAuthTokenInKeyring("test-token")
 	require.NoError(t, err, "failed to store token in keyring")
 
-	stdout, stderr, err := runLstk(t, testContext(t), "", nil, "logout")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, stderr, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "logout")
 	require.NoError(t, err, "lstk logout failed: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "Logged out successfully")
 
 	_, err = GetAuthTokenFromKeyring()
 	assert.Error(t, err, "token should be removed from keyring")
+	assertCommandTelemetry(t, events, "logout", 0)
 }
 
 func TestLogoutCommandSucceedsWhenNoToken(t *testing.T) {
 	_ = DeleteAuthTokenFromKeyring()
 
-	stdout, stderr, err := runLstk(t, testContext(t), "", env.Without(env.AuthToken), "logout")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, stderr, err := runLstk(t, testContext(t), "", env.Without(env.AuthToken).With(env.AnalyticsEndpoint, analyticsSrv.URL), "logout")
 	require.NoError(t, err, "lstk logout should succeed even with no token: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "Not currently logged in")
+	assertCommandTelemetry(t, events, "logout", 0)
 }
 
 func TestLogoutCommandWithEnvVarToken(t *testing.T) {

--- a/test/integration/logs_test.go
+++ b/test/integration/logs_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,9 +21,11 @@ func TestLogsExitsByDefault(t *testing.T) {
 	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
-	_, _, err := runLstk(t, ctx, "", nil, "logs")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	_, _, err := runLstk(t, ctx, "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "logs")
 	require.NoError(t, err, "lstk logs should exit cleanly when container is running")
 	requireExitCode(t, 0, err)
+	assertCommandTelemetry(t, events, "logs", 0)
 }
 
 func TestLogsCommandFailsWhenNotRunning(t *testing.T) {
@@ -30,10 +33,12 @@ func TestLogsCommandFailsWhenNotRunning(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	_, stderr, err := runLstk(t, testContext(t), "", nil, "logs", "--follow")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "logs", "--follow")
 	require.Error(t, err, "expected lstk logs --follow to fail when container not running")
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stderr, "emulator is not running")
+	assertCommandTelemetry(t, events, "logs", 1)
 }
 
 func TestLogsFollowStreamsOutput(t *testing.T) {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -83,10 +83,12 @@ func TestStartCommandDoesNothingWhenAlreadyRunning(t *testing.T) {
 	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
-	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.AuthToken, "fake-token"), "start")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.AuthToken, "fake-token").With(env.AnalyticsEndpoint, analyticsSrv.URL), "start")
 	require.NoError(t, err, "lstk start should succeed when container is already running: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "already running")
+	assertCommandTelemetry(t, events, "start", 0)
 }
 
 func TestStartCommandFailsWhenPortInUse(t *testing.T) {
@@ -98,12 +100,18 @@ func TestStartCommandFailsWhenPortInUse(t *testing.T) {
 	require.NoError(t, err, "failed to bind port 4566 for test")
 	defer func() { _ = ln.Close() }()
 
-	stdout, _, err := runLstk(t, testContext(t), "", env.With(env.AuthToken, "fake-token"), "start")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, _, err := runLstk(t, testContext(t), "", env.With(env.AuthToken, "fake-token").With(env.AnalyticsEndpoint, analyticsSrv.URL), "start")
 	require.Error(t, err, "expected lstk start to fail when port is in use")
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stdout, "Port 4566 already in use")
 	assert.Contains(t, stdout, "LocalStack may already be running.")
 	assert.Contains(t, stdout, "lstk stop")
+
+	// Both lstk_lifecycle (start_error) and lstk_command events should be emitted.
+	byName := collectTelemetryByName(t, events, 2)
+	assert.Contains(t, byName, "lstk_lifecycle")
+	assert.Contains(t, byName, "lstk_command")
 }
 
 func TestStartCommandSucceedsWithNonDefaultPort(t *testing.T) {

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -20,12 +20,14 @@ func TestStatusCommandFailsWhenNotRunning(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	stdout, _, err := runLstk(t, testContext(t), "", nil, "status")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, _, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "status")
 	require.Error(t, err, "expected lstk status to fail when emulator not running")
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stdout, "is not running")
 	assert.Contains(t, stdout, "Start LocalStack:")
 	assert.Contains(t, stdout, "See help:")
+	assertCommandTelemetry(t, events, "status", 1)
 }
 
 func TestStatusCommandShowsResourcesWhenRunning(t *testing.T) {
@@ -54,7 +56,8 @@ func TestStatusCommandShowsResourcesWhenRunning(t *testing.T) {
 
 	host := strings.TrimPrefix(server.URL, "http://")
 
-	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, host), "status")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, host).With(env.AnalyticsEndpoint, analyticsSrv.URL), "status")
 	require.NoError(t, err, "lstk status failed: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "running")
@@ -67,6 +70,7 @@ func TestStatusCommandShowsResourcesWhenRunning(t *testing.T) {
 	assert.Contains(t, stdout, "my-bucket")
 	assert.Contains(t, stdout, "Lambda")
 	assert.Contains(t, stdout, "my-function")
+	assertCommandTelemetry(t, events, "status", 0)
 }
 
 func TestStatusCommandWorksWithNonDefaultPort(t *testing.T) {

--- a/test/integration/stop_test.go
+++ b/test/integration/stop_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"testing"
 
+	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +16,8 @@ func TestStopCommandSucceeds(t *testing.T) {
 	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
-	stdout, stderr, err := runLstk(t, ctx, "", nil, "stop")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "stop")
 	require.NoError(t, err, "lstk stop failed: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "Stopping", "should show stopping message")
@@ -23,6 +25,11 @@ func TestStopCommandSucceeds(t *testing.T) {
 
 	_, err = dockerClient.ContainerInspect(ctx, containerName)
 	assert.Error(t, err, "container should not exist after stop")
+
+	// Both lstk_lifecycle (stop) and lstk_command events should be emitted.
+	byName := collectTelemetryByName(t, events, 2)
+	assert.Contains(t, byName, "lstk_lifecycle")
+	assert.Contains(t, byName, "lstk_command")
 }
 
 func TestStopCommandFailsWhenNotRunning(t *testing.T) {
@@ -30,10 +37,12 @@ func TestStopCommandFailsWhenNotRunning(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	_, stderr, err := runLstk(t, testContext(t), "", nil, "stop")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "stop")
 	require.Error(t, err, "expected lstk stop to fail when container not running")
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stderr, "is not running")
+	assertCommandTelemetry(t, events, "stop", 1)
 }
 
 func TestStopCommandIsIdempotent(t *testing.T) {

--- a/test/integration/telemetry_test.go
+++ b/test/integration/telemetry_test.go
@@ -193,3 +193,49 @@ func TestStartCommandDoesNotSendTelemetryWhenDisabled(t *testing.T) {
 		// No event received — correct.
 	}
 }
+
+// receiveEventByName waits up to 3s for an event with the given name.
+// Events with a different name are skipped until the deadline.
+func receiveEventByName(t *testing.T, events <-chan map[string]any, name string) map[string]any {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case event := <-events:
+			if event["name"] == name {
+				return event
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for %q telemetry event", name)
+			return nil
+		}
+	}
+}
+
+// asserts that a lstk_command event was emitted with the expected command name and exit code
+func assertCommandTelemetry(t *testing.T, events <-chan map[string]any, command string, exitCode int) {
+	t.Helper()
+	event := receiveEventByName(t, events, "lstk_command")
+	payload, _ := event["payload"].(map[string]any)
+	params, _ := payload["parameters"].(map[string]any)
+	assert.Equal(t, command, params["command"])
+	result, _ := payload["result"].(map[string]any)
+	assert.InDelta(t, exitCode, result["exit_code"], 0)
+}
+
+// collects events until count distinct event names have been received or the deadline expires.
+func collectTelemetryByName(t *testing.T, events <-chan map[string]any, count int) map[string]map[string]any {
+	t.Helper()
+	byName := make(map[string]map[string]any)
+	deadline := time.After(3 * time.Second)
+	for len(byName) < count {
+		select {
+		case event := <-events:
+			name, _ := event["name"].(string)
+			byName[name] = event
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d telemetry events; received: %v", count, byName)
+		}
+	}
+	return byName
+}

--- a/test/integration/telemetry_test.go
+++ b/test/integration/telemetry_test.go
@@ -69,7 +69,7 @@ func TestStartCommandSendsTelemetryEvent(t *testing.T) {
 	// The telemetry goroutine is async; wait up to 3s for the event to arrive.
 	select {
 	case event := <-events:
-		assert.Equal(t, "cli_cmd", event["name"])
+		assert.Equal(t, "lstk_command", event["name"])
 
 		metadata, ok := event["metadata"].(map[string]any)
 		require.True(t, ok)
@@ -80,15 +80,71 @@ func TestStartCommandSendsTelemetryEvent(t *testing.T) {
 
 		payload, ok := event["payload"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "lstk start", payload["cmd"])
-		assert.NotEmpty(t, payload["version"])
-		assert.Equal(t, runtime.GOOS, payload["os"])
-		assert.Equal(t, runtime.GOARCH, payload["arch"])
 		assert.NotEmpty(t, payload["machine_id"], "machine_id should be present")
 		assert.Equal(t, os.Getenv("CI") != "", payload["is_ci"])
+
+		environment, ok := payload["environment"].(map[string]any)
+		require.True(t, ok)
+		assert.NotEmpty(t, environment["lstk_version"])
+		assert.Equal(t, runtime.GOOS, environment["os"])
+		assert.Equal(t, runtime.GOARCH, environment["arch"])
+
+		params, ok := payload["parameters"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "start", params["command"])
+
+		result, ok := payload["result"].(map[string]any)
+		require.True(t, ok)
+		assert.InDelta(t, 0, result["exit_code"], 0)
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for telemetry event")
 	}
+}
+
+func TestStopCommandSendsTelemetryEvents(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.AuthToken, "fake-token").
+		With(env.AnalyticsEndpoint, analyticsSrv.URL), "stop")
+	require.NoError(t, err, "lstk stop failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	// Collect both the lstk_lifecycle and lstk_command events (order not guaranteed).
+	byName := make(map[string]map[string]any)
+	deadline := time.After(3 * time.Second)
+	for len(byName) < 2 {
+		select {
+		case event := <-events:
+			name, _ := event["name"].(string)
+			byName[name] = event
+		case <-deadline:
+			t.Fatalf("timed out waiting for telemetry events; received: %v", byName)
+		}
+	}
+
+	lifecycle, ok := byName["lstk_lifecycle"]
+	require.True(t, ok, "expected lstk_lifecycle event")
+	lp := lifecycle["payload"].(map[string]any)
+	assert.Equal(t, "stop", lp["event_type"])
+	assert.Equal(t, "aws", lp["emulator"])
+	assert.NotEmpty(t, lp["trigger_event_id"], "lifecycle event should carry trigger_event_id for correlation")
+
+	command, ok := byName["lstk_command"]
+	require.True(t, ok, "expected lstk_command event")
+	cp := command["payload"].(map[string]any)
+	params, ok := cp["parameters"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "stop", params["command"])
+	result, ok := cp["result"].(map[string]any)
+	require.True(t, ok)
+	assert.InDelta(t, 0, result["exit_code"], 0)
 }
 
 func TestStartCommandSucceedsWhenAnalyticsEndpointUnreachable(t *testing.T) {

--- a/test/integration/telemetry_test.go
+++ b/test/integration/telemetry_test.go
@@ -166,6 +166,94 @@ func TestStartCommandSucceedsWhenAnalyticsEndpointUnreachable(t *testing.T) {
 	requireExitCode(t, 0, err)
 }
 
+func TestStopCommandCorrelatesTelemetryEventIDs(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.AuthToken, "fake-token").
+		With(env.AnalyticsEndpoint, analyticsSrv.URL), "stop")
+	require.NoError(t, err, "lstk stop failed: %s", stderr)
+
+	byName := make(map[string]map[string]any)
+	deadline := time.After(3 * time.Second)
+	for len(byName) < 2 {
+		select {
+		case event := <-events:
+			name, _ := event["name"].(string)
+			byName[name] = event
+		case <-deadline:
+			t.Fatalf("timed out waiting for telemetry events; received: %v", byName)
+		}
+	}
+
+	lifecycle, ok := byName["lstk_lifecycle"]
+	require.True(t, ok, "expected lstk_lifecycle event")
+	lp, ok := lifecycle["payload"].(map[string]any)
+	require.True(t, ok)
+	triggerEventID, _ := lp["trigger_event_id"].(string)
+	require.NotEmpty(t, triggerEventID, "lstk_lifecycle must carry a trigger_event_id")
+
+	command, ok := byName["lstk_command"]
+	require.True(t, ok, "expected lstk_command event")
+	cp, ok := command["payload"].(map[string]any)
+	require.True(t, ok)
+	eventID, _ := cp["event_id"].(string)
+	require.NotEmpty(t, eventID, "lstk_command must carry an event_id")
+
+	assert.Equal(t, eventID, triggerEventID, "lstk_lifecycle.trigger_event_id must match lstk_command.event_id")
+}
+
+func TestStartCommandCorrelatesTelemetryEventIDs(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL).
+		With(env.AnalyticsEndpoint, analyticsSrv.URL), "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+
+	byName := make(map[string]map[string]any)
+	deadline := time.After(5 * time.Second)
+	for len(byName) < 2 {
+		select {
+		case event := <-events:
+			name, _ := event["name"].(string)
+			byName[name] = event
+		case <-deadline:
+			t.Fatalf("timed out waiting for telemetry events; received: %v", byName)
+		}
+	}
+
+	lifecycle, ok := byName["lstk_lifecycle"]
+	require.True(t, ok, "expected lstk_lifecycle event")
+	lp, ok := lifecycle["payload"].(map[string]any)
+	require.True(t, ok)
+	triggerEventID, _ := lp["trigger_event_id"].(string)
+	require.NotEmpty(t, triggerEventID, "lstk_lifecycle must carry a trigger_event_id")
+
+	command, ok := byName["lstk_command"]
+	require.True(t, ok, "expected lstk_command event")
+	cp, ok := command["payload"].(map[string]any)
+	require.True(t, ok)
+	eventID, _ := cp["event_id"].(string)
+	require.NotEmpty(t, eventID, "lstk_command must carry an event_id")
+
+	assert.Equal(t, eventID, triggerEventID, "lstk_lifecycle.trigger_event_id must match lstk_command.event_id")
+}
+
 func TestStartCommandDoesNotSendTelemetryWhenDisabled(t *testing.T) {
 	requireDocker(t)
 	cleanup()

--- a/test/integration/telemetry_test.go
+++ b/test/integration/telemetry_test.go
@@ -134,7 +134,6 @@ func TestStopCommandSendsTelemetryEvents(t *testing.T) {
 	lp := lifecycle["payload"].(map[string]any)
 	assert.Equal(t, "stop", lp["event_type"])
 	assert.Equal(t, "aws", lp["emulator"])
-	assert.NotEmpty(t, lp["trigger_event_id"], "lifecycle event should carry trigger_event_id for correlation")
 
 	command, ok := byName["lstk_command"]
 	require.True(t, ok, "expected lstk_command event")
@@ -164,94 +163,6 @@ func TestStartCommandSucceedsWhenAnalyticsEndpointUnreachable(t *testing.T) {
 
 	require.NoError(t, err, "lstk start should succeed even when analytics endpoint is unreachable: %s", out)
 	requireExitCode(t, 0, err)
-}
-
-func TestStopCommandCorrelatesTelemetryEventIDs(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
-
-	ctx := testContext(t)
-	startTestContainer(t, ctx)
-
-	analyticsSrv, events := mockAnalyticsServer(t)
-
-	_, stderr, err := runLstk(t, ctx, "", env.With(env.AuthToken, "fake-token").
-		With(env.AnalyticsEndpoint, analyticsSrv.URL), "stop")
-	require.NoError(t, err, "lstk stop failed: %s", stderr)
-
-	byName := make(map[string]map[string]any)
-	deadline := time.After(3 * time.Second)
-	for len(byName) < 2 {
-		select {
-		case event := <-events:
-			name, _ := event["name"].(string)
-			byName[name] = event
-		case <-deadline:
-			t.Fatalf("timed out waiting for telemetry events; received: %v", byName)
-		}
-	}
-
-	lifecycle, ok := byName["lstk_lifecycle"]
-	require.True(t, ok, "expected lstk_lifecycle event")
-	lp, ok := lifecycle["payload"].(map[string]any)
-	require.True(t, ok)
-	triggerEventID, _ := lp["trigger_event_id"].(string)
-	require.NotEmpty(t, triggerEventID, "lstk_lifecycle must carry a trigger_event_id")
-
-	command, ok := byName["lstk_command"]
-	require.True(t, ok, "expected lstk_command event")
-	cp, ok := command["payload"].(map[string]any)
-	require.True(t, ok)
-	eventID, _ := cp["event_id"].(string)
-	require.NotEmpty(t, eventID, "lstk_command must carry an event_id")
-
-	assert.Equal(t, eventID, triggerEventID, "lstk_lifecycle.trigger_event_id must match lstk_command.event_id")
-}
-
-func TestStartCommandCorrelatesTelemetryEventIDs(t *testing.T) {
-	requireDocker(t)
-	_ = env.Require(t, env.AuthToken)
-	cleanup()
-	t.Cleanup(cleanup)
-
-	mockServer := createMockLicenseServer(true)
-	defer mockServer.Close()
-
-	analyticsSrv, events := mockAnalyticsServer(t)
-
-	ctx := testContext(t)
-	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL).
-		With(env.AnalyticsEndpoint, analyticsSrv.URL), "start")
-	require.NoError(t, err, "lstk start failed: %s", stderr)
-
-	byName := make(map[string]map[string]any)
-	deadline := time.After(5 * time.Second)
-	for len(byName) < 2 {
-		select {
-		case event := <-events:
-			name, _ := event["name"].(string)
-			byName[name] = event
-		case <-deadline:
-			t.Fatalf("timed out waiting for telemetry events; received: %v", byName)
-		}
-	}
-
-	lifecycle, ok := byName["lstk_lifecycle"]
-	require.True(t, ok, "expected lstk_lifecycle event")
-	lp, ok := lifecycle["payload"].(map[string]any)
-	require.True(t, ok)
-	triggerEventID, _ := lp["trigger_event_id"].(string)
-	require.NotEmpty(t, triggerEventID, "lstk_lifecycle must carry a trigger_event_id")
-
-	command, ok := byName["lstk_command"]
-	require.True(t, ok, "expected lstk_command event")
-	cp, ok := command["payload"].(map[string]any)
-	require.True(t, ok)
-	eventID, _ := cp["event_id"].(string)
-	require.NotEmpty(t, eventID, "lstk_command must carry an event_id")
-
-	assert.Equal(t, eventID, triggerEventID, "lstk_lifecycle.trigger_event_id must match lstk_command.event_id")
 }
 
 func TestStartCommandDoesNotSendTelemetryWhenDisabled(t *testing.T) {

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,12 +16,14 @@ import (
 func TestUpdateCheckCommand(t *testing.T) {
 	ctx := testContext(t)
 
-	stdout, stderr, err := runLstk(t, ctx, "", nil, "update", "--check")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "update", "--check")
 	require.NoError(t, err, "lstk update --check failed: %s", stderr)
 	requireExitCode(t, 0, err)
 
 	// Dev builds report a note about skipping update check
 	assert.Contains(t, stdout, "Note:", "should show a note (dev build or up-to-date)")
+	assertCommandTelemetry(t, events, "update", 0)
 }
 
 func TestUpdateCheckCommandNonInteractive(t *testing.T) {


### PR DESCRIPTION
We'll start tracking these events:
- `lstk_command`: generic command execution event with one stable schema (no subtype)
- `lstk_lifecycle`: emulator lifecycle event family, emitted per emulator/container instance with lifecycle subtypes (`start_success`, `stop`, `start_error`)

### Test
To test in local use: `LSTK_ANALYTICS_ENDPOINT=http://localhost:8000/v1/events ./bin/lstk <cmd>`