### PR TITLE
Avoid duplicate macOS keychain prompts during auth token lookup

### DIFF
--- a/internal/auth/mock_token_storage.go
+++ b/internal/auth/mock_token_storage.go
@@ -81,3 +81,70 @@ func (mr *MockAuthTokenStorageMockRecorder) SetAuthToken(token any) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAuthToken", reflect.TypeOf((*MockAuthTokenStorage)(nil).SetAuthToken), token)
 }
+
+// Mockkeyringer is a mock of keyringer interface.
+type Mockkeyringer struct {
+	ctrl     *gomock.Controller
+	recorder *MockkeyringerMockRecorder
+	isgomock struct{}
+}
+
+// MockkeyringerMockRecorder is the mock recorder for Mockkeyringer.
+type MockkeyringerMockRecorder struct {
+	mock *Mockkeyringer
+}
+
+// NewMockkeyringer creates a new mock instance.
+func NewMockkeyringer(ctrl *gomock.Controller) *Mockkeyringer {
+	mock := &Mockkeyringer{ctrl: ctrl}
+	mock.recorder = &MockkeyringerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *Mockkeyringer) EXPECT() *MockkeyringerMockRecorder {
+	return m.recorder
+}
+
+// Delete mocks base method.
+func (m *Mockkeyringer) Delete(service, user string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", service, user)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockkeyringerMockRecorder) Delete(service, user any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*Mockkeyringer)(nil).Delete), service, user)
+}
+
+// Get mocks base method.
+func (m *Mockkeyringer) Get(service, user string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", service, user)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockkeyringerMockRecorder) Get(service, user any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockkeyringer)(nil).Get), service, user)
+}
+
+// Set mocks base method.
+func (m *Mockkeyringer) Set(service, user, password string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Set", service, user, password)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Set indicates an expected call of Set.
+func (mr *MockkeyringerMockRecorder) Set(service, user, password any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*Mockkeyringer)(nil).Set), service, user, password)
+}

--- a/internal/auth/token_storage.go
+++ b/internal/auth/token_storage.go
@@ -48,6 +48,40 @@ func (s *systemTokenStorage) DeleteAuthToken() error {
 	return err
 }
 
