### PR TITLE
Bind port 443 for HTTPS 

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -124,7 +124,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		containerName := c.Name()
 		env := append(resolvedEnv,
 			"LOCALSTACK_AUTH_TOKEN="+token,
-			"GATEWAY_LISTEN=:4566",
+			"GATEWAY_LISTEN=:4566,:443",
 			"MAIN_CONTAINER_NAME="+containerName,
 		)
 

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -424,7 +424,7 @@ func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {
 func servicePortRange() []runtime.PortMapping {
 	const start = 4510
 	const end = 4559
-	var ports []runtime.PortMapping
+	ports := []runtime.PortMapping{{ContainerPort: "443", HostPort: "443"}}
 	for p := start; p <= end; p++ {
 		ps := strconv.Itoa(p)
 		ports = append(ports, runtime.PortMapping{ContainerPort: ps, HostPort: ps})

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"strconv"
 	"testing"
 
 	"github.com/localstack/lstk/internal/log"
@@ -54,18 +53,14 @@ func TestEmitPostStartPointers_WithoutWebApp(t *testing.T) {
 	assert.Contains(t, got, "> Tip:")
 }
 
-func TestServicePortRange_Returns50Entries(t *testing.T) {
+func TestServicePortRange_ReturnsExpectedPorts(t *testing.T) {
 	ports := servicePortRange()
 
-	require.Len(t, ports, 50)
-	assert.Equal(t, "4510", ports[0].ContainerPort)
-	assert.Equal(t, "4510", ports[0].HostPort)
-	assert.Equal(t, "4559", ports[49].ContainerPort)
-	assert.Equal(t, "4559", ports[49].HostPort)
-
-	for i, p := range ports {
-		expected := strconv.Itoa(4510 + i)
-		assert.Equal(t, expected, p.ContainerPort)
-		assert.Equal(t, expected, p.HostPort)
-	}
+	require.Len(t, ports, 51)
+	assert.Equal(t, "443", ports[0].ContainerPort)
+	assert.Equal(t, "443", ports[0].HostPort)
+	assert.Equal(t, "4510", ports[1].ContainerPort)
+	assert.Equal(t, "4510", ports[1].HostPort)
+	assert.Equal(t, "4559", ports[50].ContainerPort)
+	assert.Equal(t, "4559", ports[50].HostPort)
 }

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -160,7 +160,7 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 
 	t.Run("environment variables", func(t *testing.T) {
 		envVars := containerEnvToMap(inspect.Config.Env)
-		assert.Equal(t, ":4566", envVars["GATEWAY_LISTEN"])
+		assert.Equal(t, ":4566,:443", envVars["GATEWAY_LISTEN"])
 		assert.Equal(t, containerName, envVars["MAIN_CONTAINER_NAME"])
 		assert.NotEmpty(t, envVars["LOCALSTACK_AUTH_TOKEN"])
 	})
@@ -212,7 +212,8 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 	})
 
 	t.Run("https health endpoint", func(t *testing.T) {
-		// LocalStack uses a self-signed certificate for HTTPS.
+		// LS certificate is not in system trust store
+		// But cert validity is out of scope here: use InsecureSkipVerify
 		client := &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -2,8 +2,10 @@ package integration_test
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -191,9 +193,35 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 		assert.Equal(t, "4566", mainBindings[0].HostPort)
 	})
 
+	t.Run("https port", func(t *testing.T) {
+		httpsBindings := inspect.HostConfig.PortBindings[nat.Port("443/tcp")]
+		require.NotEmpty(t, httpsBindings, "port 443/tcp should be bound")
+		assert.Equal(t, "443", httpsBindings[0].HostPort)
+	})
+
 	t.Run("volume mount", func(t *testing.T) {
 		assert.True(t, hasBindTarget(inspect.HostConfig.Binds, "/var/lib/localstack"),
 			"expected volume bind mount to /var/lib/localstack, got: %v", inspect.HostConfig.Binds)
+	})
+
+	t.Run("http health endpoint", func(t *testing.T) {
+		resp, err := http.Get("http://localhost.localstack.cloud:4566/_localstack/health")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("https health endpoint", func(t *testing.T) {
+		// LocalStack uses a self-signed certificate for HTTPS.
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+		resp, err := client.Get("https://localhost.localstack.cloud/_localstack/health")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 }
 


### PR DESCRIPTION
## Motivation

Port 443 was exposed by the LocalStack container but never mapped to the host, making HTTPS endpoints unreachable (e.g. \`https://localhost.localstack.cloud/_localstack/health\` returned connection refused).

## Tests

New sub-tests in \`TestStartCommandSetsUpContainerCorrectly\` verify that both \`http://localhost.localstack.cloud:4566/_localstack/health\` and \`https://localhost.localstack.cloud/_localstack/health\` return 200 after \`lstk start\`. The HTTPS test was failing before this fix.


Closes DRG-661