### PR TITLE
Fix status command failing with non-default port

### DIFF
--- a/internal/container/status.go
+++ b/internal/container/status.go
@@ -39,7 +39,16 @@ func Status(ctx context.Context, rt runtime.Runtime, containers []config.Contain
 			return output.NewSilentError(fmt.Errorf("%s is not running", name))
 		}
 
-		host, _ := endpoint.ResolveHost(c.Port, localStackHost)
+		// status makes direct HTTP calls to LocalStack, so it needs the actual host port.
+		// Ask Docker rather than trusting the config: the user may have changed the config
+		// port while the container still runs on the old one.
+		port := c.Port
+		if containerPort, err := c.ContainerPort(); err == nil {
+			if actualPort, err := rt.GetBoundPort(ctx, name, containerPort); err == nil {
+				port = actualPort
+			}
+		}
+		host, _ := endpoint.ResolveHost(port, localStackHost)
 
 		var uptime time.Duration
 		if startedAt, err := rt.ContainerStartedAt(ctx, name); err == nil {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -284,6 +284,18 @@ func (d *DockerRuntime) StreamLogs(ctx context.Context, containerID string, out 
 	return nil
 }
 
+func (d *DockerRuntime) GetBoundPort(ctx context.Context, containerName string, containerPort string) (string, error) {
+	inspect, err := d.client.ContainerInspect(ctx, containerName)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect container: %w", err)
+	}
+	bindings, ok := inspect.NetworkSettings.Ports[nat.Port(containerPort)]
+	if !ok || len(bindings) == 0 {
+		return "", fmt.Errorf("no binding found for port %s on container %s", containerPort, containerName)
+	}
+	return bindings[0].HostPort, nil
+}
+
 func (d *DockerRuntime) GetImageVersion(ctx context.Context, imageName string) (string, error) {
 	inspect, err := d.client.ImageInspect(ctx, imageName)
 	if err != nil {

--- a/internal/runtime/mock_runtime.go
+++ b/internal/runtime/mock_runtime.go
@@ -70,6 +70,21 @@ func (mr *MockRuntimeMockRecorder) EmitUnhealthyError(sink, err any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmitUnhealthyError", reflect.TypeOf((*MockRuntime)(nil).EmitUnhealthyError), sink, err)
 }
 
+// GetBoundPort mocks base method.
+func (m *MockRuntime) GetBoundPort(ctx context.Context, containerName string, containerPort string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBoundPort", ctx, containerName, containerPort)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBoundPort indicates an expected call of GetBoundPort.
+func (mr *MockRuntimeMockRecorder) GetBoundPort(ctx, containerName, containerPort any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBoundPort", reflect.TypeOf((*MockRuntime)(nil).GetBoundPort), ctx, containerName, containerPort)
+}
+
 // GetImageVersion mocks base method.
 func (m *MockRuntime) GetImageVersion(ctx context.Context, imageName string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -55,5 +55,7 @@ type Runtime interface {
 	Logs(ctx context.Context, containerID string, tail int) (string, error)
 	StreamLogs(ctx context.Context, containerID string, out io.Writer, follow bool) error
 	GetImageVersion(ctx context.Context, imageName string) (string, error)
+	// GetBoundPort returns the host port bound to the given container port (e.g. "4566/tcp").
+	GetBoundPort(ctx context.Context, containerName string, containerPort string) (string, error)
 	SocketPath() string
 }

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
 	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/go-keyring"
@@ -169,7 +170,10 @@ const (
 	testImage     = "alpine:latest"
 )
 
-func startTestContainer(t *testing.T, ctx context.Context) {
+// startTestContainer starts the test container with no port bindings by default.
+// Pass hostPort to bind 4566/tcp to a specific host port (e.g. to test that lstk status
+// uses the actual bound port rather than the port from config).
+func startTestContainer(t *testing.T, ctx context.Context, hostPort ...string) {
 	t.Helper()
 
 	reader, err := dockerClient.ImagePull(ctx, testImage, image.PullOptions{})
@@ -177,10 +181,23 @@ func startTestContainer(t *testing.T, ctx context.Context) {
 	_, _ = io.Copy(io.Discard, reader)
 	_ = reader.Close()
 
-	resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
+	cfg := &container.Config{
 		Image: testImage,
 		Cmd:   []string{"sleep", "infinity"},
-	}, nil, nil, nil, containerName)
+	}
+	var hostCfg *container.HostConfig
+	if len(hostPort) > 0 {
+		const containerPort = nat.Port("4566/tcp")
+		cfg.ExposedPorts = nat.PortSet{containerPort: struct{}{}}
+		hostCfg = &container.HostConfig{
+			PortBindings: nat.PortMap{
+				// 127.0.0.2 avoids conflicting with the mock HTTP server on 127.0.0.1:hostPort.
+				containerPort: []nat.PortBinding{{HostIP: "127.0.0.2", HostPort: hostPort[0]}},
+			},
+		}
+	}
+
+	resp, err := dockerClient.ContainerCreate(ctx, cfg, hostCfg, nil, nil, containerName)
 	require.NoError(t, err, "failed to create test container")
 	err = dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
 	require.NoError(t, err, "failed to start test container")

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -2,8 +2,11 @@ package integration_test
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -64,6 +67,45 @@ func TestStatusCommandShowsResourcesWhenRunning(t *testing.T) {
 	assert.Contains(t, stdout, "my-bucket")
 	assert.Contains(t, stdout, "Lambda")
 	assert.Contains(t, stdout, "my-function")
+}
+
+func TestStatusCommandWorksWithNonDefaultPort(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+
+	// The mock server is assigned a random free port (guaranteed not to conflict).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_localstack/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"version": "4.14.1", "services": {}}`)
+		case "/_localstack/resources":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// Extract the port so we can bind it to the container.
+	_, mockPort, err := net.SplitHostPort(server.Listener.Addr().String())
+	require.NoError(t, err)
+
+	// Simulates starting LocalStack on a non-default host port.
+	startTestContainer(t, ctx, mockPort)
+
+	// Write a config with the default port 4566
+	// Simulates the user changing the config port after starting the container
+	configContent := "[[containers]]\ntype = \"aws\"\ntag = \"latest\"\nport = \"4566\"\n"
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	stdout, stderr, err := runLstk(t, ctx, "", nil, "--config", configFile, "status")
+	require.NoError(t, err, "lstk status failed: %s", stderr)
+	assert.Contains(t, stdout, "4.14.1")
 }
 
 func TestStatusCommandShowsNoResourcesWhenEmpty(t *testing.T) {


### PR DESCRIPTION
## Motivation

`lstk status` was always using the port from config to reach LocalStack's HTTP API. If the user changed the config port while a container was still running on the old port, status would try the wrong port and return a connection refused error.

## Changes

- `status` now reads the actual host port from Docker's port bindings via `GetBoundPort`, falling back to the config port if unavailable
- Added `GetBoundPort` to the `Runtime` interface, implemented in `DockerRuntime` and the mock
- Merged `startTestContainer` and `startTestContainerWithPortBinding` into a single variadic function

## Tests

Added `TestStatusCommandWorksWithNonDefaultPort`: starts a container with a non-default port binding, writes a config with the wrong port (4566), and verifies that `lstk status` still connects successfully using Docker's actual bound port.

Closes DRG-642