### PR TITLE
Add update notification prompt on command start

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,7 +122,7 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 
 	notifyOpts := update.NotifyOptions{
 		GitHubToken:    cfg.GitHubToken,
-		UpdatePrompt:   config.IsUpdatePromptEnabled(),
+		UpdatePrompt:   appConfig.UpdatePrompt,
 		PersistDisable: config.DisableUpdatePrompt,
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"github.com/localstack/lstk/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 )
 
 func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
@@ -121,12 +120,10 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 		Telemetry:        tel,
 	}
 
-	notifyOpts := ui.UpdateNotifyOptions{
-		GitHubToken:  cfg.GitHubToken,
-		UpdatePrompt: viper.GetBool("update_prompt"),
-		PersistDisable: func() error {
-			return config.Set("update_prompt", false)
-		},
+	notifyOpts := update.NotifyOptions{
+		GitHubToken:    cfg.GitHubToken,
+		UpdatePrompt:   config.IsUpdatePromptEnabled(),
+		PersistDisable: config.DisableUpdatePrompt,
 	}
 
 	if isInteractiveMode(cfg) {
@@ -134,7 +131,7 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 	}
 
 	sink := output.NewPlainSink(os.Stdout)
-	update.NotifyUpdate(ctx, sink, notifyOpts.GitHubToken, false, nil)
+	update.NotifyUpdate(ctx, sink, update.NotifyOptions{GitHubToken: cfg.GitHubToken})
 	return container.Start(ctx, rt, sink, opts, false)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,9 +17,11 @@ import (
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
+	"github.com/localstack/lstk/internal/update"
 	"github.com/localstack/lstk/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
@@ -119,10 +121,21 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 		Telemetry:        tel,
 	}
 
-	if isInteractiveMode(cfg) {
-		return ui.Run(ctx, rt, version.Version(), opts)
+	notifyOpts := ui.UpdateNotifyOptions{
+		GitHubToken:  cfg.GitHubToken,
+		UpdatePrompt: viper.GetBool("update_prompt"),
+		PersistDisable: func() error {
+			return config.Set("update_prompt", false)
+		},
 	}
-	return container.Start(ctx, rt, output.NewPlainSink(os.Stdout), opts, false)
+
+	if isInteractiveMode(cfg) {
+		return ui.Run(ctx, rt, version.Version(), opts, notifyOpts)
+	}
+
+	sink := output.NewPlainSink(os.Stdout)
+	update.NotifyUpdate(ctx, sink, notifyOpts.GitHubToken, false, nil)
+	return container.Start(ctx, rt, sink, opts, false)
 }
 
 func runStart(ctx context.Context, cmdFlags *pflag.FlagSet, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,14 @@ func Set(key string, value any) error {
 	return viper.WriteConfig()
 }
 
+func IsUpdatePromptEnabled() bool {
+	return viper.GetBool("update_prompt")
+}
+
+func DisableUpdatePrompt() error {
+	return Set("update_prompt", false)
+}
+
 func Get() (*Config, error) {
 	var cfg Config
 	if err := viper.Unmarshal(&cfg); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,8 +14,9 @@ import (
 var defaultConfigTemplate string
 
 type Config struct {
-	Containers []ContainerConfig            `mapstructure:"containers"`
-	Env        map[string]map[string]string `mapstructure:"env"`
+	Containers   []ContainerConfig            `mapstructure:"containers"`
+	Env          map[string]map[string]string `mapstructure:"env"`
+	UpdatePrompt bool                          `mapstructure:"update_prompt"`
 }
 
 func setDefaults() {
@@ -94,10 +95,6 @@ func resolvedConfigPath() string {
 func Set(key string, value any) error {
 	viper.Set(key, value)
 	return viper.WriteConfig()
-}
-
-func IsUpdatePromptEnabled() bool {
-	return viper.GetBool("update_prompt")
 }
 
 func DisableUpdatePrompt() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ func setDefaults() {
 			"port": "4566",
 		},
 	})
+	viper.SetDefault("update_prompt", true)
 }
 
 func loadConfig(path string) error {
@@ -88,6 +89,11 @@ func Init() error {
 
 func resolvedConfigPath() string {
 	return viper.ConfigFileUsed()
+}
+
+func Set(key string, value any) error {
+	viper.Set(key, value)
+	return viper.WriteConfig()
 }
 
 func Get() (*Config, error) {

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/localstack/lstk/internal/endpoint"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/update"
 	"golang.org/x/term"
 )
 
@@ -24,7 +25,13 @@ func (s programSender) Send(msg any) {
 	s.p.Send(msg)
 }
 
-func Run(parentCtx context.Context, rt runtime.Runtime, version string, opts container.StartOptions) error {
+type UpdateNotifyOptions struct {
+	GitHubToken    string
+	UpdatePrompt   bool
+	PersistDisable func() error
+}
+
+func Run(parentCtx context.Context, rt runtime.Runtime, version string, opts container.StartOptions, notifyOpts UpdateNotifyOptions) error {
 	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
@@ -45,7 +52,12 @@ func Run(parentCtx context.Context, rt runtime.Runtime, version string, opts con
 	go func() {
 		var err error
 		defer func() { runErrCh <- err }()
-		err = container.Start(ctx, rt, output.NewTUISink(programSender{p: p}), opts, true)
+		sink := output.NewTUISink(programSender{p: p})
+		if update.NotifyUpdate(ctx, sink, notifyOpts.GitHubToken, notifyOpts.UpdatePrompt, notifyOpts.PersistDisable) {
+			p.Send(runDoneMsg{})
+			return
+		}
+		err = container.Start(ctx, rt, sink, opts, true)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -25,13 +25,7 @@ func (s programSender) Send(msg any) {
 	s.p.Send(msg)
 }
 
-type UpdateNotifyOptions struct {
-	GitHubToken    string
-	UpdatePrompt   bool
-	PersistDisable func() error
-}
-
-func Run(parentCtx context.Context, rt runtime.Runtime, version string, opts container.StartOptions, notifyOpts UpdateNotifyOptions) error {
+func Run(parentCtx context.Context, rt runtime.Runtime, version string, opts container.StartOptions, notifyOpts update.NotifyOptions) error {
 	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
@@ -53,7 +47,7 @@ func Run(parentCtx context.Context, rt runtime.Runtime, version string, opts con
 		var err error
 		defer func() { runErrCh <- err }()
 		sink := output.NewTUISink(programSender{p: p})
-		if update.NotifyUpdate(ctx, sink, notifyOpts.GitHubToken, notifyOpts.UpdatePrompt, notifyOpts.PersistDisable) {
+		if update.NotifyUpdate(ctx, sink, notifyOpts) {
 			p.Send(runDoneMsg{})
 			return
 		}

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -13,7 +13,7 @@ import (
 
 const githubRepo = "localstack/lstk"
 
-var latestReleaseURL = "https://api.github.com/repos/" + githubRepo + "/releases/latest"
+const latestReleaseURL = "https://api.github.com/repos/" + githubRepo + "/releases/latest"
 
 type githubRelease struct {
 	TagName string        `json:"tag_name"`

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -11,10 +11,9 @@ import (
 	goruntime "runtime"
 )
 
-const (
-	githubRepo       = "localstack/lstk"
-	latestReleaseURL = "https://api.github.com/repos/" + githubRepo + "/releases/latest"
-)
+const githubRepo = "localstack/lstk"
+
+var latestReleaseURL = "https://api.github.com/repos/" + githubRepo + "/releases/latest"
 
 type githubRelease struct {
 	TagName string        `json:"tag_name"`

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -44,17 +44,6 @@ func checkQuietlyWithVersion(ctx context.Context, githubToken string, currentVer
 	return current, latestVer, true
 }
 
-func UpdateCommandHint(info InstallInfo) string {
-	switch info.Method {
-	case InstallHomebrew:
-		return "brew upgrade localstack/tap/lstk"
-	case InstallNPM:
-		return "npm install -g @localstack/lstk@latest"
-	default:
-		return "lstk update"
-	}
-}
-
 func NotifyUpdate(ctx context.Context, sink output.Sink, opts NotifyOptions) (exitAfter bool) {
 	return notifyUpdateWithVersion(ctx, sink, opts, version.Version(), fetchLatestVersion)
 }
@@ -66,7 +55,7 @@ func notifyUpdateWithVersion(ctx context.Context, sink output.Sink, opts NotifyO
 	}
 
 	if !opts.UpdatePrompt {
-		output.EmitNote(sink, fmt.Sprintf("Update available: %s → %s (run %s)", current, latest, UpdateCommandHint(DetectInstallMethod())))
+		output.EmitNote(sink, fmt.Sprintf("Update available: %s → %s (run lstk update)", current, latest))
 		return false
 	}
 

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -3,22 +3,30 @@ package update
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/version"
 )
 
+type versionFetcher func(ctx context.Context, token string) (string, error)
+
+const checkTimeout = 500 * time.Millisecond
+
 func CheckQuietly(ctx context.Context, githubToken string) (current, latest string, available bool) {
-	return checkQuietlyWithVersion(ctx, githubToken, version.Version())
+	return checkQuietlyWithVersion(ctx, githubToken, version.Version(), fetchLatestVersion)
 }
 
-func checkQuietlyWithVersion(ctx context.Context, githubToken string, currentVersion string) (current, latest string, available bool) {
+func checkQuietlyWithVersion(ctx context.Context, githubToken string, currentVersion string, fetch versionFetcher) (current, latest string, available bool) {
 	current = currentVersion
 	if current == "dev" {
 		return current, "", false
 	}
 
-	latestVer, err := fetchLatestVersion(ctx, githubToken)
+	ctx, cancel := context.WithTimeout(ctx, checkTimeout)
+	defer cancel()
+
+	latestVer, err := fetch(ctx, githubToken)
 	if err != nil {
 		return current, "", false
 	}
@@ -42,11 +50,11 @@ func UpdateCommandHint(info InstallInfo) string {
 }
 
 func NotifyUpdate(ctx context.Context, sink output.Sink, githubToken string, updatePrompt bool, persistDisable func() error) (exitAfter bool) {
-	return notifyUpdateWithVersion(ctx, sink, githubToken, updatePrompt, persistDisable, version.Version())
+	return notifyUpdateWithVersion(ctx, sink, githubToken, updatePrompt, persistDisable, version.Version(), fetchLatestVersion)
 }
 
-func notifyUpdateWithVersion(ctx context.Context, sink output.Sink, githubToken string, updatePrompt bool, persistDisable func() error, currentVersion string) (exitAfter bool) {
-	current, latest, available := checkQuietlyWithVersion(ctx, githubToken, currentVersion)
+func notifyUpdateWithVersion(ctx context.Context, sink output.Sink, githubToken string, updatePrompt bool, persistDisable func() error, currentVersion string, fetch versionFetcher) (exitAfter bool) {
+	current, latest, available := checkQuietlyWithVersion(ctx, githubToken, currentVersion, fetch)
 	if !available {
 		return false
 	}

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -11,6 +11,12 @@ import (
 
 type versionFetcher func(ctx context.Context, token string) (string, error)
 
+type NotifyOptions struct {
+	GitHubToken    string
+	UpdatePrompt   bool
+	PersistDisable func() error
+}
+
 const checkTimeout = 500 * time.Millisecond
 
 func CheckQuietly(ctx context.Context, githubToken string) (current, latest string, available bool) {
@@ -49,22 +55,22 @@ func UpdateCommandHint(info InstallInfo) string {
 	}
 }
 
-func NotifyUpdate(ctx context.Context, sink output.Sink, githubToken string, updatePrompt bool, persistDisable func() error) (exitAfter bool) {
-	return notifyUpdateWithVersion(ctx, sink, githubToken, updatePrompt, persistDisable, version.Version(), fetchLatestVersion)
+func NotifyUpdate(ctx context.Context, sink output.Sink, opts NotifyOptions) (exitAfter bool) {
+	return notifyUpdateWithVersion(ctx, sink, opts, version.Version(), fetchLatestVersion)
 }
 
-func notifyUpdateWithVersion(ctx context.Context, sink output.Sink, githubToken string, updatePrompt bool, persistDisable func() error, currentVersion string, fetch versionFetcher) (exitAfter bool) {
-	current, latest, available := checkQuietlyWithVersion(ctx, githubToken, currentVersion, fetch)
+func notifyUpdateWithVersion(ctx context.Context, sink output.Sink, opts NotifyOptions, currentVersion string, fetch versionFetcher) (exitAfter bool) {
+	current, latest, available := checkQuietlyWithVersion(ctx, opts.GitHubToken, currentVersion, fetch)
 	if !available {
 		return false
 	}
 
-	if !updatePrompt {
+	if !opts.UpdatePrompt {
 		output.EmitNote(sink, fmt.Sprintf("Update available: %s → %s (run %s)", current, latest, UpdateCommandHint(DetectInstallMethod())))
 		return false
 	}
 
-	return promptAndUpdate(ctx, sink, githubToken, current, latest, persistDisable)
+	return promptAndUpdate(ctx, sink, opts.GitHubToken, current, latest, opts.PersistDisable)
 }
 
 func promptAndUpdate(ctx context.Context, sink output.Sink, githubToken string, current, latest string, persistDisable func() error) (exitAfter bool) {

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -1,0 +1,105 @@
+package update
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/version"
+)
+
+func CheckQuietly(ctx context.Context, githubToken string) (current, latest string, available bool) {
+	return checkQuietlyWithVersion(ctx, githubToken, version.Version())
+}
+
+func checkQuietlyWithVersion(ctx context.Context, githubToken string, currentVersion string) (current, latest string, available bool) {
+	current = currentVersion
+	if current == "dev" {
+		return current, "", false
+	}
+
+	latestVer, err := fetchLatestVersion(ctx, githubToken)
+	if err != nil {
+		return current, "", false
+	}
+
+	if normalizeVersion(current) == normalizeVersion(latestVer) {
+		return current, latestVer, false
+	}
+
+	return current, latestVer, true
+}
+
+func UpdateCommandHint(info InstallInfo) string {
+	switch info.Method {
+	case InstallHomebrew:
+		return "brew upgrade localstack/tap/lstk"
+	case InstallNPM:
+		return "npm install -g @localstack/lstk@latest"
+	default:
+		return "lstk update"
+	}
+}
+
+func NotifyUpdate(ctx context.Context, sink output.Sink, githubToken string, updatePrompt bool, persistDisable func() error) (exitAfter bool) {
+	return notifyUpdateWithVersion(ctx, sink, githubToken, updatePrompt, persistDisable, version.Version())
+}
+
+func notifyUpdateWithVersion(ctx context.Context, sink output.Sink, githubToken string, updatePrompt bool, persistDisable func() error, currentVersion string) (exitAfter bool) {
+	current, latest, available := checkQuietlyWithVersion(ctx, githubToken, currentVersion)
+	if !available {
+		return false
+	}
+
+	if !updatePrompt {
+		output.EmitNote(sink, fmt.Sprintf("Update available: %s → %s (run %s)", current, latest, UpdateCommandHint(DetectInstallMethod())))
+		return false
+	}
+
+	return promptAndUpdate(ctx, sink, githubToken, current, latest, persistDisable)
+}
+
+func promptAndUpdate(ctx context.Context, sink output.Sink, githubToken string, current, latest string, persistDisable func() error) (exitAfter bool) {
+	output.EmitWarning(sink, fmt.Sprintf("Update available: %s → %s", current, latest))
+
+	responseCh := make(chan output.InputResponse, 1)
+	output.EmitUserInputRequest(sink, output.UserInputRequestEvent{
+		Prompt: "A new version is available",
+		Options: []output.InputOption{
+			{Key: "u", Label: "Update"},
+			{Key: "s", Label: "SKIP"},
+			{Key: "n", Label: "Never ask again"},
+		},
+		ResponseCh: responseCh,
+	})
+
+	var resp output.InputResponse
+	select {
+	case resp = <-responseCh:
+	case <-ctx.Done():
+		return false
+	}
+
+	if resp.Cancelled {
+		return false
+	}
+
+	switch resp.SelectedKey {
+	case "u":
+		if err := applyUpdate(ctx, sink, latest, githubToken); err != nil {
+			output.EmitWarning(sink, fmt.Sprintf("Update failed: %v", err))
+			return false
+		}
+		output.EmitSuccess(sink, fmt.Sprintf("Updated to %s — please re-run your command.", latest))
+		return true
+	case "n":
+		if persistDisable != nil {
+			if err := persistDisable(); err != nil {
+				output.EmitWarning(sink, fmt.Sprintf("Failed to save preference: %v", err))
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}

--- a/internal/update/notify_test.go
+++ b/internal/update/notify_test.go
@@ -1,0 +1,177 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/localstack/lstk/internal/output"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestGitHubServer(t *testing.T, tagName string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := githubRelease{TagName: tagName}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatal(err)
+		}
+	}))
+}
+
+func withLatestReleaseURL(t *testing.T, url string) func() {
+	t.Helper()
+	orig := latestReleaseURL
+	latestReleaseURL = url
+	return func() { latestReleaseURL = orig }
+}
+
+func TestCheckQuietlyDevBuild(t *testing.T) {
+	current, latest, available := CheckQuietly(context.Background(), "")
+	assert.Equal(t, "dev", current)
+	assert.Empty(t, latest)
+	assert.False(t, available)
+}
+
+func TestCheckQuietlyNetworkError(t *testing.T) {
+	cleanup := withLatestReleaseURL(t, "http://localhost:1/nonexistent")
+	defer cleanup()
+
+	current, latest, available := checkQuietlyWithVersion(context.Background(), "", "1.0.0")
+	assert.Equal(t, "1.0.0", current)
+	assert.Empty(t, latest)
+	assert.False(t, available)
+}
+
+func TestCheckQuietlyUpdateAvailable(t *testing.T) {
+	server := newTestGitHubServer(t, "v2.0.0")
+	defer server.Close()
+	cleanup := withLatestReleaseURL(t, server.URL)
+	defer cleanup()
+
+	current, latest, available := checkQuietlyWithVersion(context.Background(), "", "1.0.0")
+	assert.Equal(t, "1.0.0", current)
+	assert.Equal(t, "v2.0.0", latest)
+	assert.True(t, available)
+}
+
+func TestCheckQuietlyAlreadyUpToDate(t *testing.T) {
+	server := newTestGitHubServer(t, "v1.0.0")
+	defer server.Close()
+	cleanup := withLatestReleaseURL(t, server.URL)
+	defer cleanup()
+
+	current, latest, available := checkQuietlyWithVersion(context.Background(), "", "v1.0.0")
+	assert.Equal(t, "v1.0.0", current)
+	assert.Equal(t, "v1.0.0", latest)
+	assert.False(t, available)
+}
+
+func TestUpdateCommandHint(t *testing.T) {
+	tests := []struct {
+		method InstallMethod
+		want   string
+	}{
+		{InstallHomebrew, "brew upgrade localstack/tap/lstk"},
+		{InstallNPM, "npm install -g @localstack/lstk@latest"},
+		{InstallBinary, "lstk update"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, UpdateCommandHint(InstallInfo{Method: tt.method}))
+	}
+}
+
+func TestNotifyUpdateNoUpdateAvailable(t *testing.T) {
+	server := newTestGitHubServer(t, "v1.0.0")
+	defer server.Close()
+	cleanup := withLatestReleaseURL(t, server.URL)
+	defer cleanup()
+
+	var events []any
+	sink := output.SinkFunc(func(event any) { events = append(events, event) })
+
+	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "v1.0.0")
+	assert.False(t, exit)
+	assert.Empty(t, events)
+}
+
+func TestNotifyUpdatePromptDisabled(t *testing.T) {
+	server := newTestGitHubServer(t, "v2.0.0")
+	defer server.Close()
+	cleanup := withLatestReleaseURL(t, server.URL)
+	defer cleanup()
+
+	var events []any
+	sink := output.SinkFunc(func(event any) { events = append(events, event) })
+
+	exit := notifyUpdateWithVersion(context.Background(), sink, "", false, nil, "1.0.0")
+	assert.False(t, exit)
+	assert.Len(t, events, 1)
+	msg, ok := events[0].(output.MessageEvent)
+	assert.True(t, ok)
+	assert.Equal(t, output.SeverityNote, msg.Severity)
+	assert.Contains(t, msg.Text, "Update available")
+}
+
+func TestNotifyUpdatePromptSkip(t *testing.T) {
+	server := newTestGitHubServer(t, "v2.0.0")
+	defer server.Close()
+	cleanup := withLatestReleaseURL(t, server.URL)
+	defer cleanup()
+
+	var events []any
+	sink := output.SinkFunc(func(event any) {
+		events = append(events, event)
+		if req, ok := event.(output.UserInputRequestEvent); ok {
+			req.ResponseCh <- output.InputResponse{SelectedKey: "s"}
+		}
+	})
+
+	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "1.0.0")
+	assert.False(t, exit)
+}
+
+func TestNotifyUpdatePromptNever(t *testing.T) {
+	server := newTestGitHubServer(t, "v2.0.0")
+	defer server.Close()
+	cleanup := withLatestReleaseURL(t, server.URL)
+	defer cleanup()
+
+	persistCalled := false
+
+	var events []any
+	sink := output.SinkFunc(func(event any) {
+		events = append(events, event)
+		if req, ok := event.(output.UserInputRequestEvent); ok {
+			req.ResponseCh <- output.InputResponse{SelectedKey: "n"}
+		}
+	})
+
+	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, func() error {
+		persistCalled = true
+		return nil
+	}, "1.0.0")
+	assert.False(t, exit)
+	assert.True(t, persistCalled)
+}
+
+func TestNotifyUpdatePromptCancelled(t *testing.T) {
+	server := newTestGitHubServer(t, "v2.0.0")
+	defer server.Close()
+	cleanup := withLatestReleaseURL(t, server.URL)
+	defer cleanup()
+
+	var events []any
+	sink := output.SinkFunc(func(event any) {
+		events = append(events, event)
+		if req, ok := event.(output.UserInputRequestEvent); ok {
+			req.ResponseCh <- output.InputResponse{Cancelled: true}
+		}
+	})
+
+	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "1.0.0")
+	assert.False(t, exit)
+}

--- a/internal/update/notify_test.go
+++ b/internal/update/notify_test.go
@@ -80,20 +80,6 @@ func TestCheckQuietlyAlreadyUpToDate(t *testing.T) {
 	assert.False(t, available)
 }
 
-func TestUpdateCommandHint(t *testing.T) {
-	tests := []struct {
-		method InstallMethod
-		want   string
-	}{
-		{InstallHomebrew, "brew upgrade localstack/tap/lstk"},
-		{InstallNPM, "npm install -g @localstack/lstk@latest"},
-		{InstallBinary, "lstk update"},
-	}
-	for _, tt := range tests {
-		assert.Equal(t, tt.want, UpdateCommandHint(InstallInfo{Method: tt.method}))
-	}
-}
-
 func TestNotifyUpdateNoUpdateAvailable(t *testing.T) {
 	server := newTestGitHubServer(t, "v1.0.0")
 	defer server.Close()

--- a/internal/update/notify_test.go
+++ b/internal/update/notify_test.go
@@ -101,7 +101,7 @@ func TestNotifyUpdateNoUpdateAvailable(t *testing.T) {
 	var events []any
 	sink := output.SinkFunc(func(event any) { events = append(events, event) })
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "v1.0.0", testFetcher(server.URL))
+	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{UpdatePrompt: true}, "v1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 	assert.Empty(t, events)
 }
@@ -113,7 +113,7 @@ func TestNotifyUpdatePromptDisabled(t *testing.T) {
 	var events []any
 	sink := output.SinkFunc(func(event any) { events = append(events, event) })
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, "", false, nil, "1.0.0", testFetcher(server.URL))
+	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{}, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 	assert.Len(t, events, 1)
 	msg, ok := events[0].(output.MessageEvent)
@@ -134,7 +134,7 @@ func TestNotifyUpdatePromptSkip(t *testing.T) {
 		}
 	})
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "1.0.0", testFetcher(server.URL))
+	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{UpdatePrompt: true}, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 }
 
@@ -152,9 +152,12 @@ func TestNotifyUpdatePromptNever(t *testing.T) {
 		}
 	})
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, func() error {
-		persistCalled = true
-		return nil
+	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{
+		UpdatePrompt: true,
+		PersistDisable: func() error {
+			persistCalled = true
+			return nil
+		},
 	}, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 	assert.True(t, persistCalled)
@@ -172,6 +175,6 @@ func TestNotifyUpdatePromptCancelled(t *testing.T) {
 		}
 	})
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "1.0.0", testFetcher(server.URL))
+	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{UpdatePrompt: true}, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 }

--- a/internal/update/notify_test.go
+++ b/internal/update/notify_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,11 +23,23 @@ func newTestGitHubServer(t *testing.T, tagName string) *httptest.Server {
 	}))
 }
 
-func withLatestReleaseURL(t *testing.T, url string) func() {
-	t.Helper()
-	orig := latestReleaseURL
-	latestReleaseURL = url
-	return func() { latestReleaseURL = orig }
+func testFetcher(serverURL string) versionFetcher {
+	return func(ctx context.Context, token string) (string, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, serverURL, nil)
+		if err != nil {
+			return "", err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		var release githubRelease
+		if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+			return "", err
+		}
+		return release.TagName, nil
+	}
 }
 
 func TestCheckQuietlyDevBuild(t *testing.T) {
@@ -37,10 +50,11 @@ func TestCheckQuietlyDevBuild(t *testing.T) {
 }
 
 func TestCheckQuietlyNetworkError(t *testing.T) {
-	cleanup := withLatestReleaseURL(t, "http://localhost:1/nonexistent")
-	defer cleanup()
+	fetch := func(ctx context.Context, token string) (string, error) {
+		return "", fmt.Errorf("connection refused")
+	}
 
-	current, latest, available := checkQuietlyWithVersion(context.Background(), "", "1.0.0")
+	current, latest, available := checkQuietlyWithVersion(context.Background(), "", "1.0.0", fetch)
 	assert.Equal(t, "1.0.0", current)
 	assert.Empty(t, latest)
 	assert.False(t, available)
@@ -49,10 +63,8 @@ func TestCheckQuietlyNetworkError(t *testing.T) {
 func TestCheckQuietlyUpdateAvailable(t *testing.T) {
 	server := newTestGitHubServer(t, "v2.0.0")
 	defer server.Close()
-	cleanup := withLatestReleaseURL(t, server.URL)
-	defer cleanup()
 
-	current, latest, available := checkQuietlyWithVersion(context.Background(), "", "1.0.0")
+	current, latest, available := checkQuietlyWithVersion(context.Background(), "", "1.0.0", testFetcher(server.URL))
 	assert.Equal(t, "1.0.0", current)
 	assert.Equal(t, "v2.0.0", latest)
 	assert.True(t, available)
@@ -61,10 +73,8 @@ func TestCheckQuietlyUpdateAvailable(t *testing.T) {
 func TestCheckQuietlyAlreadyUpToDate(t *testing.T) {
 	server := newTestGitHubServer(t, "v1.0.0")
 	defer server.Close()
-	cleanup := withLatestReleaseURL(t, server.URL)
-	defer cleanup()
 
-	current, latest, available := checkQuietlyWithVersion(context.Background(), "", "v1.0.0")
+	current, latest, available := checkQuietlyWithVersion(context.Background(), "", "v1.0.0", testFetcher(server.URL))
 	assert.Equal(t, "v1.0.0", current)
 	assert.Equal(t, "v1.0.0", latest)
 	assert.False(t, available)
@@ -87,13 +97,11 @@ func TestUpdateCommandHint(t *testing.T) {
 func TestNotifyUpdateNoUpdateAvailable(t *testing.T) {
 	server := newTestGitHubServer(t, "v1.0.0")
 	defer server.Close()
-	cleanup := withLatestReleaseURL(t, server.URL)
-	defer cleanup()
 
 	var events []any
 	sink := output.SinkFunc(func(event any) { events = append(events, event) })
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "v1.0.0")
+	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "v1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 	assert.Empty(t, events)
 }
@@ -101,13 +109,11 @@ func TestNotifyUpdateNoUpdateAvailable(t *testing.T) {
 func TestNotifyUpdatePromptDisabled(t *testing.T) {
 	server := newTestGitHubServer(t, "v2.0.0")
 	defer server.Close()
-	cleanup := withLatestReleaseURL(t, server.URL)
-	defer cleanup()
 
 	var events []any
 	sink := output.SinkFunc(func(event any) { events = append(events, event) })
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, "", false, nil, "1.0.0")
+	exit := notifyUpdateWithVersion(context.Background(), sink, "", false, nil, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 	assert.Len(t, events, 1)
 	msg, ok := events[0].(output.MessageEvent)
@@ -119,8 +125,6 @@ func TestNotifyUpdatePromptDisabled(t *testing.T) {
 func TestNotifyUpdatePromptSkip(t *testing.T) {
 	server := newTestGitHubServer(t, "v2.0.0")
 	defer server.Close()
-	cleanup := withLatestReleaseURL(t, server.URL)
-	defer cleanup()
 
 	var events []any
 	sink := output.SinkFunc(func(event any) {
@@ -130,15 +134,13 @@ func TestNotifyUpdatePromptSkip(t *testing.T) {
 		}
 	})
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "1.0.0")
+	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 }
 
 func TestNotifyUpdatePromptNever(t *testing.T) {
 	server := newTestGitHubServer(t, "v2.0.0")
 	defer server.Close()
-	cleanup := withLatestReleaseURL(t, server.URL)
-	defer cleanup()
 
 	persistCalled := false
 
@@ -153,7 +155,7 @@ func TestNotifyUpdatePromptNever(t *testing.T) {
 	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, func() error {
 		persistCalled = true
 		return nil
-	}, "1.0.0")
+	}, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 	assert.True(t, persistCalled)
 }
@@ -161,8 +163,6 @@ func TestNotifyUpdatePromptNever(t *testing.T) {
 func TestNotifyUpdatePromptCancelled(t *testing.T) {
 	server := newTestGitHubServer(t, "v2.0.0")
 	defer server.Close()
-	cleanup := withLatestReleaseURL(t, server.URL)
-	defer cleanup()
 
 	var events []any
 	sink := output.SinkFunc(func(event any) {
@@ -172,6 +172,6 @@ func TestNotifyUpdatePromptCancelled(t *testing.T) {
 		}
 	})
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "1.0.0")
+	exit := notifyUpdateWithVersion(context.Background(), sink, "", true, nil, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -46,8 +46,18 @@ func Update(ctx context.Context, sink output.Sink, checkOnly bool, githubToken s
 		return nil
 	}
 
+	if err := applyUpdate(ctx, sink, latest, githubToken); err != nil {
+		return err
+	}
+
+	output.EmitSuccess(sink, fmt.Sprintf("Updated to %s", latest))
+	return nil
+}
+
+func applyUpdate(ctx context.Context, sink output.Sink, latest, githubToken string) error {
 	info := DetectInstallMethod()
 
+	var err error
 	switch info.Method {
 	case InstallHomebrew:
 		output.EmitNote(sink, "Installed through Homebrew, running brew upgrade")
@@ -69,7 +79,6 @@ func Update(ctx context.Context, sink output.Sink, checkOnly bool, githubToken s
 		return fmt.Errorf("update failed: %w", err)
 	}
 
-	output.EmitSuccess(sink, fmt.Sprintf("Updated to %s", latest))
 	return nil
 }
 

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -1,13 +1,18 @@
 package integration_test
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/creack/pty"
 	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -206,6 +211,185 @@ func TestUpdateHomebrew(t *testing.T) {
 	requireExitCode(t, 0, err)
 	assert.Contains(t, updateStr, "Homebrew", "should detect Homebrew install")
 	assert.Contains(t, updateStr, "brew upgrade", "should mention brew upgrade")
+}
+
+func TestUpdateNotification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	ctx := testContext(t)
+
+	// Build a fake old version to a temp location
+	tmpBinary := filepath.Join(t.TempDir(), "lstk")
+	repoRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+
+	buildCmd := exec.CommandContext(ctx, "go", "build",
+		"-ldflags", "-X github.com/localstack/lstk/internal/version.version=0.0.1",
+		"-o", tmpBinary,
+		".",
+	)
+	buildCmd.Dir = repoRoot
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", string(out))
+
+	// Mock API server so license validation fails fast after the notification
+	mockServer := createMockLicenseServer(false)
+	defer mockServer.Close()
+
+	t.Run("prompt_disabled", func(t *testing.T) {
+		configFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(configFile, []byte("update_prompt = false\n"), 0o644))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, tmpBinary, "--config", configFile)
+		cmd.Env = env.Without(env.AuthToken).With(env.AuthToken, "fake-token").With(env.APIEndpoint, mockServer.URL)
+
+		ptmx, err := pty.Start(cmd)
+		require.NoError(t, err, "failed to start command in PTY")
+		defer func() { _ = ptmx.Close() }()
+
+		output := &syncBuffer{}
+		outputCh := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(output, ptmx)
+			close(outputCh)
+		}()
+
+		// Process should exit without prompting (license validation fails)
+		_ = cmd.Wait()
+		<-outputCh
+
+		out := output.String()
+		assert.Contains(t, out, "Update available: 0.0.1", "should show update note")
+		assert.Contains(t, out, "lstk update", "should include the update command hint")
+		assert.NotContains(t, out, "new version is available", "should not show interactive prompt")
+	})
+
+	t.Run("skip", func(t *testing.T) {
+		configFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(configFile, []byte("update_prompt = true\n"), 0o644))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, tmpBinary, "--config", configFile)
+		cmd.Env = env.Without(env.AuthToken).With(env.AuthToken, "fake-token").With(env.APIEndpoint, mockServer.URL)
+
+		ptmx, err := pty.Start(cmd)
+		require.NoError(t, err, "failed to start command in PTY")
+		defer func() { _ = ptmx.Close() }()
+
+		output := &syncBuffer{}
+		outputCh := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(output, ptmx)
+			close(outputCh)
+		}()
+
+		require.Eventually(t, func() bool {
+			return bytes.Contains(output.Bytes(), []byte("new version is available"))
+		}, 10*time.Second, 100*time.Millisecond, "update notification prompt should appear")
+
+		_, err = ptmx.Write([]byte("s"))
+		require.NoError(t, err)
+
+		_ = cmd.Wait()
+		<-outputCh
+
+		assert.Contains(t, output.String(), "Update available: 0.0.1")
+	})
+
+	t.Run("never", func(t *testing.T) {
+		configFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(configFile, []byte("update_prompt = true\n"), 0o644))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, tmpBinary, "--config", configFile)
+		cmd.Env = env.Without(env.AuthToken).With(env.AuthToken, "fake-token").With(env.APIEndpoint, mockServer.URL)
+
+		ptmx, err := pty.Start(cmd)
+		require.NoError(t, err, "failed to start command in PTY")
+		defer func() { _ = ptmx.Close() }()
+
+		output := &syncBuffer{}
+		outputCh := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(output, ptmx)
+			close(outputCh)
+		}()
+
+		require.Eventually(t, func() bool {
+			return bytes.Contains(output.Bytes(), []byte("new version is available"))
+		}, 10*time.Second, 100*time.Millisecond, "update notification prompt should appear")
+
+		_, err = ptmx.Write([]byte("n"))
+		require.NoError(t, err)
+
+		_ = cmd.Wait()
+		<-outputCh
+
+		assert.Contains(t, output.String(), "Update available: 0.0.1")
+
+		// Verify config was updated to disable future prompts
+		configData, err := os.ReadFile(configFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(configData), "update_prompt = false")
+	})
+
+	t.Run("update", func(t *testing.T) {
+		// Copy binary since it will be replaced during the update
+		updateBinary := filepath.Join(t.TempDir(), "lstk")
+		data, err := os.ReadFile(tmpBinary)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(updateBinary, data, 0o755))
+
+		configFile := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(configFile, []byte("update_prompt = true\n"), 0o644))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, updateBinary, "--config", configFile)
+		cmd.Env = env.Without(env.AuthToken).With(env.AuthToken, "fake-token").With(env.APIEndpoint, mockServer.URL)
+
+		ptmx, err := pty.Start(cmd)
+		require.NoError(t, err, "failed to start command in PTY")
+		defer func() { _ = ptmx.Close() }()
+
+		output := &syncBuffer{}
+		outputCh := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(output, ptmx)
+			close(outputCh)
+		}()
+
+		require.Eventually(t, func() bool {
+			return bytes.Contains(output.Bytes(), []byte("new version is available"))
+		}, 10*time.Second, 100*time.Millisecond, "update notification prompt should appear")
+
+		_, err = ptmx.Write([]byte("u"))
+		require.NoError(t, err)
+
+		err = cmd.Wait()
+		<-outputCh
+
+		out := output.String()
+		require.NoError(t, err, "update should succeed: %s", out)
+		assert.Contains(t, out, "Update available: 0.0.1")
+		assert.Contains(t, out, "Updated to")
+
+		// Verify the binary was actually replaced
+		verCmd := exec.CommandContext(ctx, updateBinary, "--version")
+		verOut, err := verCmd.CombinedOutput()
+		require.NoError(t, err)
+		assert.NotContains(t, string(verOut), "0.0.1", "binary should no longer be the old version")
+	})
 }
 
 func npmPlatformPackage() string {


### PR DESCRIPTION
## Motivation

Users don't know when a new CLI version is available unless they manually run `lstk update --check`. This adds a check on every start so users are prompted to update.

## Changes

- Add `CheckQuietly`, `NotifyUpdate`, and `UpdateCommandHint` in `internal/update/notify.go` to silently check for updates and prompt interactive users
- Extract `applyUpdate` from `Update` so the notify flow can run the update without a redundant version check
- Add `update_prompt` config default (`true`) and `config.Set` for persisting config changes
- Wire update notification into `ui.Run` (TUI) and the non-interactive path in `cmd/root.go`
- Interactive mode shows a prompt: Update / SKIP / Never ask again
- Non-interactive mode emits a note with the update command hint
- Change `latestReleaseURL` from const to var to allow test overrides

## Tests

- Unit tests for `CheckQuietly` (dev build, network error, update available, up-to-date)
- Unit tests for `UpdateCommandHint` (homebrew, npm, binary)
- Unit tests for `NotifyUpdate` (no update, prompt disabled, skip, never, cancelled)
- Manual TUI verification via tmux for all three prompt options (u/s/n) and non-interactive mode

## Related

- [FLC-472](https://linear.app/localstack/issue/FLC-472/prompt-notifications-to-update-cli)