### PR TITLE
Rotate tips shown after emulator start

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	stdruntime "runtime"
@@ -180,7 +181,11 @@ func emitPostStartPointers(sink output.Sink, resolvedHost, webAppURL string) {
 	if webAppURL != "" {
 		output.EmitSecondary(sink, fmt.Sprintf("• Web app: %s", strings.TrimRight(webAppURL, "/")))
 	}
-	output.EmitSecondary(sink, "> Tip: View emulator logs: lstk logs --follow")
+	tips := []string{
+		"> Tip: View emulator logs: lstk logs --follow",
+		"> Tip: View deployed resources: lstk status",
+	}
+	output.EmitSecondary(sink, tips[rand.IntN(len(tips))])
 }
 
 func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []runtime.ContainerConfig) error {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -37,12 +37,10 @@ func TestEmitPostStartPointers_WithWebApp(t *testing.T) {
 
 	emitPostStartPointers(sink, "localhost.localstack.cloud:4566", "https://app.localstack.cloud/")
 
-	assert.Equal(t, ""+
-		"• Endpoint: localhost.localstack.cloud:4566\n"+
-		"• Web app: https://app.localstack.cloud\n"+
-		"> Tip: View emulator logs: lstk logs --follow\n",
-		out.String(),
-	)
+	got := out.String()
+	assert.Contains(t, got, "• Endpoint: localhost.localstack.cloud:4566\n")
+	assert.Contains(t, got, "• Web app: https://app.localstack.cloud\n")
+	assert.Contains(t, got, "> Tip:")
 }
 
 func TestEmitPostStartPointers_WithoutWebApp(t *testing.T) {
@@ -51,11 +49,9 @@ func TestEmitPostStartPointers_WithoutWebApp(t *testing.T) {
 
 	emitPostStartPointers(sink, "127.0.0.1:4566", "")
 
-	assert.Equal(t, ""+
-		"• Endpoint: 127.0.0.1:4566\n"+
-		"> Tip: View emulator logs: lstk logs --follow\n",
-		out.String(),
-	)
+	got := out.String()
+	assert.Contains(t, got, "• Endpoint: 127.0.0.1:4566\n")
+	assert.Contains(t, got, "> Tip:")
 }
 
 func TestServicePortRange_Returns50Entries(t *testing.T) {


### PR DESCRIPTION
This will rotate between multiple tips after emulator start instead of always showing the same one. 

Currently rotates between `lstk logs --follow` and `lstk status`.

| Tip 1 | Tip 2 |
|--------|--------|
| <img width="669" height="380" alt="Screenshot 2026-03-18 at 11 05 00" src="https://github.com/user-attachments/assets/4dee75a7-6301-417f-a326-6c932964f7c1" /> | <img width="669" height="380" alt="Screenshot 2026-03-18 at 11 05 37" src="https://github.com/user-attachments/assets/0fd7c8cb-c77b-438d-ac8d-a765feec3af9" /> | 