### PR TITLE
Use catalog API to resolve latest version before pulling

### DIFF
--- a/internal/api/catalog_version_test.go
+++ b/internal/api/catalog_version_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/localstack/lstk/internal/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLatestCatalogVersion_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/license/catalog/aws/version", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"emulator_type": "aws",
+			"version":       "4.14.0",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewPlatformClient(srv.URL, log.Nop())
+	version, err := client.GetLatestCatalogVersion(context.Background(), "aws")
+
+	require.NoError(t, err)
+	assert.Equal(t, "4.14.0", version)
+}
+
+func TestGetLatestCatalogVersion_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client := NewPlatformClient(srv.URL, log.Nop())
+	_, err := client.GetLatestCatalogVersion(context.Background(), "aws")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 503")
+}
+
+func TestGetLatestCatalogVersion_EmptyVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"emulator_type": "aws",
+			"version":       "",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewPlatformClient(srv.URL, log.Nop())
+	_, err := client.GetLatestCatalogVersion(context.Background(), "aws")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "incomplete catalog response")
+}
+
+func TestGetLatestCatalogVersion_MissingEmulatorType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"version": "4.14.0",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewPlatformClient(srv.URL, log.Nop())
+	_, err := client.GetLatestCatalogVersion(context.Background(), "aws")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "incomplete catalog response")
+}
+
+func TestGetLatestCatalogVersion_MismatchedEmulatorType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"emulator_type": "azure",
+			"version":       "4.14.0",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewPlatformClient(srv.URL, log.Nop())
+	_, err := client.GetLatestCatalogVersion(context.Background(), "aws")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected emulator_type")
+}
+
+func TestGetLatestCatalogVersion_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	client := NewPlatformClient(srv.URL, log.Nop())
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := client.GetLatestCatalogVersion(ctx, "aws")
+
+	require.Error(t, err)
+}
+
+func TestGetLatestCatalogVersion_ServerDown(t *testing.T) {
+	client := NewPlatformClient("http://127.0.0.1:1", log.Nop())
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_, err := client.GetLatestCatalogVersion(ctx, "aws")
+
+	require.Error(t, err)
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/localstack/lstk/internal/log"
@@ -21,6 +22,7 @@ type PlatformAPI interface {
 	ExchangeAuthRequest(ctx context.Context, id, exchangeToken string) (string, error)
 	GetLicenseToken(ctx context.Context, bearerToken string) (string, error)
 	GetLicense(ctx context.Context, req *LicenseRequest) error
+	GetLatestCatalogVersion(ctx context.Context, emulatorType string) (string, error)
 }
 
 type AuthRequest struct {
@@ -275,4 +277,46 @@ func (c *PlatformClient) GetLicense(ctx context.Context, licReq *LicenseRequest)
 			Detail:  detail,
 		}
 	}
+}
+
+type catalogVersionResponse struct {
+	EmulatorType string `json:"emulator_type"`
+	Version      string `json:"version"`
+}
+
+func (c *PlatformClient) GetLatestCatalogVersion(ctx context.Context, emulatorType string) (string, error) {
+	reqURL := fmt.Sprintf("%s/v1/license/catalog/%s/version", c.baseURL, url.PathEscape(emulatorType))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get catalog version: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			c.logger.Error("failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get catalog version: status %d", resp.StatusCode)
+	}
+
+	var versionResp catalogVersionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&versionResp); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if versionResp.EmulatorType == "" || versionResp.Version == "" {
+		return "", fmt.Errorf("incomplete catalog response: emulator_type=%q version=%q", versionResp.EmulatorType, versionResp.Version)
+	}
+
+	if versionResp.EmulatorType != emulatorType {
+		return "", fmt.Errorf("unexpected emulator_type: got=%q want=%q", versionResp.EmulatorType, emulatorType)
+	}
+
+	return versionResp.Version, nil
 }

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -166,14 +166,20 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		return nil
 	}
 
-	// TODO validate license for tag "latest" without resolving the actual image version,
-	// and avoid pulling all images first
+	// Validate licenses before pulling where possible (pinned tags always; "latest" tags via catalog API).
+	// Returns containers that still need post-pull validation (catalog unavailable).
+	postPullContainers, err := tryPrePullLicenseValidation(ctx, sink, opts, tel, containers, token)
+	if err != nil {
+		return err
+	}
+
 	pulled, err := pullImages(ctx, rt, sink, tel, containers)
 	if err != nil {
 		return err
 	}
 
-	if err := validateLicenses(ctx, rt, sink, opts, tel, containers, token); err != nil {
+	// Catalog was unavailable for these; fall back to image inspection.
+	if err := validateLicensesFromImages(ctx, rt, sink, opts, tel, postPullContainers, token); err != nil {
 		return err
 	}
 
@@ -258,9 +264,46 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *
 	return pulled, nil
 }
 
