### PR TITLE
Wrap error title to terminal width

### DIFF
--- a/internal/ui/components/error_display.go
+++ b/internal/ui/components/error_display.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/ui/styles"
@@ -34,8 +35,19 @@ func (e ErrorDisplay) View(maxWidth int) string {
 
 	var sb strings.Builder
 
-	sb.WriteString(styles.ErrorTitle.Render("✗ " + e.event.Title))
-	sb.WriteString("\n")
+	titlePrefix := "✗ "
+	prefixWidth := utf8.RuneCountInString(titlePrefix)
+	titleWidth := maxWidth - prefixWidth
+	titleLines := wrap.SoftWrap(e.event.Title, titleWidth)
+	for i, line := range titleLines {
+		if i == 0 {
+			sb.WriteString(styles.ErrorTitle.Render(titlePrefix + line))
+		} else {
+			sb.WriteString(strings.Repeat(" ", prefixWidth))
+			sb.WriteString(styles.ErrorTitle.Render(line))
+		}
+		sb.WriteString("\n")
+	}
 
 	if e.event.Summary != "" {
 		prefix := "> "

--- a/internal/ui/components/error_display_test.go
+++ b/internal/ui/components/error_display_test.go
@@ -3,8 +3,10 @@ package components
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/ui/wrap"
 )
 
 func TestErrorDisplay_ShowView(t *testing.T) {
@@ -81,6 +83,36 @@ func TestErrorDisplay_MultiActionRenders(t *testing.T) {
 	}
 	if !strings.Contains(view, "/home/user/.config/lstk/config.toml") {
 		t.Fatalf("expected view to contain second action value, got: %q", view)
+	}
+}
+
+func TestErrorDisplay_TitleWrapsToWidth(t *testing.T) {
+	t.Parallel()
+
+	e := NewErrorDisplay()
+	longTitle := "license validation failed for localstack-pro:4.14.1.dev206: license validation failed: your token is invalid"
+	e = e.Show(output.ErrorEvent{Title: longTitle})
+
+	const maxWidth = 50
+
+	// Verify that View contains the full text (content presence check on styled output)
+	view := e.View(maxWidth)
+	if !strings.Contains(view, "invalid") {
+		t.Fatalf("expected view to contain full text, got: %q", view)
+	}
+
+	// Verify wrapping widths on unstyled text to avoid ANSI escape code interference
+	titlePrefix := "✗ "
+	prefixWidth := utf8.RuneCountInString(titlePrefix)
+	titleWidth := maxWidth - prefixWidth
+	wrappedLines := wrap.SoftWrap(longTitle, titleWidth)
+	if len(wrappedLines) < 2 {
+		t.Fatalf("expected title to wrap across multiple lines, got %d", len(wrappedLines))
+	}
+	for _, line := range wrappedLines {
+		if utf8.RuneCountInString(line) > titleWidth {
+			t.Errorf("wrapped line exceeds max width %d: %q (%d runes)", titleWidth, line, utf8.RuneCountInString(line))
+		}
 	}
 }
 


### PR DESCRIPTION
This will:
1. Soft-wrap the error display title so long messages (e.g. license validation failures) wrap at word boundaries instead of being truncated at the terminal edge.
1. Use rune count instead of byte length for the `✗ ` prefix to get correct indentation on continuation lines
1. Add test for title wrapping behavior

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="325" alt="Screenshot 2026-03-18 at 10 41 47" src="https://github.com/user-attachments/assets/856efd3d-075d-4c6b-9a73-910a756c8cb4" /> | <img width="669" height="325" alt="Screenshot 2026-03-18 at 10 41 30" src="https://github.com/user-attachments/assets/97cc75a5-725f-4a28-b27e-e665af5fd0f5" /> | 