### PR TITLE
Add --verbose flag to bypass log filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Running `lstk` will automatically handle configuration setup and start LocalStac
 - **Start / stop / status** — manage LocalStack emulators with a single command
 - **Interactive TUI** — a Bubble Tea-powered terminal UI when run in an interactive shell
 - **Plain output** for CI/CD and scripting (auto-detected in non-interactive environments or forced with `--non-interactive`)
-- **Log streaming** — tail emulator logs in real-time with `--follow`
+- **Log streaming** — tail emulator logs in real-time with `--follow`; use `--verbose` to show all logs without filtering
 - **Browser-based login** — authenticate via browser and store credentials securely in the system keyring
 - **AWS CLI profile** — optionally configure a `localstack` profile in `~/.aws/` after start
 - **Self-update** — check for and install the latest `lstk` release with `lstk update`
@@ -160,6 +160,9 @@ lstk status
 
 # Stream emulator logs
 lstk logs --follow
+
+# Stream all emulator logs without filtering
+lstk logs --follow --verbose
 
 # Log in (opens browser for authentication)
 lstk login

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -9,8 +9,8 @@ import (
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
-	"github.com/localstack/lstk/internal/ui"
 	"github.com/localstack/lstk/internal/telemetry"
+	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +25,10 @@ func newLogsCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			verbose, err := cmd.Flags().GetBool("verbose")
+			if err != nil {
+				return err
+			}
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
@@ -34,11 +38,12 @@ func newLogsCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 				return fmt.Errorf("failed to get config: %w", err)
 			}
 			if isInteractiveMode(cfg) {
-				return ui.RunLogs(cmd.Context(), rt, appConfig.Containers, follow)
+				return ui.RunLogs(cmd.Context(), rt, appConfig.Containers, follow, verbose)
 			}
-			return container.Logs(cmd.Context(), rt, output.NewPlainSink(os.Stdout), appConfig.Containers, follow)
+			return container.Logs(cmd.Context(), rt, output.NewPlainSink(os.Stdout), appConfig.Containers, follow, verbose)
 		}),
 	}
 	cmd.Flags().BoolP("follow", "f", false, "Follow log output")
+	cmd.Flags().BoolP("verbose", "v", false, "Show all log output without filtering")
 	return cmd
 }

--- a/internal/container/logs.go
+++ b/internal/container/logs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/localstack/lstk/internal/runtime"
 )
 
-func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []config.ContainerConfig, follow bool) error {
+func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []config.ContainerConfig, follow bool, verbose bool) error {
 	if len(containers) == 0 {
 		return fmt.Errorf("no containers configured")
 	}
@@ -30,7 +30,7 @@ func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 	scanner := bufio.NewScanner(pr)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if shouldFilter(line) {
+		if !verbose && shouldFilter(line) {
 			continue
 		}
 		level, _ := parseLogLine(line)

--- a/internal/ui/run_logs.go
+++ b/internal/ui/run_logs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/localstack/lstk/internal/runtime"
 )
 
-func RunLogs(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, follow bool) error {
+func RunLogs(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, follow bool, verbose bool) error {
 	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
@@ -21,7 +21,7 @@ func RunLogs(parentCtx context.Context, rt runtime.Runtime, containers []config.
 	runErrCh := make(chan error, 1)
 
 	go func() {
-		err := container.Logs(ctx, rt, output.NewTUISink(programSender{p: p}), containers, follow)
+		err := container.Logs(ctx, rt, output.NewTUISink(programSender{p: p}), containers, follow, verbose)
 		runErrCh <- err
 		if err != nil && !errors.Is(err, context.Canceled) {
 			p.Send(runErrMsg{err: err})


### PR DESCRIPTION
## Motivation

The log filtering introduced in [the previous PR](https://github.com/localstack/lstk/pull/137/) hides noisy lines by default, but users may need to see all raw output for debugging. The `--verbose` flag provides an escape hatch.

## Changes

- Add `--verbose` / `-v` flag to `lstk logs` to bypass log filtering
- Thread `verbose` param through `container.Logs` and `ui.RunLogs`
- Document the flag in README

## Tests

The filtering logic is already covered by unit tests in `internal/container/logfilter_test.go`. The `--verbose` flag toggles the existing `shouldFilter` predicate — no new logic to test.

Towards DRG-589