-func validateLicenses(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel *telemetry.Client, containers []runtime.ContainerConfig, token string) error {
+// Validates licenses before pulling where the version is known.
+// Pinned tags are validated immediately; "latest" tags are resolved via the catalog API.
+// Returns containers that couldn't be resolved (catalog unavailable) for post-pull validation.
+func tryPrePullLicenseValidation(ctx context.Context, sink output.Sink, opts StartOptions, tel *telemetry.Client, containers []runtime.ContainerConfig, token string) ([]runtime.ContainerConfig, error) {
+	var needsPostPull []runtime.ContainerConfig
 	for _, c := range containers {
-		if err := validateLicense(ctx, rt, sink, opts, tel, c, token); err != nil {
+		if c.Tag != "" && c.Tag != "latest" {
+			if err := validateLicense(ctx, sink, opts, tel, c, token); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		apiCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		v, err := opts.PlatformClient.GetLatestCatalogVersion(apiCtx, c.EmulatorType)
+		cancel()
+
+		if err != nil {
+			needsPostPull = append(needsPostPull, c)
+			continue
+		}
+
+		cWithVersion := c
+		cWithVersion.Tag = v
+		if err := validateLicense(ctx, sink, opts, tel, cWithVersion, token); err != nil {
+			return nil, err
+		}
+	}
+	return needsPostPull, nil
+}
+
+// Fallback path: inspects each pulled image for its version, then validates the license.
+func validateLicensesFromImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel *telemetry.Client, containers []runtime.ContainerConfig, token string) error {
+	for _, c := range containers {
+		v, err := rt.GetImageVersion(ctx, c.Image)
+		if err != nil {
+			return fmt.Errorf("could not resolve version from image %s: %w", c.Image, err)
+		}
+		c.Tag = v
+		if err := validateLicense(ctx, sink, opts, tel, c, token); err != nil {
 			return err
 		}
 	}
@@ -328,16 +371,8 @@ func emitPortInUseError(sink output.Sink, port string) {
 	})
 }
 
-func validateLicense(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel *telemetry.Client, containerConfig runtime.ContainerConfig, token string) error {
+func validateLicense(ctx context.Context, sink output.Sink, opts StartOptions, tel *telemetry.Client, containerConfig runtime.ContainerConfig, token string) error {
 	version := containerConfig.Tag
-	if version == "" || version == "latest" {
-		actualVersion, err := rt.GetImageVersion(ctx, containerConfig.Image)
-		if err != nil {
-			return fmt.Errorf("could not resolve version from image %s: %w", containerConfig.Image, err)
-		}
-		version = actualVersion
-	}
-
 	output.EmitStatus(sink, "validating license", containerConfig.Name, version)
 
 	hostname, _ := os.Hostname()

--- a/test/integration/version_resolution_test.go
+++ b/test/integration/version_resolution_test.go
@@ -1,0 +1,114 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// returns a mock server for catalog and license endpoints.
+// Empty catalogVersion → 503. The returned *string captures the product version from license requests.
+func createVersionResolutionMockServer(t *testing.T, catalogVersion string, licenseSuccess bool) (*httptest.Server, *string) {
+	t.Helper()
+	capturedVersion := new(string)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/license/catalog/"):
+			if catalogVersion == "" {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+			emulatorType := parts[len(parts)-2]
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"emulator_type":%q,"version":%q}`, emulatorType, catalogVersion)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/license/request":
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				Product struct {
+					Version string `json:"version"`
+				} `json:"product"`
+			}
+			_ = json.Unmarshal(body, &req)
+			*capturedVersion = req.Product.Version
+			if licenseSuccess {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, capturedVersion
+}
+
+// Verifies that when the catalog API returns a version, the license request uses
+// that version (not "latest"), allowing license validation to happen before pulling the image.
+func TestVersionResolvedViaCatalog(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer, capturedVersion := createVersionResolutionMockServer(t, "4.14.0", true)
+
+	ctx := testContext(t)
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "start")
+	require.NoError(t, err, "lstk start failed:\nstdout: %s\nstderr: %s", stdout, stderr)
+
+	assert.Equal(t, "4.14.0", *capturedVersion,
+		"license request should carry the version returned by the catalog API")
+	assert.NotEqual(t, "latest", *capturedVersion,
+		"license request should not use the unresolved 'latest' tag")
+}
+
+// Verifies that when the catalog endpoint is unavailable, the version is resolved
+// by inspecting the pulled image and used for licensing.
+func TestVersionFallsBackToImageInspectionWhenCatalogFails(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// Catalog returns 503; license accepts all requests
+	mockServer, capturedVersion := createVersionResolutionMockServer(t, "", true)
+
+	ctx := testContext(t)
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "start")
+	require.NoError(t, err, "lstk start should succeed via image inspection fallback:\nstdout: %s\nstderr: %s", stdout, stderr)
+
+	assert.NotEmpty(t, *capturedVersion, "license request should carry a version resolved from image inspection")
+	assert.NotEqual(t, "latest", *capturedVersion, "resolved version should not be the unresolved 'latest' tag")
+}
+
+// Verifies that when both the catalog endpoint is unavailable and the license
+// validation fails in the image inspection fallback path, the command exits with a clear error.
+func TestCommandFailsNicelyWhenCatalogAndLicenseBothFail(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// Catalog unavailable; license rejects all requests
+	mockServer, _ := createVersionResolutionMockServer(t, "", false)
+
+	ctx := testContext(t)
+	stdout, stderr, err := runLstk(t, ctx, "",
+		env.With(env.APIEndpoint, mockServer.URL), "start")
+	require.Error(t, err, "expected lstk start to fail when catalog is down and license check fails")
+	assert.Contains(t, stderr, "license validation failed",
+		"stdout: %s", stdout)
+}


### PR DESCRIPTION
When the image tag is "latest", the CLI previously had to pull the image first to resolve the version for license validation.

This changes the order: the catalog API  (/v1/license/catalog/{emulator_type}/version) is called first to get the latest released version, so license validation happens before any image data is downloaded. 

If the catalog API is unavailable, the original behavior is preserved as a fallback (pull first, inspect image for version, then validate).  