### PR TITLE
Mount daemon Docker socket for nested workloads

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -71,6 +71,12 @@ func probeSocket(candidates ...string) string {
 	return ""
 }
 
+// SocketPath returns the Unix socket path used by the Docker client.
+// Returns the actual path for the standard /var/run/docker.sock so callers
+// can bind-mount it into containers. Returns empty string for non-standard
+// sockets (Colima, OrbStack) which communicate with VMs and cannot be
+// bind-mounted. Called by internal/container/start.go to decide whether
+// to add a Docker socket bind-mount when starting LocalStack.
 func (d *DockerRuntime) SocketPath() string {
 	return socketPathFromHost(d.client.DaemonHost())
 }
@@ -80,7 +86,13 @@ func (d *DockerRuntime) SocketPath() string {
 // but exposes the socket at /var/run/docker.sock for Linux containers to bind-mount (via WSL2).
 func socketPathFromHost(host string) string {
 	if strings.HasPrefix(host, "unix://") {
-		return strings.TrimPrefix(host, "unix://")
+		sock := strings.TrimPrefix(host, "unix://")
+		// Skip bind-mount for non-standard sockets (Colima, OrbStack, etc.)
+		// These sockets communicate with VMs and cannot be bind-mounted
+		if sock != "/var/run/docker.sock" {
+			return ""
+		}
+		return sock
 	}
 	if strings.HasPrefix(host, "npipe://") {
 		return "/var/run/docker.sock"

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -71,12 +71,11 @@ func probeSocket(candidates ...string) string {
 	return ""
 }
 
-// SocketPath returns the Unix socket path used by the Docker client.
-// Returns the actual path for the standard /var/run/docker.sock so callers
-// can bind-mount it into containers. Returns empty string for non-standard
-// sockets (Colima, OrbStack) which communicate with VMs and cannot be
-// bind-mounted. Called by internal/container/start.go to decide whether
-// to add a Docker socket bind-mount when starting LocalStack.
+// SocketPath returns the daemon-visible Unix socket path to bind-mount into
+// containers so LocalStack can launch nested workloads such as Lambda functions.
+// Even when the CLI connects through a user-scoped socket (for example Colima),
+// the daemon resolves bind mounts inside its own environment where the socket is
+// exposed at /var/run/docker.sock.
 func (d *DockerRuntime) SocketPath() string {
 	return socketPathFromHost(d.client.DaemonHost())
 }
@@ -86,13 +85,7 @@ func (d *DockerRuntime) SocketPath() string {
 // but exposes the socket at /var/run/docker.sock for Linux containers to bind-mount (via WSL2).
 func socketPathFromHost(host string) string {
 	if strings.HasPrefix(host, "unix://") {
-		sock := strings.TrimPrefix(host, "unix://")
-		// Skip bind-mount for non-standard sockets (Colima, OrbStack, etc.)
-		// These sockets communicate with VMs and cannot be bind-mounted
-		if sock != "/var/run/docker.sock" {
-			return ""
-		}
-		return sock
+		return "/var/run/docker.sock"
 	}
 	if strings.HasPrefix(host, "npipe://") {
 		return "/var/run/docker.sock"

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -71,12 +71,38 @@ func probeSocket(candidates ...string) string {
 	return ""
 }
 
+// isVM reports whether the Docker daemon is running inside a VM (e.g., Colima, OrbStack).
+// In these cases the socket is remapped inside the VM and the container sees it at
+// /var/run/docker.sock even if the CLI connects via a user-scoped socket path.
+func (d *DockerRuntime) isVM() bool {
+	host := d.client.DaemonHost()
+	if strings.HasPrefix(host, "unix://") {
+		socketPath := strings.TrimPrefix(host, "unix://")
+		// Check for known VM-based Docker socket locations
+		home, _ := os.UserHomeDir()
+		vmSockets := []string{
+			filepath.Join(home, ".colima", "default", "docker.sock"),
+			filepath.Join(home, ".colima", "docker.sock"),
+			filepath.Join(home, ".orbstack", "run", "docker.sock"),
+		}
+		for _, vmSock := range vmSockets {
+			if socketPath == vmSock {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // SocketPath returns the daemon-visible Unix socket path to bind-mount into
 // containers so LocalStack can launch nested workloads such as Lambda functions.
-// Even when the CLI connects through a user-scoped socket (for example Colima),
-// the daemon resolves bind mounts inside its own environment where the socket is
-// exposed at /var/run/docker.sock.
+// For VM-based Docker (Colima, OrbStack) returns /var/run/docker.sock as the
+// socket is remapped inside the VM. For rootless or custom setups, returns the
+// actual socket path extracted from the daemon host.
 func (d *DockerRuntime) SocketPath() string {
+	if d.isVM() {
+		return "/var/run/docker.sock"
+	}
 	return socketPathFromHost(d.client.DaemonHost())
 }
 
@@ -85,7 +111,7 @@ func (d *DockerRuntime) SocketPath() string {
 // but exposes the socket at /var/run/docker.sock for Linux containers to bind-mount (via WSL2).
 func socketPathFromHost(host string) string {
 	if strings.HasPrefix(host, "unix://") {
-		return "/var/run/docker.sock"
+		return strings.TrimPrefix(host, "unix://")
 	}
 	if strings.HasPrefix(host, "npipe://") {
 		return "/var/run/docker.sock"

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -41,25 +41,25 @@ func TestProbeSocket_ReturnsEmptyForNoCandidates(t *testing.T) {
 }
 
 func TestSocketPath_ExtractsUnixPath(t *testing.T) {
-	t.Run("standard socket returns path", func(t *testing.T) {
+	t.Run("standard socket returns daemon path", func(t *testing.T) {
 		cli, err := client.NewClientWithOpts(client.WithHost("unix:///var/run/docker.sock"))
 		require.NoError(t, err)
 		rt := &DockerRuntime{client: cli}
 		assert.Equal(t, "/var/run/docker.sock", rt.SocketPath())
 	})
 
-	t.Run("non-standard socket returns empty", func(t *testing.T) {
+	t.Run("non-standard socket returns daemon path", func(t *testing.T) {
 		cli, err := client.NewClientWithOpts(client.WithHost("unix:///home/user/.colima/default/docker.sock"))
 		require.NoError(t, err)
 		rt := &DockerRuntime{client: cli}
-		assert.Equal(t, "", rt.SocketPath(), "non-standard sockets should return empty to skip bind-mount")
+		assert.Equal(t, "/var/run/docker.sock", rt.SocketPath())
 	})
 
-	t.Run("orbstack socket returns empty", func(t *testing.T) {
+	t.Run("orbstack socket returns daemon path", func(t *testing.T) {
 		cli, err := client.NewClientWithOpts(client.WithHost("unix:///Users/user/.orbstack/run/docker.sock"))
 		require.NoError(t, err)
 		rt := &DockerRuntime{client: cli}
-		assert.Equal(t, "", rt.SocketPath(), "non-standard sockets should return empty to skip bind-mount")
+		assert.Equal(t, "/var/run/docker.sock", rt.SocketPath())
 	})
 }
 

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -52,14 +52,14 @@ func TestSocketPath_ExtractsUnixPath(t *testing.T) {
 		cli, err := client.NewClientWithOpts(client.WithHost("unix:///home/user/.colima/default/docker.sock"))
 		require.NoError(t, err)
 		rt := &DockerRuntime{client: cli}
-		assert.Equal(t, "/var/run/docker.sock", rt.SocketPath())
+		assert.Equal(t, "/home/user/.colima/default/docker.sock", rt.SocketPath())
 	})
 
 	t.Run("orbstack socket returns daemon path", func(t *testing.T) {
 		cli, err := client.NewClientWithOpts(client.WithHost("unix:///Users/user/.orbstack/run/docker.sock"))
 		require.NoError(t, err)
 		rt := &DockerRuntime{client: cli}
-		assert.Equal(t, "/var/run/docker.sock", rt.SocketPath())
+		assert.Equal(t, "/Users/user/.orbstack/run/docker.sock", rt.SocketPath())
 	})
 }
 
@@ -77,6 +77,51 @@ func TestSocketPathFromHost_ReturnsDockerSockForWindowsNamedPipe(t *testing.T) {
 
 func TestSocketPathFromHost_ExtractsUnixPath(t *testing.T) {
 	assert.Equal(t, "/var/run/docker.sock", socketPathFromHost("unix:///var/run/docker.sock"))
+}
+
+func TestSocketPath_VMDetection(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	t.Run("colima socket exists returns remapped path", func(t *testing.T) {
+		colimaSock := filepath.Join(home, ".colima", "default", "docker.sock")
+		require.NoError(t, os.MkdirAll(filepath.Dir(colimaSock), 0o755))
+		f, err := os.Create(colimaSock)
+		require.NoError(t, err)
+		f.Close()
+		defer os.Remove(colimaSock)
+
+		cli, err := client.NewClientWithOpts(client.WithHost("unix://" + colimaSock))
+		require.NoError(t, err)
+		rt := &DockerRuntime{client: cli}
+		assert.Equal(t, "/var/run/docker.sock", rt.SocketPath())
+	})
+
+	t.Run("orbstack socket exists returns remapped path", func(t *testing.T) {
+		orbstackSock := filepath.Join(home, ".orbstack", "run", "docker.sock")
+		require.NoError(t, os.MkdirAll(filepath.Dir(orbstackSock), 0o755))
+		f, err := os.Create(orbstackSock)
+		require.NoError(t, err)
+		f.Close()
+		defer os.Remove(orbstackSock)
+
+		cli, err := client.NewClientWithOpts(client.WithHost("unix://" + orbstackSock))
+		require.NoError(t, err)
+		rt := &DockerRuntime{client: cli}
+		assert.Equal(t, "/var/run/docker.sock", rt.SocketPath())
+	})
+
+	t.Run("rootless socket exists returns actual path", func(t *testing.T) {
+		// Use a non-VM socket path (short path to avoid Docker client limit)
+		rootlessSock := "/tmp/lstk-docker.sock"
+		require.NoError(t, os.WriteFile(rootlessSock, nil, 0o600))
+		defer os.Remove(rootlessSock)
+
+		cli, err := client.NewClientWithOpts(client.WithHost("unix://" + rootlessSock))
+		require.NoError(t, err)
+		rt := &DockerRuntime{client: cli}
+		assert.Equal(t, rootlessSock, rt.SocketPath())
+	})
 }
 
 func TestWindowsDockerStartCommand_DockerAvailable(t *testing.T) {

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -80,8 +80,8 @@ func TestSocketPathFromHost_ExtractsUnixPath(t *testing.T) {
 }
 
 func TestSocketPath_VMDetection(t *testing.T) {
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
 	t.Run("colima socket exists returns remapped path", func(t *testing.T) {
 		colimaSock := filepath.Join(home, ".colima", "default", "docker.sock")

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -41,11 +41,26 @@ func TestProbeSocket_ReturnsEmptyForNoCandidates(t *testing.T) {
 }
 
 func TestSocketPath_ExtractsUnixPath(t *testing.T) {
-	cli, err := client.NewClientWithOpts(client.WithHost("unix:///home/user/.colima/default/docker.sock"))
-	require.NoError(t, err)
-	rt := &DockerRuntime{client: cli}
+	t.Run("standard socket returns path", func(t *testing.T) {
+		cli, err := client.NewClientWithOpts(client.WithHost("unix:///var/run/docker.sock"))
+		require.NoError(t, err)
+		rt := &DockerRuntime{client: cli}
+		assert.Equal(t, "/var/run/docker.sock", rt.SocketPath())
+	})
 
-	assert.Equal(t, "/home/user/.colima/default/docker.sock", rt.SocketPath())
+	t.Run("non-standard socket returns empty", func(t *testing.T) {
+		cli, err := client.NewClientWithOpts(client.WithHost("unix:///home/user/.colima/default/docker.sock"))
+		require.NoError(t, err)
+		rt := &DockerRuntime{client: cli}
+		assert.Equal(t, "", rt.SocketPath(), "non-standard sockets should return empty to skip bind-mount")
+	})
+
+	t.Run("orbstack socket returns empty", func(t *testing.T) {
+		cli, err := client.NewClientWithOpts(client.WithHost("unix:///Users/user/.orbstack/run/docker.sock"))
+		require.NoError(t, err)
+		rt := &DockerRuntime{client: cli}
+		assert.Equal(t, "", rt.SocketPath(), "non-standard sockets should return empty to skip bind-mount")
+	})
 }
 
 func TestSocketPath_ReturnsEmptyForTCPHost(t *testing.T) {

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -88,8 +88,10 @@ func TestSocketPath_VMDetection(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(colimaSock), 0o755))
 		f, err := os.Create(colimaSock)
 		require.NoError(t, err)
-		f.Close()
-		defer os.Remove(colimaSock)
+		require.NoError(t, f.Close())
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(colimaSock))
+		})
 
 		cli, err := client.NewClientWithOpts(client.WithHost("unix://" + colimaSock))
 		require.NoError(t, err)
@@ -102,8 +104,10 @@ func TestSocketPath_VMDetection(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(orbstackSock), 0o755))
 		f, err := os.Create(orbstackSock)
 		require.NoError(t, err)
-		f.Close()
-		defer os.Remove(orbstackSock)
+		require.NoError(t, f.Close())
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(orbstackSock))
+		})
 
 		cli, err := client.NewClientWithOpts(client.WithHost("unix://" + orbstackSock))
 		require.NoError(t, err)
@@ -115,7 +119,9 @@ func TestSocketPath_VMDetection(t *testing.T) {
 		// Use a non-VM socket path (short path to avoid Docker client limit)
 		rootlessSock := "/tmp/lstk-docker.sock"
 		require.NoError(t, os.WriteFile(rootlessSock, nil, 0o600))
-		defer os.Remove(rootlessSock)
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(rootlessSock))
+		})
 
 		cli, err := client.NewClientWithOpts(client.WithHost("unix://" + rootlessSock))
 		require.NoError(t, err)

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -170,6 +170,12 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 			t.Skip("Docker daemon is not reachable via unix socket")
 		}
 
+		// Skip bind-mount assertion for non-standard sockets (Colima, OrbStack)
+		// since these communicate with VMs and cannot be bind-mounted
+		if dockerClient.DaemonHost() != "unix:///var/run/docker.sock" {
+			t.Skip("Docker daemon uses non-standard socket (Colima/OrbStack) - socket not bind-mounted")
+		}
+
 		assert.True(t, hasBindTarget(inspect.HostConfig.Binds, "/var/run/docker.sock"),
 			"expected Docker socket bind mount to /var/run/docker.sock, got: %v", inspect.HostConfig.Binds)
 

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -170,14 +170,10 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 			t.Skip("Docker daemon is not reachable via unix socket")
 		}
 
-		// Skip bind-mount assertion for non-standard sockets (Colima, OrbStack)
-		// since these communicate with VMs and cannot be bind-mounted
-		if dockerClient.DaemonHost() != "unix:///var/run/docker.sock" {
-			t.Skip("Docker daemon uses non-standard socket (Colima/OrbStack) - socket not bind-mounted")
-		}
-
 		assert.True(t, hasBindTarget(inspect.HostConfig.Binds, "/var/run/docker.sock"),
 			"expected Docker socket bind mount to /var/run/docker.sock, got: %v", inspect.HostConfig.Binds)
+		assert.True(t, hasBindSource(inspect.HostConfig.Binds, "/var/run/docker.sock"),
+			"expected Docker socket bind mount from /var/run/docker.sock, got: %v", inspect.HostConfig.Binds)
 
 		envVars := containerEnvToMap(inspect.Config.Env)
 		assert.Equal(t, "unix:///var/run/docker.sock", envVars["DOCKER_HOST"])
@@ -247,6 +243,16 @@ func hasBindTarget(binds []string, containerPath string) bool {
 	for _, b := range binds {
 		parts := strings.Split(b, ":")
 		if len(parts) >= 2 && parts[1] == containerPath {
+			return true
+		}
+	}
+	return false
+}
+
+func hasBindSource(binds []string, hostPath string) bool {
+	for _, b := range binds {
+		parts := strings.Split(b, ":")
+		if len(parts) >= 2 && parts[0] == hostPath {
 			return true
 		}
 	}


### PR DESCRIPTION
This fixes nested-workload startup on VM-based Docker runtimes such as Colima and OrbStack.

The CLI was previously skipping the Docker socket bind-mount entirely for non-standard sockets (e.g. Colima), so Lambda and other nested workloads couldn't reach the daemon. This change detects VM-based runtimes and mounts `/var/run/docker.sock`, the path the daemon exposes inside the VM. For rootless Docker or custom socket setups, the actual socket path is used.