+type fallbackTokenStorage struct {
+	system AuthTokenStorage
+	file   AuthTokenStorage
+	logger log.Logger
+}
+
+func (s *fallbackTokenStorage) GetAuthToken() (string, error) {
+	token, err := s.system.GetAuthToken()
+	if err == nil || errors.Is(err, ErrTokenNotFound) {
+		return token, err
+	}
+
+	s.logger.Info("system keyring unavailable (%v), falling back to file-based storage", err)
+	return s.file.GetAuthToken()
+}
+
+func (s *fallbackTokenStorage) SetAuthToken(token string) error {
+	if err := s.system.SetAuthToken(token); err != nil {
+		s.logger.Info("system keyring unavailable (%v), falling back to file-based storage", err)
+		return s.file.SetAuthToken(token)
+	}
+
+	return nil
+}
+
+func (s *fallbackTokenStorage) DeleteAuthToken() error {
+	if err := s.system.DeleteAuthToken(); err != nil {
+		s.logger.Info("system keyring unavailable (%v), falling back to file-based storage", err)
+		return s.file.DeleteAuthToken()
+	}
+
+	return nil
+}
+
 func NewTokenStorage(forceFileKeyring bool, logger log.Logger) (AuthTokenStorage, error) {
 	if logger == nil {
 		logger = log.Nop()
@@ -62,12 +96,9 @@ func NewTokenStorage(forceFileKeyring bool, logger log.Logger) (AuthTokenStorage
 		return newFileTokenStorage(configDir), nil
 	}
 
-	// Probe whether the system keyring is functional.
-	_, err = keyring.Get(keyringService, keyringAuthTokenKey)
-	if err == nil || errors.Is(err, keyring.ErrNotFound) {
-		return &systemTokenStorage{}, nil
-	}
-
-	logger.Info("system keyring unavailable (%v), falling back to file-based storage", err)
-	return newFileTokenStorage(configDir), nil
+	return &fallbackTokenStorage{
+		system: &systemTokenStorage{},
+		file:   newFileTokenStorage(configDir),
+		logger: logger,
+	}, nil
 }

--- a/internal/auth/token_storage.go
+++ b/internal/auth/token_storage.go
@@ -23,63 +23,51 @@ type AuthTokenStorage interface {
 	DeleteAuthToken() error
 }
 
-type systemTokenStorage struct{}
+type keyringer interface {
+	Get(service, user string) (string, error)
+	Set(service, user, password string) error
+	Delete(service, user string) error
+}
+
+type osKeyringer struct{}
+
+func (osKeyringer) Get(service, user string) (string, error)             { return keyring.Get(service, user) }
+func (osKeyringer) Set(service, user, password string) error             { return keyring.Set(service, user, password) }
+func (osKeyringer) Delete(service, user string) error                    { return keyring.Delete(service, user) }
+
+type systemTokenStorage struct {
+	keyring keyringer
+	file    AuthTokenStorage
+	logger  log.Logger
+}
 
 func (s *systemTokenStorage) GetAuthToken() (string, error) {
-	token, err := keyring.Get(keyringService, keyringAuthTokenKey)
-	if err != nil {
-		if errors.Is(err, keyring.ErrNotFound) {
-			return "", ErrTokenNotFound
-		}
-		return "", err
+	token, err := s.keyring.Get(keyringService, keyringAuthTokenKey)
+	if err == nil {
+		return token, nil
 	}
-	return token, nil
-}
-
-func (s *systemTokenStorage) SetAuthToken(token string) error {
-	return keyring.Set(keyringService, keyringAuthTokenKey, token)
-}
-
-func (s *systemTokenStorage) DeleteAuthToken() error {
-	err := keyring.Delete(keyringService, keyringAuthTokenKey)
 	if errors.Is(err, keyring.ErrNotFound) {
-		return nil
+		return "", ErrTokenNotFound
 	}
-	return err
-}
-
-type fallbackTokenStorage struct {
-	system AuthTokenStorage
-	file   AuthTokenStorage
-	logger log.Logger
-}
-
-func (s *fallbackTokenStorage) GetAuthToken() (string, error) {
-	token, err := s.system.GetAuthToken()
-	if err == nil || errors.Is(err, ErrTokenNotFound) {
-		return token, err
-	}
-
 	s.logger.Info("system keyring unavailable (%v), falling back to file-based storage", err)
 	return s.file.GetAuthToken()
 }
 
-func (s *fallbackTokenStorage) SetAuthToken(token string) error {
-	if err := s.system.SetAuthToken(token); err != nil {
+func (s *systemTokenStorage) SetAuthToken(token string) error {
+	if err := s.keyring.Set(keyringService, keyringAuthTokenKey, token); err != nil {
 		s.logger.Info("system keyring unavailable (%v), falling back to file-based storage", err)
 		return s.file.SetAuthToken(token)
 	}
-
 	return nil
 }
 
-func (s *fallbackTokenStorage) DeleteAuthToken() error {
-	if err := s.system.DeleteAuthToken(); err != nil {
-		s.logger.Info("system keyring unavailable (%v), falling back to file-based storage", err)
-		return s.file.DeleteAuthToken()
+func (s *systemTokenStorage) DeleteAuthToken() error {
+	err := s.keyring.Delete(keyringService, keyringAuthTokenKey)
+	if err == nil || errors.Is(err, keyring.ErrNotFound) {
+		return nil
 	}
-
-	return nil
+	s.logger.Info("system keyring unavailable (%v), falling back to file-based storage", err)
+	return s.file.DeleteAuthToken()
 }
 
 func NewTokenStorage(forceFileKeyring bool, logger log.Logger) (AuthTokenStorage, error) {
@@ -96,9 +84,9 @@ func NewTokenStorage(forceFileKeyring bool, logger log.Logger) (AuthTokenStorage
 		return newFileTokenStorage(configDir), nil
 	}
 
-	return &fallbackTokenStorage{
-		system: &systemTokenStorage{},
-		file:   newFileTokenStorage(configDir),
-		logger: logger,
+	return &systemTokenStorage{
+		keyring: osKeyringer{},
+		file:    newFileTokenStorage(configDir),
+		logger:  logger,
 	}, nil
 }

--- a/internal/auth/token_storage_test.go
+++ b/internal/auth/token_storage_test.go
@@ -1,0 +1,75 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/localstack/lstk/internal/log"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubTokenStorage struct {
+	getToken  string
+	getErr    error
+	setErr    error
+	deleteErr error
+	setToken  string
+}
+
+func (s *stubTokenStorage) GetAuthToken() (string, error) {
+	return s.getToken, s.getErr
+}
+
+func (s *stubTokenStorage) SetAuthToken(token string) error {
+	s.setToken = token
+	return s.setErr
+}
+
+func (s *stubTokenStorage) DeleteAuthToken() error {
+	return s.deleteErr
+}
+
+func TestFallbackTokenStorage_GetUsesSystemWithoutFallbackWhenTokenMissing(t *testing.T) {
+	system := &stubTokenStorage{getErr: ErrTokenNotFound}
+	file := &stubTokenStorage{getToken: "file-token"}
+	storage := &fallbackTokenStorage{
+		system: system,
+		file:   file,
+		logger: log.Nop(),
+	}
+
+	token, err := storage.GetAuthToken()
+
+	assert.Empty(t, token)
+	assert.ErrorIs(t, err, ErrTokenNotFound)
+}
+
+func TestFallbackTokenStorage_GetFallsBackToFileWhenSystemUnavailable(t *testing.T) {
+	system := &stubTokenStorage{getErr: errors.New("keychain unavailable")}
+	file := &stubTokenStorage{getToken: "file-token"}
+	storage := &fallbackTokenStorage{
+		system: system,
+		file:   file,
+		logger: log.Nop(),
+	}
+
+	token, err := storage.GetAuthToken()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "file-token", token)
+}
+
+func TestFallbackTokenStorage_SetFallsBackToFileWhenSystemUnavailable(t *testing.T) {
+	system := &stubTokenStorage{setErr: errors.New("keychain unavailable")}
+	file := &stubTokenStorage{}
+	storage := &fallbackTokenStorage{
+		system: system,
+		file:   file,
+		logger: log.Nop(),
+	}
+
+	err := storage.SetAuthToken("token")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "token", file.setToken)
+}

--- a/internal/auth/token_storage_test.go
+++ b/internal/auth/token_storage_test.go
@@ -6,70 +6,117 @@ import (
 
 	"github.com/localstack/lstk/internal/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/zalando/go-keyring"
+	"go.uber.org/mock/gomock"
 )
 
-type stubTokenStorage struct {
-	getToken  string
-	getErr    error
-	setErr    error
-	deleteErr error
-	setToken  string
-}
-
-func (s *stubTokenStorage) GetAuthToken() (string, error) {
-	return s.getToken, s.getErr
-}
-
-func (s *stubTokenStorage) SetAuthToken(token string) error {
-	s.setToken = token
-	return s.setErr
-}
-
-func (s *stubTokenStorage) DeleteAuthToken() error {
-	return s.deleteErr
-}
-
-func TestFallbackTokenStorage_GetUsesSystemWithoutFallbackWhenTokenMissing(t *testing.T) {
-	system := &stubTokenStorage{getErr: ErrTokenNotFound}
-	file := &stubTokenStorage{getToken: "file-token"}
-	storage := &fallbackTokenStorage{
-		system: system,
-		file:   file,
-		logger: log.Nop(),
+func newTestStorage(t *testing.T, kr keyringer, file AuthTokenStorage) *systemTokenStorage {
+	t.Helper()
+	return &systemTokenStorage{
+		keyring: kr,
+		file:    file,
+		logger:  log.Nop(),
 	}
+}
 
-	token, err := storage.GetAuthToken()
+func TestSystemTokenStorage_GetReturnsTokenFromKeyring(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kr := NewMockkeyringer(ctrl)
+	file := NewMockAuthTokenStorage(ctrl)
+
+	kr.EXPECT().Get(keyringService, keyringAuthTokenKey).Return("system-token", nil)
+
+	token, err := newTestStorage(t, kr, file).GetAuthToken()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "system-token", token)
+}
+
+func TestSystemTokenStorage_GetReturnsErrTokenNotFoundWhenKeyringEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kr := NewMockkeyringer(ctrl)
+	file := NewMockAuthTokenStorage(ctrl)
+
+	kr.EXPECT().Get(keyringService, keyringAuthTokenKey).Return("", keyring.ErrNotFound)
+
+	token, err := newTestStorage(t, kr, file).GetAuthToken()
 
 	assert.Empty(t, token)
 	assert.ErrorIs(t, err, ErrTokenNotFound)
 }
 
-func TestFallbackTokenStorage_GetFallsBackToFileWhenSystemUnavailable(t *testing.T) {
-	system := &stubTokenStorage{getErr: errors.New("keychain unavailable")}
-	file := &stubTokenStorage{getToken: "file-token"}
-	storage := &fallbackTokenStorage{
-		system: system,
-		file:   file,
-		logger: log.Nop(),
-	}
+func TestSystemTokenStorage_GetFallsBackToFileWhenKeyringUnavailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kr := NewMockkeyringer(ctrl)
+	file := NewMockAuthTokenStorage(ctrl)
 
-	token, err := storage.GetAuthToken()
+	kr.EXPECT().Get(keyringService, keyringAuthTokenKey).Return("", errors.New("keychain unavailable"))
+	file.EXPECT().GetAuthToken().Return("file-token", nil)
+
+	token, err := newTestStorage(t, kr, file).GetAuthToken()
 
 	assert.NoError(t, err)
 	assert.Equal(t, "file-token", token)
 }
 
-func TestFallbackTokenStorage_SetFallsBackToFileWhenSystemUnavailable(t *testing.T) {
-	system := &stubTokenStorage{setErr: errors.New("keychain unavailable")}
-	file := &stubTokenStorage{}
-	storage := &fallbackTokenStorage{
-		system: system,
-		file:   file,
-		logger: log.Nop(),
-	}
+func TestSystemTokenStorage_SetStoresInKeyring(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kr := NewMockkeyringer(ctrl)
+	file := NewMockAuthTokenStorage(ctrl)
 
-	err := storage.SetAuthToken("token")
+	kr.EXPECT().Set(keyringService, keyringAuthTokenKey, "token").Return(nil)
+
+	err := newTestStorage(t, kr, file).SetAuthToken("token")
 
 	assert.NoError(t, err)
-	assert.Equal(t, "token", file.setToken)
+}
+
+func TestSystemTokenStorage_SetFallsBackToFileWhenKeyringUnavailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kr := NewMockkeyringer(ctrl)
+	file := NewMockAuthTokenStorage(ctrl)
+
+	kr.EXPECT().Set(keyringService, keyringAuthTokenKey, "token").Return(errors.New("keychain unavailable"))
+	file.EXPECT().SetAuthToken("token").Return(nil)
+
+	err := newTestStorage(t, kr, file).SetAuthToken("token")
+
+	assert.NoError(t, err)
+}
+
+func TestSystemTokenStorage_DeleteRemovesFromKeyring(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kr := NewMockkeyringer(ctrl)
+	file := NewMockAuthTokenStorage(ctrl)
+
+	kr.EXPECT().Delete(keyringService, keyringAuthTokenKey).Return(nil)
+
+	err := newTestStorage(t, kr, file).DeleteAuthToken()
+
+	assert.NoError(t, err)
+}
+
+func TestSystemTokenStorage_DeleteSucceedsWhenKeyringTokenMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kr := NewMockkeyringer(ctrl)
+	file := NewMockAuthTokenStorage(ctrl)
+
+	kr.EXPECT().Delete(keyringService, keyringAuthTokenKey).Return(keyring.ErrNotFound)
+
+	err := newTestStorage(t, kr, file).DeleteAuthToken()
+
+	assert.NoError(t, err)
+}
+
+func TestSystemTokenStorage_DeleteFallsBackToFileWhenKeyringUnavailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kr := NewMockkeyringer(ctrl)
+	file := NewMockAuthTokenStorage(ctrl)
+
+	kr.EXPECT().Delete(keyringService, keyringAuthTokenKey).Return(errors.New("keychain unavailable"))
+	file.EXPECT().DeleteAuthToken().Return(nil)
+
+	err := newTestStorage(t, kr, file).DeleteAuthToken()
+
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- Removes the eager `keyring.Get()` probe in `NewTokenStorage()` that caused duplicate macOS Keychain dialogs on every startup (one for the probe, one for the actual auth read)
- Merges `systemTokenStorage` and `fallbackTokenStorage` into a single struct that lazily falls back to file-based storage when the system keyring is unavailable
- Introduces a `keyringer` interface (with `osKeyringer` as the real implementation) to keep the keyring calls injectable and testable
- Replaces hand-rolled stubs in tests with `MockAuthTokenStorage` and `Mockkeyringer` (generated via mockgen), covering all paths including the previously missing `DeleteAuthToken` fallback test

Co-authored-by: George Tsiolis <gtsiolis@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)