### PR TITLE
Use .lstk/config.toml for project-local config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ lstk always writes diagnostic logs to `$CONFIG_DIR/lstk.log` (appends across run
 
 # Configuration
 
-Uses Viper with TOML format. lstk uses the first config file found in this order:
-1. `./lstk.toml` (project-local)
+Uses Viper with TOML format. lstk uses the first `config.toml` found in this order:
+1. `./.lstk/config.toml` (project-local)
 2. `$HOME/.config/lstk/config.toml`
 3. **macOS**: `$HOME/Library/Application Support/lstk/config.toml` / **Windows**: `%AppData%\lstk\config.toml`
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ The CLI supports multiple auth workflows. `lstk` resolves your auth token in thi
 
 `lstk` uses a TOML config file, created automatically on first run.
 
-`lstk` uses the first config file found in this order:
-1. `./lstk.toml` (project-local)
+`lstk` uses the first `config.toml` found in this order:
+1. `./.lstk/config.toml` (project-local)
 2. `$HOME/.config/lstk/config.toml`
 3. **macOS**: `$HOME/Library/Application Support/lstk/config.toml` / **Windows**: `%AppData%\lstk\config.toml`
 
@@ -86,7 +86,7 @@ lstk config path
 You can also point `lstk` at a specific config file for any command:
 
 ```bash
-lstk --config /path/to/lstk.toml start
+lstk --config /path/to/config.toml start
 ```
 
 ### Default config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,45 +47,57 @@ func InitFromPath(path string) error {
 }
 
 func Init() error {
-	// Reuse the same ordered path resolution used by ConfigFilePath.
-	existingPath, found, err := firstExistingConfigPath()
+	viper.Reset()
+	setDefaults()
+	viper.SetConfigName(configName)
+	viper.SetConfigType(configType)
+
+	dirs, err := configSearchDirs()
 	if err != nil {
 		return err
 	}
-	if found {
-		return loadConfig(existingPath)
+	for _, dir := range dirs {
+		viper.AddConfigPath(dir)
 	}
 
-	// No config found anywhere, create one using creation policy.
-	creationDir, err := configCreationDir()
-	if err != nil {
-		return err
-	}
-
-	if err := os.MkdirAll(creationDir, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
-	}
-
-	configPath := filepath.Join(creationDir, userConfigFileName)
-	f, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
-	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return loadConfig(configPath)
+	if err := viper.ReadInConfig(); err != nil {
+		var notFoundErr viper.ConfigFileNotFoundError
+		if !errors.As(err, &notFoundErr) {
+			return fmt.Errorf("failed to read config file: %w", err)
 		}
-		return fmt.Errorf("failed to create config file: %w", err)
-	}
-	_, writeErr := f.WriteString(defaultConfigTemplate)
-	closeErr := f.Close()
-	if writeErr != nil {
-		_ = os.Remove(configPath)
-		return fmt.Errorf("failed to write config file: %w", writeErr)
-	}
-	if closeErr != nil {
-		_ = os.Remove(configPath)
-		return fmt.Errorf("failed to close config file: %w", closeErr)
-	}
 
-	return loadConfig(configPath)
+		// No config found anywhere, create one using creation policy.
+		creationDir, err := configCreationDir()
+		if err != nil {
+			return err
+		}
+
+		if err := os.MkdirAll(creationDir, 0755); err != nil {
+			return fmt.Errorf("failed to create config directory: %w", err)
+		}
+
+		configPath := filepath.Join(creationDir, configFileName)
+		f, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		if err != nil {
+			if errors.Is(err, os.ErrExist) {
+				return loadConfig(configPath)
+			}
+			return fmt.Errorf("failed to create config file: %w", err)
+		}
+		_, writeErr := f.WriteString(defaultConfigTemplate)
+		closeErr := f.Close()
+		if writeErr != nil {
+			_ = os.Remove(configPath)
+			return fmt.Errorf("failed to write config file: %w", writeErr)
+		}
+		if closeErr != nil {
+			_ = os.Remove(configPath)
+			return fmt.Errorf("failed to close config file: %w", closeErr)
+		}
+
+		return loadConfig(configPath)
+	}
+	return nil
 }
 
 func resolvedConfigPath() string {

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -15,9 +15,7 @@ const (
 	EmulatorSnowflake EmulatorType = "snowflake"
 	EmulatorAzure     EmulatorType = "azure"
 
-	dockerRegistry      = "localstack"
-	localConfigFileName = "lstk.toml"
-	userConfigFileName  = "config.toml"
+	dockerRegistry = "localstack"
 )
 
 var emulatorDisplayNames = map[EmulatorType]string{

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -6,9 +6,15 @@ import (
 	"path/filepath"
 )
 
+const (
+	localConfigDir = ".lstk"
+	configName     = "config"
+	configType     = "toml"
+	configFileName = configName + "." + configType
+)
+
 func ConfigFilePath() (string, error) {
 	if resolved := resolvedConfigPath(); resolved != "" {
-		// If Init already ran, use Viper's selected file directly.
 		absResolved, err := filepath.Abs(resolved)
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve absolute config path: %w", err)
@@ -34,7 +40,7 @@ func ConfigFilePath() (string, error) {
 		return "", err
 	}
 
-	creationPath := filepath.Join(creationDir, userConfigFileName)
+	creationPath := filepath.Join(creationDir, configFileName)
 	absCreationPath, err := filepath.Abs(creationPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve absolute config path: %w", err)
@@ -67,11 +73,9 @@ func osConfigDir() (string, error) {
 	return filepath.Join(configHome, "lstk"), nil
 }
 
-func localConfigPath() string {
-	return filepath.Join(".", localConfigFileName)
-}
-
-func configSearchPaths() ([]string, error) {
+// configSearchDirs returns directories to search for config.toml, in priority order:
+// project-local (.lstk/), XDG-style home config, OS-specific fallback.
+func configSearchDirs() ([]string, error) {
 	xdgDir, err := xdgConfigDir()
 	if err != nil {
 		return nil, err
@@ -83,10 +87,9 @@ func configSearchPaths() ([]string, error) {
 	}
 
 	return []string{
-		// Priority order: project-local, then XDG-style home config, then OS-specific fallback.
-		localConfigPath(),
-		filepath.Join(xdgDir, userConfigFileName),
-		filepath.Join(osDir, userConfigFileName),
+		filepath.Join(".", localConfigDir),
+		xdgDir,
+		osDir,
 	}, nil
 }
 
@@ -111,12 +114,13 @@ func configCreationDir() (string, error) {
 }
 
 func firstExistingConfigPath() (string, bool, error) {
-	paths, err := configSearchPaths()
+	dirs, err := configSearchDirs()
 	if err != nil {
 		return "", false, err
 	}
 
-	for _, path := range paths {
+	for _, dir := range dirs {
+		path := filepath.Join(dir, configFileName)
 		if _, err := os.Stat(path); err == nil {
 			return path, true, nil
 		} else if !os.IsNotExist(err) {

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -94,7 +94,7 @@ func TestLocalConfigTakesPrecedence(t *testing.T) {
 	workDir := t.TempDir()
 	xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
 
-	localConfigFile := filepath.Join(workDir, "lstk.toml")
+	localConfigFile := filepath.Join(workDir, ".lstk", "config.toml")
 	writeConfigFile(t, localConfigFile)
 	writeConfigFile(t, filepath.Join(tmpHome, ".config", "lstk", "config.toml"))
 	writeConfigFile(t, filepath.Join(expectedOSConfigDir(tmpHome, xdgOverride), "config.toml"))


### PR DESCRIPTION
## Motivation

Local config used `./lstk.toml` while all other config locations used `config.toml`, which was confusing — users naturally create `config.toml` in their project directory and it doesn't get picked up. This changes the local config to `.lstk/config.toml` inside a conventional dotdir, making the filename consistent across all config locations.

## Changes

- Move config path constants from `containers.go` to `paths.go` where they belong
- Change local config path from `./lstk.toml` to `./.lstk/config.toml`
- Unify on a single `configFileName` constant since all locations now use `config.toml`
- Replace manual path search in `Init()` with Viper's built-in `AddConfigPath`/`SetConfigName` search
- Replace `configSearchPaths()` (full file paths) with `configSearchDirs()` (directories only)
- Update integration test and documentation

## Tests

- All existing integration tests pass, including `TestLocalConfigTakesPrecedence` updated to use the new `.lstk/config.toml` path

## Related

- [FLC-536](https://linear.app/localstack/issue/FLC-536/lstk-doesnt-favour-local-config)