### PR TITLE
Remove 127.0.0.2 workaround from status integration test

### DIFF
--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
 	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/go-keyring"
@@ -170,10 +169,7 @@ const (
 	testImage     = "alpine:latest"
 )
 
-// startTestContainer starts the test container with no port bindings by default.
-// Pass hostPort to bind 4566/tcp to a specific host port (e.g. to test that lstk status
-// uses the actual bound port rather than the port from config).
-func startTestContainer(t *testing.T, ctx context.Context, hostPort ...string) {
+func startTestContainer(t *testing.T, ctx context.Context) {
 	t.Helper()
 
 	reader, err := dockerClient.ImagePull(ctx, testImage, image.PullOptions{})
@@ -185,19 +181,8 @@ func startTestContainer(t *testing.T, ctx context.Context, hostPort ...string) {
 		Image: testImage,
 		Cmd:   []string{"sleep", "infinity"},
 	}
-	var hostCfg *container.HostConfig
-	if len(hostPort) > 0 {
-		const containerPort = nat.Port("4566/tcp")
-		cfg.ExposedPorts = nat.PortSet{containerPort: struct{}{}}
-		hostCfg = &container.HostConfig{
-			PortBindings: nat.PortMap{
-				// 127.0.0.2 avoids conflicting with the mock HTTP server on 127.0.0.1:hostPort.
-				containerPort: []nat.PortBinding{{HostIP: "127.0.0.2", HostPort: hostPort[0]}},
-			},
-		}
-	}
 
-	resp, err := dockerClient.ContainerCreate(ctx, cfg, hostCfg, nil, nil, containerName)
+	resp, err := dockerClient.ContainerCreate(ctx, cfg, nil, nil, nil, containerName)
 	require.NoError(t, err, "failed to create test container")
 	err = dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
 	require.NoError(t, err, "failed to start test container")

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -2,11 +2,8 @@ package integration_test
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -85,7 +82,6 @@ func TestStatusCommandWorksWithNonDefaultPort(t *testing.T) {
 
 	ctx := testContext(t)
 
-	// The mock server is assigned a random free port (guaranteed not to conflict).
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/_localstack/health":
@@ -99,20 +95,10 @@ func TestStatusCommandWorksWithNonDefaultPort(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Extract the port so we can bind it to the container.
-	_, mockPort, err := net.SplitHostPort(server.Listener.Addr().String())
-	require.NoError(t, err)
+	startTestContainer(t, ctx)
 
-	// Simulates starting LocalStack on a non-default host port.
-	startTestContainer(t, ctx, mockPort)
-
-	// Write a config with the default port 4566
-	// Simulates the user changing the config port after starting the container
-	configContent := "[[containers]]\ntype = \"aws\"\ntag = \"latest\"\nport = \"4566\"\n"
-	configFile := filepath.Join(t.TempDir(), "config.toml")
-	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
-
-	stdout, stderr, err := runLstk(t, ctx, "", nil, "--config", configFile, "status")
+	host := strings.TrimPrefix(server.URL, "http://")
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, host), "status")
 	require.NoError(t, err, "lstk status failed: %s", stderr)
 	assert.Contains(t, stdout, "4.14.1")
 }


### PR DESCRIPTION
Now that `DockerRuntime` binds ports to `127.0.0.1` instead of `0.0.0.0` (see https://github.com/localstack/lstk/pull/151), the `127.0.0.2` trick used to avoid conflicts between the mock HTTP server and the test container is no longer necessary for the integration test `TestStatusCommandWorksWithNonDefaultPort`