### PR TITLE
Refine AWS profile setup flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,14 @@ When adding a new command that depends on configuration, wire config initializat
 
 Created automatically on first run with defaults. Supports emulator types (aws, snowflake, azure) - currently only aws is implemented.
 
+# Emulator Setup Commands
+
+Use `lstk setup <emulator>` to set up CLI integration for an emulator type:
+- `lstk setup aws` — Sets up AWS CLI profile in `~/.aws/config` and `~/.aws/credentials`
+
+This naming avoids AWS-specific "profile" terminology and uses a clear verb for mutation operations.
+The deprecated `lstk config profile` command still works but points users to `lstk setup aws`.
+
 Environment variables:
 - `LOCALSTACK_AUTH_TOKEN` - Auth token (skips browser login if set)
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ To see which config file is currently in use:
 lstk config path
 ```
 
+You can also configure AWS CLI integration:
+
+```bash
+lstk setup aws
+```
+
+This sets up a `localstack` profile in `~/.aws/config` and `~/.aws/credentials`.
+
 You can also point `lstk` at a specific config file for any command:
 
 ```bash
@@ -183,6 +191,9 @@ lstk update
 
 # Show resolved config file path
 lstk config path
+
+# Set up AWS CLI profile integration
+lstk setup aws
 
 ```
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/telemetry"
+	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -14,8 +15,30 @@ func newConfigCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Use:   "config",
 		Short: "Manage configuration",
 	}
+	cmd.AddCommand(newConfigProfileCmd(cfg, tel))
 	cmd.AddCommand(newConfigPathCmd(cfg, tel))
 	return cmd
+}
+
+func newConfigProfileCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+	return &cobra.Command{
+		Use:     "profile",
+		Short:   "Deprecated: use 'lstk setup aws' instead",
+		PreRunE: initConfig,
+		RunE: commandWithTelemetry("config profile", tel, func(cmd *cobra.Command, args []string) error {
+			appConfig, err := config.Get()
+			if err != nil {
+				return fmt.Errorf("failed to get config: %w", err)
+			}
+
+			if !isInteractiveMode(cfg) {
+				return fmt.Errorf("config profile requires an interactive terminal")
+			}
+
+			// Delegate to the same handler as "lstk setup aws"
+			return ui.RunConfigProfile(cmd.Context(), appConfig.Containers, cfg.LocalStackHost)
+		}),
+	}
 }
 
 func newConfigPathCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 		newLogoutCmd(cfg, tel, logger),
 		newStatusCmd(cfg, tel),
 		newLogsCmd(cfg, tel),
+		newSetupCmd(cfg, tel),
 		newConfigCmd(cfg, tel),
 		newUpdateCmd(cfg, tel),
 		newDocsCmd(),

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/env"
+	"github.com/localstack/lstk/internal/telemetry"
+	"github.com/localstack/lstk/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newSetupCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Set up emulator CLI integration",
+		Long:  "Set up emulator CLI integration (e.g., AWS, Snowflake, Azure). Currently only AWS is supported.",
+	}
+	cmd.AddCommand(newSetupAWSCmd(cfg, tel))
+	return cmd
+}
+
+func newSetupAWSCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+	return &cobra.Command{
+		Use:     "aws",
+		Short:   "Set up the LocalStack AWS profile",
+		Long:    "Set up the LocalStack AWS profile in ~/.aws/config and ~/.aws/credentials for use with AWS CLI and SDKs.",
+		PreRunE: initConfig,
+		RunE: commandWithTelemetry("setup aws", tel, func(cmd *cobra.Command, args []string) error {
+			appConfig, err := config.Get()
+			if err != nil {
+				return fmt.Errorf("failed to get config: %w", err)
+			}
+
+			if !isInteractiveMode(cfg) {
+				return fmt.Errorf("setup aws requires an interactive terminal")
+			}
+
+			return ui.RunConfigProfile(cmd.Context(), appConfig.Containers, cfg.LocalStackHost)
+		}),
+	}
+}

--- a/internal/awsconfig/awsconfig.go
+++ b/internal/awsconfig/awsconfig.go
@@ -76,8 +76,12 @@ func (s profileStatus) anyNeeded() bool {
 	return s.configNeeded || s.credsNeeded
 }
 
-// checkProfileStatus determines which AWS profile files need to be written or updated.
-func checkProfileStatus(configPath, credsPath, resolvedHost string) (profileStatus, error) {
+// CheckProfileStatus determines which AWS profile files need to be written or updated.
+func CheckProfileStatus(resolvedHost string) (profileStatus, error) {
+	configPath, credsPath, err := awsPaths()
+	if err != nil {
+		return profileStatus{}, err
+	}
 	configNeeded, err := configNeedsWrite(configPath, resolvedHost)
 	if err != nil {
 		return profileStatus{}, err
@@ -184,17 +188,40 @@ func writeCredsProfile(credsPath string) error {
 	return upsertSection(credsPath, credsSectionName, credentialsDefaults())
 }
 
-// Setup checks for the localstack AWS profile and prompts to create or update it if needed.
-// resolvedHost must be a host:port string (e.g. "localhost.localstack.cloud:4566").
-// In non-interactive mode, emits a note instead of prompting.
-func Setup(ctx context.Context, sink output.Sink, interactive bool, resolvedHost string) error {
+func emitMissingProfileNote(sink output.Sink) {
+	output.EmitNote(sink, "LocalStack AWS profile is incomplete. Run 'lstk setup aws'.")
+}
+
+// checkProfileSetup returns both the profile status (which files need writing) and presence (which files exist).
+// This avoids loading the same files twice by combining needsProfileSetup and profilePresence.
+func checkProfileSetup(resolvedHost string) (profileStatus, bool, bool, error) {
 	configPath, credsPath, err := awsPaths()
 	if err != nil {
-		output.EmitWarning(sink, fmt.Sprintf("could not determine AWS config paths: %v", err))
-		return nil
+		return profileStatus{}, false, false, err
 	}
 
-	status, err := checkProfileStatus(configPath, credsPath, resolvedHost)
+	status, err := CheckProfileStatus(resolvedHost)
+	if err != nil {
+		return profileStatus{}, false, false, err
+	}
+
+	configOK, err := sectionExists(configPath, configSectionName)
+	if err != nil {
+		return profileStatus{}, false, false, err
+	}
+	credsOK, err := sectionExists(credsPath, credsSectionName)
+	if err != nil {
+		return profileStatus{}, false, false, err
+	}
+
+	return status, configOK, credsOK, nil
+}
+
+// EnsureProfile checks for the LocalStack AWS profile and either emits a note when it is incomplete
+// or triggers the interactive setup flow.
+// resolvedHost must be a host:port string (e.g. "localhost.localstack.cloud:4566").
+func EnsureProfile(ctx context.Context, sink output.Sink, interactive bool, resolvedHost string) error {
+	status, configOK, credsOK, err := checkProfileSetup(resolvedHost)
 	if err != nil {
 		output.EmitWarning(sink, fmt.Sprintf("could not check AWS profile: %v", err))
 		return nil
@@ -202,22 +229,43 @@ func Setup(ctx context.Context, sink output.Sink, interactive bool, resolvedHost
 	if !status.anyNeeded() {
 		return nil
 	}
+	if interactive && !configOK && !credsOK {
+		return Setup(ctx, sink, resolvedHost, status)
+	}
 
-	if !interactive {
-		output.EmitNote(sink, fmt.Sprintf("No complete LocalStack AWS profile found. Run lstk interactively to configure one, or add a [profile %s] section to ~/.aws/config manually.", profileName))
+	emitMissingProfileNote(sink)
+	return nil
+}
+
+// Setup checks for the localstack AWS profile and prompts to create or update it if needed.
+// resolvedHost must be a host:port string (e.g. "localhost.localstack.cloud:4566").
+// status is passed in from EnsureProfile to avoid re-checking the profile status.
+func Setup(ctx context.Context, sink output.Sink, resolvedHost string, status profileStatus) error {
+	if !status.anyNeeded() {
+		output.EmitNote(sink, "LocalStack AWS profile is already configured.")
+		return nil
+	}
+
+	configPath, credsPath, err := awsPaths()
+	if err != nil {
+		output.EmitWarning(sink, fmt.Sprintf("could not determine AWS config paths: %v", err))
 		return nil
 	}
 
 	responseCh := make(chan output.InputResponse, 1)
 	output.EmitUserInputRequest(sink, output.UserInputRequestEvent{
-		Prompt:     "Configure AWS profile in ~/.aws/?",
+		Prompt:     "Set up a LocalStack profile for AWS CLI and SDKs in ~/.aws?",
 		Options:    []output.InputOption{{Key: "y", Label: "Y"}, {Key: "n", Label: "n"}},
 		ResponseCh: responseCh,
 	})
 
 	select {
 	case resp := <-responseCh:
-		if resp.Cancelled || resp.SelectedKey == "n" {
+		if resp.Cancelled {
+			return nil
+		}
+		if resp.SelectedKey == "n" {
+			output.EmitNote(sink, "Skipped adding LocalStack AWS profile.")
 			return nil
 		}
 		if status.configNeeded {
@@ -232,12 +280,16 @@ func Setup(ctx context.Context, sink output.Sink, interactive bool, resolvedHost
 				return nil
 			}
 		}
-		output.EmitSuccess(sink, "AWS profile successfully configured")
-		output.EmitNote(sink, fmt.Sprintf("Try: aws s3 mb s3://test --profile %s", profileName))
+		if status.configNeeded && status.credsNeeded {
+			output.EmitSuccess(sink, "Created LocalStack profile in ~/.aws")
+		} else if status.configNeeded {
+			output.EmitSuccess(sink, "Created LocalStack profile in ~/.aws/config")
+		} else {
+			output.EmitSuccess(sink, "Updated LocalStack credentials in ~/.aws/credentials")
+		}
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 
 	return nil
 }
-

--- a/internal/awsconfig/awsconfig_test.go
+++ b/internal/awsconfig/awsconfig_test.go
@@ -199,7 +199,8 @@ func TestCheckProfileStatus(t *testing.T) {
 			if tc.credsContent != "" {
 				writeFile(t, credsPath, tc.credsContent)
 			}
-			status, err := checkProfileStatus(configPath, credsPath, tc.resolvedHost)
+			t.Setenv("HOME", dir)
+			status, err := CheckProfileStatus(tc.resolvedHost)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -221,7 +222,9 @@ func TestCheckProfileStatusMalformedFile(t *testing.T) {
 	writeFile(t, configPath, "this is not valid \x00\x01\x02 ini content [[[")
 	writeFile(t, credsPath, "[localstack]\naws_access_key_id = test\naws_secret_access_key = test\n")
 
-	_, err := checkProfileStatus(configPath, credsPath, "127.0.0.1:4566")
+	// Override HOME to use our test directory
+	t.Setenv("HOME", dir)
+	_, err := CheckProfileStatus("127.0.0.1:4566")
 	if err == nil {
 		t.Error("expected error for malformed config file, got nil")
 	}

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -140,12 +140,12 @@ func (c *ContainerConfig) ProductName() (string, error) {
 }
 
 // GetAWSContainer returns the AWS container config from the list of containers.
-// Returns nil if no AWS container is configured.
-func GetAWSContainer(containers []ContainerConfig) *ContainerConfig {
+// Returns an error if no AWS container is configured.
+func GetAWSContainer(containers []ContainerConfig) (*ContainerConfig, error) {
 	for i := range containers {
 		if containers[i].Type == EmulatorAWS {
-			return &containers[i]
+			return &containers[i], nil
 		}
 	}
-	return nil
+	return nil, fmt.Errorf("no aws emulator configured")
 }

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -138,14 +138,3 @@ func (c *ContainerConfig) ProductName() (string, error) {
 	}
 	return productName, nil
 }
-
-// GetAWSContainer returns the AWS container config from the list of containers.
-// Returns an error if no AWS container is configured.
-func GetAWSContainer(containers []ContainerConfig) (*ContainerConfig, error) {
-	for i := range containers {
-		if containers[i].Type == EmulatorAWS {
-			return &containers[i], nil
-		}
-	}
-	return nil, fmt.Errorf("no aws emulator configured")
-}

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -138,3 +138,14 @@ func (c *ContainerConfig) ProductName() (string, error) {
 	}
 	return productName, nil
 }
+
+// GetAWSContainer returns the AWS container config from the list of containers.
+// Returns nil if no AWS container is configured.
+func GetAWSContainer(containers []ContainerConfig) *ContainerConfig {
+	for i := range containers {
+		if containers[i].Type == EmulatorAWS {
+			return &containers[i]
+		}
+	}
+	return nil
+}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -190,7 +190,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 	// Maps emulator types to their post-start setup functions.
 	// Add an entry here to run setup for a new emulator type (e.g. Azure, Snowflake).
 	setups := map[config.EmulatorType]postStartSetupFunc{
-		config.EmulatorAWS: awsconfig.Setup,
+		config.EmulatorAWS: awsconfig.EnsureProfile,
 	}
 	return runPostStartSetups(ctx, sink, opts.Containers, interactive, opts.LocalStackHost, opts.WebAppURL, setups)
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -96,10 +96,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if a.pendingInput != nil {
 			if opt := resolveOption(a.pendingInput.Options, msg); opt != nil {
-				a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
 				responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
 				a.pendingInput = nil
-				a.inputPrompt = a.inputPrompt.Hide()
+				a.inputPrompt = components.NewInputPrompt()
+				a.spinner = a.spinner.SetText("")
 				return a, responseCmd
 			}
 		}
@@ -293,27 +293,6 @@ func (a *App) flushBufferedLines() {
 		a.lines = appendLine(a.lines, line)
 	}
 	a.bufferedLines = nil
-}
-
-func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) string {
-	formatted := output.FormatPrompt(req.Prompt, req.Options)
-	firstLine := strings.Split(formatted, "\n")[0]
-
-	selected := selectedKey
-	hasLabels := false
-	for _, opt := range req.Options {
-		if opt.Label != "" {
-			hasLabels = true
-		}
-		if opt.Key == selectedKey && opt.Label != "" {
-			selected = opt.Label
-		}
-	}
-
-	if selected == "" || !hasLabels || selectedKey == "any" {
-		return firstLine
-	}
-	return fmt.Sprintf("%s %s", firstLine, selected)
 }
 
 // resolveOption finds the best matching option for a key event, in priority order:

--- a/internal/ui/components/input_prompt_test.go
+++ b/internal/ui/components/input_prompt_test.go
@@ -38,12 +38,12 @@ func TestInputPromptView(t *testing.T) {
 		},
 		{
 			name:   "multiple options shows brackets",
-			prompt: "Configure AWS profile?",
+			prompt: "Set up a LocalStack profile for AWS CLI and SDKs in ~/.aws?",
 			options: []output.InputOption{
 				{Key: "y", Label: "Y"},
 				{Key: "n", Label: "n"},
 			},
-			contains: []string{"?", "Configure AWS profile?", "[Y/n]"},
+			contains: []string{"?", "Set up a LocalStack profile for AWS CLI and SDKs in ~/.aws?", "[Y/n]"},
 		},
 		{
 			name:   "multi-line prompt renders trailing lines",

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -82,3 +82,42 @@ func Run(parentCtx context.Context, rt runtime.Runtime, version string, opts con
 func IsInteractive() bool {
 	return term.IsTerminal(int(os.Stdout.Fd())) && term.IsTerminal(int(os.Stdin.Fd()))
 }
+
+// runWithTUI runs a TUI command with the given app configuration.
+// The runFn is executed in a goroutine and should send runDoneMsg or runErrMsg to the program.
+// If the app ends with an error, it's wrapped in SilentError to suppress duplicate output.
+func runWithTUI(parentCtx context.Context, appOpts AppOption, runFn func(ctx context.Context, sink output.Sink) error) error {
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	app := NewApp("", "", "", cancel, appOpts)
+	p := tea.NewProgram(app, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
+	runErrCh := make(chan error, 1)
+
+	go func() {
+		sink := output.NewTUISink(programSender{p: p})
+		err := runFn(ctx, sink)
+		runErrCh <- err
+		if err != nil && !errors.Is(err, context.Canceled) {
+			p.Send(runErrMsg{err: err})
+			return
+		}
+		p.Send(runDoneMsg{})
+	}()
+
+	model, err := p.Run()
+	if err != nil {
+		return err
+	}
+
+	if app, ok := model.(App); ok && app.Err() != nil {
+		return output.NewSilentError(app.Err())
+	}
+
+	runErr := <-runErrCh
+	if runErr != nil && !errors.Is(runErr, context.Canceled) {
+		return runErr
+	}
+
+	return nil
+}

--- a/internal/ui/run_awsconfig.go
+++ b/internal/ui/run_awsconfig.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/localstack/lstk/internal/awsconfig"
 	"github.com/localstack/lstk/internal/config"
@@ -13,9 +12,9 @@ import (
 // RunConfigProfile runs the AWS profile setup flow with TUI output.
 // It resolves the host from the AWS container config and runs the setup.
 func RunConfigProfile(parentCtx context.Context, containers []config.ContainerConfig, localStackHost string) error {
-	awsContainer := config.GetAWSContainer(containers)
-	if awsContainer == nil {
-		return fmt.Errorf("no aws emulator configured")
+	awsContainer, err := config.GetAWSContainer(containers)
+	if err != nil {
+		return err
 	}
 
 	resolvedHost, dnsOK := endpoint.ResolveHost(awsContainer.Port, localStackHost)

--- a/internal/ui/run_awsconfig.go
+++ b/internal/ui/run_awsconfig.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/localstack/lstk/internal/awsconfig"
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/endpoint"
+	"github.com/localstack/lstk/internal/output"
+)
+
+// RunConfigProfile runs the AWS profile setup flow with TUI output.
+// It resolves the host from the AWS container config and runs the setup.
+func RunConfigProfile(parentCtx context.Context, containers []config.ContainerConfig, localStackHost string) error {
+	awsContainer := config.GetAWSContainer(containers)
+	if awsContainer == nil {
+		return fmt.Errorf("no aws emulator configured")
+	}
+
+	resolvedHost, dnsOK := endpoint.ResolveHost(awsContainer.Port, localStackHost)
+
+	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
+		if !dnsOK {
+			output.EmitNote(sink, `Could not resolve "localhost.localstack.cloud" - your system may have DNS rebind protection enabled. Using 127.0.0.1 as the endpoint.`)
+		}
+		status, err := awsconfig.CheckProfileStatus(resolvedHost)
+		if err != nil {
+			return err
+		}
+		return awsconfig.Setup(ctx, sink, resolvedHost, status)
+	})
+}
+

--- a/internal/ui/run_awsconfig.go
+++ b/internal/ui/run_awsconfig.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/localstack/lstk/internal/awsconfig"
 	"github.com/localstack/lstk/internal/config"
@@ -12,9 +13,15 @@ import (
 // RunConfigProfile runs the AWS profile setup flow with TUI output.
 // It resolves the host from the AWS container config and runs the setup.
 func RunConfigProfile(parentCtx context.Context, containers []config.ContainerConfig, localStackHost string) error {
-	awsContainer, err := config.GetAWSContainer(containers)
-	if err != nil {
-		return err
+	var awsContainer *config.ContainerConfig
+	for i := range containers {
+		if containers[i].Type == config.EmulatorAWS {
+			awsContainer = &containers[i]
+			break
+		}
+	}
+	if awsContainer == nil {
+		return fmt.Errorf("no aws emulator configured")
 	}
 
 	resolvedHost, dnsOK := endpoint.ResolveHost(awsContainer.Port, localStackHost)

--- a/test/integration/awsconfig_test.go
+++ b/test/integration/awsconfig_test.go
@@ -36,14 +36,13 @@ func awsConfigEnv(t *testing.T) (env.Environ, string) {
 	return e, tmpHome
 }
 
-func TestStartPromptsToCreateAWSProfileWhenMissing(t *testing.T) {
+func TestStartPromptsWhenAWSProfileMissingEverywhere(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
 	}
 	requireDocker(t)
 	_ = env.Require(t, env.AuthToken)
 
-	cleanup()
 	t.Cleanup(cleanup)
 
 	baseEnv, tmpHome := awsConfigEnv(t)
@@ -65,21 +64,18 @@ func TestStartPromptsToCreateAWSProfileWhenMissing(t *testing.T) {
 		close(outputCh)
 	}()
 
-	// Wait for the AWS profile prompt.
+	// Wait for the prompt emitted after the container becomes ready.
 	require.Eventually(t, func() bool {
-		return bytes.Contains(out.Bytes(), []byte("Configure AWS profile in"))
+		return bytes.Contains(out.Bytes(), []byte(awsSetupPrompt))
 	}, 2*time.Minute, 200*time.Millisecond, "AWS profile prompt should appear")
 
-	// Press Y to confirm.
 	_, err = ptmx.Write([]byte("y"))
 	require.NoError(t, err)
 
-	// Wait for the success message.
-	require.Eventually(t, func() bool {
-		return bytes.Contains(out.Bytes(), []byte("AWS profile successfully configured"))
-	}, 10*time.Second, 200*time.Millisecond, "success message should appear")
+	err = cmd.Wait()
+	<-outputCh
+	require.NoError(t, err, "lstk start should exit successfully")
 
-	// Verify files were written to the isolated home dir, not the real one.
 	configContent, err := os.ReadFile(filepath.Join(tmpHome, ".aws", "config"))
 	require.NoError(t, err, "~/.aws/config should have been created")
 	assert.Contains(t, string(configContent), "[profile localstack]")
@@ -91,9 +87,6 @@ func TestStartPromptsToCreateAWSProfileWhenMissing(t *testing.T) {
 	assert.Contains(t, normalizedCreds, "[localstack]")
 	assert.Contains(t, normalizedCreds, "aws_access_key_id = test")
 	assert.Contains(t, normalizedCreds, "aws_secret_access_key = test")
-
-	_ = cmd.Wait()
-	<-outputCh
 }
 
 func TestStartSkipsAWSProfilePromptWhenAlreadyConfigured(t *testing.T) {
@@ -103,7 +96,6 @@ func TestStartSkipsAWSProfilePromptWhenAlreadyConfigured(t *testing.T) {
 	requireDocker(t)
 	_ = env.Require(t, env.AuthToken)
 
-	cleanup()
 	t.Cleanup(cleanup)
 
 	baseEnv, tmpHome := awsConfigEnv(t)
@@ -140,18 +132,20 @@ func TestStartSkipsAWSProfilePromptWhenAlreadyConfigured(t *testing.T) {
 	}, 2*time.Minute, 200*time.Millisecond, "container should become ready")
 
 	_ = cmd.Process.Kill()
-	_ = cmd.Wait()
+	err = cmd.Wait()
 	<-outputCh
+	require.NoError(t, err, "lstk start should exit after kill")
 
-	assert.NotContains(t, out.String(), "Configure AWS profile in",
+	assert.NotContains(t, out.String(), awsSetupPrompt,
 		"profile prompt should not appear when profile is already correctly configured")
 }
+
+const awsSetupPrompt = "Set up a LocalStack profile for AWS CLI and SDKs in ~/.aws?"
 
 func TestStartNonInteractiveEmitsNoteWhenAWSProfileMissing(t *testing.T) {
 	requireDocker(t)
 	_ = env.Require(t, env.AuthToken)
 
-	cleanup()
 	t.Cleanup(cleanup)
 
 	baseEnv, _ := awsConfigEnv(t)
@@ -164,5 +158,202 @@ func TestStartNonInteractiveEmitsNoteWhenAWSProfileMissing(t *testing.T) {
 	)
 	require.NoError(t, err)
 	requireExitCode(t, 0, err)
-	assert.Contains(t, stdout, "No complete LocalStack AWS profile found")
+	assert.Contains(t, stdout, "LocalStack AWS profile is incomplete. Run 'lstk setup aws'.")
+}
+
+func TestStartEmitsNoteWhenAWSProfileIsPartial(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	t.Cleanup(cleanup)
+
+	baseEnv, tmpHome := awsConfigEnv(t)
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	awsDir := filepath.Join(tmpHome, ".aws")
+	require.NoError(t, os.MkdirAll(awsDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(awsDir, "credentials"),
+		[]byte("[localstack]\naws_access_key_id = test\naws_secret_access_key = test\n"), 0600))
+
+	ctx := testContext(t)
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd.Env = baseEnv.With(env.APIEndpoint, mockServer.URL)
+
+	ptmx, err := pty.Start(cmd)
+	require.NoError(t, err, "failed to start command in PTY")
+	defer func() { _ = ptmx.Close() }()
+
+	out := &syncBuffer{}
+	outputCh := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(out, ptmx)
+		close(outputCh)
+	}()
+
+	require.Eventually(t, func() bool {
+		return bytes.Contains(out.Bytes(), []byte("LocalStack AWS profile is incomplete. Run 'lstk setup aws'."))
+	}, 2*time.Minute, 200*time.Millisecond, "AWS profile note should appear")
+
+	err = cmd.Wait()
+	<-outputCh
+	require.NoError(t, err, "lstk start should exit successfully")
+
+	assert.NotContains(t, out.String(), "Set up a LocalStack profile for AWS CLI and SDKs in ~/.aws?",
+		"profile prompt should not appear for a partial setup")
+}
+
+func TestConfigProfileCreatesAWSProfileWhenConfirmed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+	baseEnv, tmpHome := awsConfigEnv(t)
+
+	ctx := testContext(t)
+	cmd := exec.CommandContext(ctx, binaryPath(), "config", "profile")
+	cmd.Env = baseEnv
+
+	ptmx, err := pty.Start(cmd)
+	require.NoError(t, err, "failed to start command in PTY")
+	defer func() { _ = ptmx.Close() }()
+
+	out := &syncBuffer{}
+	outputCh := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(out, ptmx)
+		close(outputCh)
+	}()
+
+	// Wait for the AWS profile prompt.
+	require.Eventually(t, func() bool {
+		return bytes.Contains(out.Bytes(), []byte(awsSetupPrompt))
+	}, 2*time.Minute, 200*time.Millisecond, "AWS profile prompt should appear")
+
+	// Press Y to confirm.
+	_, err = ptmx.Write([]byte("y"))
+	require.NoError(t, err)
+
+	err = cmd.Wait()
+	<-outputCh
+	require.NoError(t, err)
+
+	configContent, err := os.ReadFile(filepath.Join(tmpHome, ".aws", "config"))
+	require.NoError(t, err, "~/.aws/config should have been created")
+	assert.Contains(t, string(configContent), "[profile localstack]")
+	assert.Contains(t, string(configContent), "endpoint_url")
+
+	credsContent, err := os.ReadFile(filepath.Join(tmpHome, ".aws", "credentials"))
+	require.NoError(t, err, "~/.aws/credentials should have been created")
+	normalizedCreds := strings.Join(strings.Fields(string(credsContent)), " ")
+	assert.Contains(t, normalizedCreds, "[localstack]")
+	assert.Contains(t, normalizedCreds, "aws_access_key_id = test")
+	assert.Contains(t, normalizedCreds, "aws_secret_access_key = test")
+
+	assert.Contains(t, out.String(), "Created LocalStack profile in ~/.aws")
+	assert.NotContains(t, out.String(), "Skipped adding LocalStack AWS profile.")
+}
+
+func TestSetupAWSCreatesAWSProfileWhenConfirmed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+	baseEnv, tmpHome := awsConfigEnv(t)
+
+	ctx := testContext(t)
+	cmd := exec.CommandContext(ctx, binaryPath(), "setup", "aws")
+	cmd.Env = baseEnv
+
+	ptmx, err := pty.Start(cmd)
+	require.NoError(t, err, "failed to start command in PTY")
+	defer func() { _ = ptmx.Close() }()
+
+	out := &syncBuffer{}
+	outputCh := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(out, ptmx)
+		close(outputCh)
+	}()
+
+	// Wait for the AWS profile prompt.
+	require.Eventually(t, func() bool {
+		return bytes.Contains(out.Bytes(), []byte(awsSetupPrompt))
+	}, 2*time.Minute, 200*time.Millisecond, "AWS profile prompt should appear")
+
+	// Press Y to confirm.
+	_, err = ptmx.Write([]byte("y"))
+	require.NoError(t, err)
+
+	err = cmd.Wait()
+	<-outputCh
+	require.NoError(t, err)
+
+	configContent, err := os.ReadFile(filepath.Join(tmpHome, ".aws", "config"))
+	require.NoError(t, err, "~/.aws/config should have been created")
+	assert.Contains(t, string(configContent), "[profile localstack]")
+	assert.Contains(t, string(configContent), "endpoint_url")
+
+	credsContent, err := os.ReadFile(filepath.Join(tmpHome, ".aws", "credentials"))
+	require.NoError(t, err, "~/.aws/credentials should have been created")
+	normalizedCreds := strings.Join(strings.Fields(string(credsContent)), " ")
+	assert.Contains(t, normalizedCreds, "[localstack]")
+	assert.Contains(t, normalizedCreds, "aws_access_key_id = test")
+	assert.Contains(t, normalizedCreds, "aws_secret_access_key = test")
+
+	assert.Contains(t, out.String(), "Created LocalStack profile in ~/.aws")
+	assert.NotContains(t, out.String(), "Skipped adding LocalStack AWS profile.")
+}
+
+func TestConfigProfileDoesNotCreateAWSProfileWhenDeclined(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+	baseEnv, tmpHome := awsConfigEnv(t)
+
+	ctx := testContext(t)
+	cmd := exec.CommandContext(ctx, binaryPath(), "config", "profile")
+	cmd.Env = baseEnv
+
+	ptmx, err := pty.Start(cmd)
+	require.NoError(t, err, "failed to start command in PTY")
+	defer func() { _ = ptmx.Close() }()
+
+	out := &syncBuffer{}
+	outputCh := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(out, ptmx)
+		close(outputCh)
+	}()
+
+	require.Eventually(t, func() bool {
+		return bytes.Contains(out.Bytes(), []byte(awsSetupPrompt))
+	}, 2*time.Minute, 200*time.Millisecond, "AWS profile prompt should appear")
+
+	_, err = ptmx.Write([]byte("n"))
+	require.NoError(t, err)
+
+	err = cmd.Wait()
+	<-outputCh
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(tmpHome, ".aws", "config"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(tmpHome, ".aws", "credentials"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	assert.Contains(t, out.String(), "Skipped adding LocalStack AWS profile.")
+	assert.NotContains(t, out.String(), "Created LocalStack profile in ~/.aws/config")
+}
+
+func TestSetupAWSNonInteractiveReturnsError(t *testing.T) {
+	baseEnv, _ := awsConfigEnv(t)
+
+	_, stderr, err := runLstk(t, testContext(t), "",
+		baseEnv,
+		"setup", "aws",
+	)
+	require.Error(t, err)
+	assert.Contains(t, stderr, "setup aws requires an interactive terminal")
 }

--- a/test/integration/awsconfig_test.go
+++ b/test/integration/awsconfig_test.go
@@ -134,7 +134,8 @@ func TestStartSkipsAWSProfilePromptWhenAlreadyConfigured(t *testing.T) {
 	_ = cmd.Process.Kill()
 	err = cmd.Wait()
 	<-outputCh
-	require.NoError(t, err, "lstk start should exit after kill")
+	// Process was killed, so we expect an error from Wait()
+	require.Error(t, err, "lstk start should exit after kill")
 
 	assert.NotContains(t, out.String(), awsSetupPrompt,
 		"profile prompt should not appear when profile is already correctly configured")

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -207,7 +207,7 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 	t.Run("http health endpoint", func(t *testing.T) {
 		resp, err := http.Get("http://localhost.localstack.cloud:4566/_localstack/health")
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, resp.Body.Close()) }()
+		t.Cleanup(func() { _ = resp.Body.Close() })
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
@@ -221,7 +221,7 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 		}
 		resp, err := client.Get("https://localhost.localstack.cloud/_localstack/health")
 		require.NoError(t, err)
-		defer func() { assert.NoError(t, resp.Body.Close()) }()
+		t.Cleanup(func() { _ = resp.Body.Close() })
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 }


### PR DESCRIPTION
This PR improves the AWS profile setup flow to reduce repeated prompts during `lstk start` without adding extra persisted config state.

Users running lstk start repeatedly were prompted every time even when a partial profile existed. This change makes the prompt conditional while still guiding users to set up a complete profile via lstk setup aws.

1. `lstk start` now prompts only when the localstack profile is missing from both `~/.aws/config` and `~/.aws/credentials`
1. If the profile exists in only one file, or exists in both but is incomplete, lstk start shows a non-blocking note instead of prompting
1. Added `lstk setup aws` command for interactive AWS profile setup
1. Updated prompt text to "Set up a LocalStack profile for AWS CLI and SDKs in ~/.aws?"
1. Shows success message on confirm and skip note on decline

| No config | Config created | Config skipped | Partial config | Config command |
|--------|--------|--------|--------|--------|
| <img width="669" height="370" alt="Screenshot 2026-03-23 at 18 10 41" src="https://github.com/user-attachments/assets/c4a25bd9-0824-4203-898b-9da4104cfe02" /> | <img width="669" height="370" alt="Screenshot 2026-03-23 at 18 10 50" src="https://github.com/user-attachments/assets/2a6ab661-c6cf-46d5-91ea-7fa328810f54" /> | <img width="669" height="370" alt="Screenshot 2026-03-23 at 18 11 15" src="https://github.com/user-attachments/assets/d3b87c0b-b5d3-4429-8cd8-11c5b7759767" /> | <img width="669" height="370" alt="Screenshot 2026-03-23 at 18 23 09" src="https://github.com/user-attachments/assets/66639f6e-247f-406b-ad62-419406f51046" /> | <img width="669" height="370" alt="Screenshot 2026-03-23 at 18 25 43" src="https://github.com/user-attachments/assets/839adc08-4d1f-4613-965d-3266f07870b6" /> | 