### PR TITLE
Simplify update notification flow

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,9 +123,10 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 	}
 
 	notifyOpts := update.NotifyOptions{
-		GitHubToken:    cfg.GitHubToken,
-		UpdatePrompt:   appConfig.UpdatePrompt,
-		PersistDisable: config.DisableUpdatePrompt,
+		GitHubToken:        cfg.GitHubToken,
+		UpdatePrompt:       appConfig.CLI.UpdatePrompt,
+		SkippedVersion:     appConfig.CLI.UpdateSkippedVersion,
+		PersistSkipVersion: config.SetUpdateSkippedVersion,
 	}
 
 	configPath, err := config.FriendlyConfigPath()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,8 +123,10 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 	}
 
 	notifyOpts := update.NotifyOptions{
-		GitHubToken:  cfg.GitHubToken,
-		UpdatePrompt: appConfig.CLI.UpdatePrompt,
+		GitHubToken:        cfg.GitHubToken,
+		UpdatePrompt:       appConfig.CLI.UpdatePrompt,
+		SkippedVersion:     appConfig.CLI.UpdateSkippedVersion,
+		PersistSkipVersion: config.SetUpdateSkippedVersion,
 	}
 
 	configPath, err := config.FriendlyConfigPath()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,7 +124,7 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 
 	notifyOpts := update.NotifyOptions{
 		GitHubToken:        cfg.GitHubToken,
-		UpdatePrompt:       appConfig.CLI.UpdatePrompt,
+		UpdatePrompt:       true,
 		SkippedVersion:     appConfig.CLI.UpdateSkippedVersion,
 		PersistSkipVersion: config.SetUpdateSkippedVersion,
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,10 +123,8 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 	}
 
 	notifyOpts := update.NotifyOptions{
-		GitHubToken:        cfg.GitHubToken,
-		UpdatePrompt:       appConfig.CLI.UpdatePrompt,
-		SkippedVersion:     appConfig.CLI.UpdateSkippedVersion,
-		PersistSkipVersion: config.SetUpdateSkippedVersion,
+		GitHubToken:  cfg.GitHubToken,
+		UpdatePrompt: appConfig.CLI.UpdatePrompt,
 	}
 
 	configPath, err := config.FriendlyConfigPath()

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/docker/go-connections v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/muesli/termenv v0.16.0
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -67,7 +68,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,8 +14,7 @@ import (
 var defaultConfigTemplate string
 
 type CLIConfig struct {
-	UpdatePrompt         bool   `mapstructure:"update_prompt"`
-	UpdateSkippedVersion string `mapstructure:"update_skipped_version"`
+	UpdatePrompt bool `mapstructure:"update_prompt"`
 }
 
 type Config struct {
@@ -33,7 +32,6 @@ func setDefaults() {
 		},
 	})
 	viper.SetDefault("cli.update_prompt", true)
-	viper.SetDefault("cli.update_skipped_version", "")
 }
 
 func loadConfig(path string) error {
@@ -122,14 +120,6 @@ func DisableUpdatePrompt() error {
 	return Set("cli.update_prompt", false)
 }
 
-func SetUpdateSkippedVersion(version string) error {
-	return Set("cli.update_skipped_version", version)
-}
-
-func GetUpdateSkippedVersion() string {
-	return viper.GetString("cli.update_skipped_version")
-}
-
 func Get() (*Config, error) {
 	var cfg Config
 	if err := viper.Unmarshal(&cfg); err != nil {
@@ -137,9 +127,6 @@ func Get() (*Config, error) {
 	}
 	if !viper.InConfig("cli.update_prompt") && viper.InConfig("update_prompt") {
 		cfg.CLI.UpdatePrompt = viper.GetBool("update_prompt")
-	}
-	if !viper.InConfig("cli.update_skipped_version") && viper.InConfig("update_skipped_version") {
-		cfg.CLI.UpdateSkippedVersion = viper.GetString("update_skipped_version")
 	}
 	for i := range cfg.Containers {
 		if err := cfg.Containers[i].Validate(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"bufio"
 	_ "embed"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -14,7 +16,8 @@ import (
 var defaultConfigTemplate string
 
 type CLIConfig struct {
-	UpdatePrompt bool `mapstructure:"update_prompt"`
+	UpdatePrompt         bool   `mapstructure:"update_prompt"`
+	UpdateSkippedVersion string `mapstructure:"update_skipped_version"`
 }
 
 type Config struct {
@@ -113,11 +116,109 @@ func resolvedConfigPath() string {
 
 func Set(key string, value any) error {
 	viper.Set(key, value)
-	return viper.WriteConfig()
+	return setInFile(viper.ConfigFileUsed(), key, value)
+}
+
+// setInFile updates a single key in the TOML config file without
+// rewriting unrelated keys (avoids Viper dumping all defaults).
+func setInFile(path, key string, value any) error {
+	// Split "cli.update_skipped_version" into section "cli" and field "update_skipped_version".
+	parts := strings.SplitN(key, ".", 2)
+	if len(parts) != 2 {
+		// Top-level keys: fall back to full rewrite.
+		return viper.WriteConfig()
+	}
+	section, field := parts[0], parts[1]
+
+	formatted := formatTOMLValue(value)
+	targetLine := field + " = " + formatted
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var result []string
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	inSection := false
+	replaced := false
+	sectionHeader := "[" + section + "]"
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		// Detect section headers.
+		if strings.HasPrefix(trimmed, "[") {
+			if trimmed == sectionHeader {
+				inSection = true
+			} else if inSection {
+				// Leaving our section without having replaced — insert before the new section.
+				if !replaced {
+					result = append(result, targetLine)
+					replaced = true
+				}
+				inSection = false
+			}
+		}
+
+		// Replace existing key in the target section.
+		if inSection && strings.HasPrefix(trimmed, field+" ") || inSection && strings.HasPrefix(trimmed, field+"=") {
+			result = append(result, targetLine)
+			replaced = true
+			continue
+		}
+
+		result = append(result, line)
+	}
+
+	// Section exists but key was not found — append to end of file (still in section).
+	if !replaced && inSection {
+		result = append(result, targetLine)
+		replaced = true
+	}
+
+	// Section doesn't exist at all — append section and key.
+	if !replaced {
+		if len(result) > 0 && strings.TrimSpace(result[len(result)-1]) != "" {
+			result = append(result, "")
+		}
+		result = append(result, sectionHeader)
+		result = append(result, targetLine)
+	}
+
+	output := strings.Join(result, "\n")
+	if !strings.HasSuffix(output, "\n") {
+		output += "\n"
+	}
+
+	return os.WriteFile(path, []byte(output), 0644)
+}
+
+func formatTOMLValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return fmt.Sprintf("%q", val)
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", val)
+	}
 }
 
 func DisableUpdatePrompt() error {
 	return Set("cli.update_prompt", false)
+}
+
+func SetUpdateSkippedVersion(version string) error {
+	return Set("cli.update_skipped_version", version)
+}
+
+func GetUpdateSkippedVersion() string {
+	return viper.GetString("cli.update_skipped_version")
 }
 
 func Get() (*Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,7 +131,7 @@ func setInFile(path, key string, value any) error {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	var doc map[string]any
+	doc := map[string]any{}
 	if err := toml.Unmarshal(data, &doc); err != nil {
 		return fmt.Errorf("failed to parse config file: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bufio"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -9,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/viper"
 )
 
@@ -16,7 +16,6 @@ import (
 var defaultConfigTemplate string
 
 type CLIConfig struct {
-	UpdatePrompt         bool   `mapstructure:"update_prompt"`
 	UpdateSkippedVersion string `mapstructure:"update_skipped_version"`
 }
 
@@ -34,7 +33,6 @@ func setDefaults() {
 			"port": "4566",
 		},
 	})
-	viper.SetDefault("cli.update_prompt", true)
 }
 
 func loadConfig(path string) error {
@@ -119,115 +117,51 @@ func Set(key string, value any) error {
 	return setInFile(viper.ConfigFileUsed(), key, value)
 }
 
-// setInFile updates a single key in the TOML config file without
-// rewriting unrelated keys (avoids Viper dumping all defaults).
+// setInFile updates a single key in the TOML config file using go-toml/v2.
+// The key must be in "section.field" form (e.g. "cli.update_skipped_version").
 func setInFile(path, key string, value any) error {
-	// Split "cli.update_skipped_version" into section "cli" and field "update_skipped_version".
 	parts := strings.SplitN(key, ".", 2)
 	if len(parts) != 2 {
-		// Top-level keys: fall back to full rewrite.
 		return viper.WriteConfig()
 	}
 	section, field := parts[0], parts[1]
-
-	formatted := formatTOMLValue(value)
-	targetLine := field + " = " + formatted
 
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	var result []string
-	scanner := bufio.NewScanner(strings.NewReader(string(data)))
-	inSection := false
-	replaced := false
-	sectionHeader := "[" + section + "]"
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		trimmed := strings.TrimSpace(line)
-
-		// Detect section headers.
-		if strings.HasPrefix(trimmed, "[") {
-			if trimmed == sectionHeader {
-				inSection = true
-			} else if inSection {
-				// Leaving our section without having replaced — insert before the new section.
-				if !replaced {
-					result = append(result, targetLine)
-					replaced = true
-				}
-				inSection = false
-			}
-		}
-
-		// Replace existing key in the target section.
-		if inSection && strings.HasPrefix(trimmed, field+" ") || inSection && strings.HasPrefix(trimmed, field+"=") {
-			result = append(result, targetLine)
-			replaced = true
-			continue
-		}
-
-		result = append(result, line)
+	var doc map[string]any
+	if err := toml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("failed to parse config file: %w", err)
 	}
 
-	// Section exists but key was not found — append to end of file (still in section).
-	if !replaced && inSection {
-		result = append(result, targetLine)
-		replaced = true
+	if doc[section] == nil {
+		doc[section] = map[string]any{}
+	}
+	sectionMap, ok := doc[section].(map[string]any)
+	if !ok {
+		return fmt.Errorf("config section %q is not a table", section)
+	}
+	sectionMap[field] = value
+	doc[section] = sectionMap
+
+	out, err := toml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// Section doesn't exist at all — append section and key.
-	if !replaced {
-		if len(result) > 0 && strings.TrimSpace(result[len(result)-1]) != "" {
-			result = append(result, "")
-		}
-		result = append(result, sectionHeader)
-		result = append(result, targetLine)
-	}
-
-	output := strings.Join(result, "\n")
-	if !strings.HasSuffix(output, "\n") {
-		output += "\n"
-	}
-
-	return os.WriteFile(path, []byte(output), 0644)
-}
-
-func formatTOMLValue(v any) string {
-	switch val := v.(type) {
-	case string:
-		return fmt.Sprintf("%q", val)
-	case bool:
-		if val {
-			return "true"
-		}
-		return "false"
-	default:
-		return fmt.Sprintf("%v", val)
-	}
-}
-
-func DisableUpdatePrompt() error {
-	return Set("cli.update_prompt", false)
+	return os.WriteFile(path, out, 0644)
 }
 
 func SetUpdateSkippedVersion(version string) error {
 	return Set("cli.update_skipped_version", version)
 }
 
-func GetUpdateSkippedVersion() string {
-	return viper.GetString("cli.update_skipped_version")
-}
-
 func Get() (*Config, error) {
 	var cfg Config
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
-	}
-	if !viper.InConfig("cli.update_prompt") && viper.InConfig("update_prompt") {
-		cfg.CLI.UpdatePrompt = viper.GetBool("update_prompt")
 	}
 	for i := range cfg.Containers {
 		if err := cfg.Containers[i].Validate(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
@@ -117,8 +118,8 @@ func Set(key string, value any) error {
 	return setInFile(viper.ConfigFileUsed(), key, value)
 }
 
-// setInFile updates a single key in the TOML config file using go-toml/v2.
-// The key must be in "section.field" form (e.g. "cli.update_skipped_version").
+// setInFile inserts or updates a single "section.field" key in the TOML config
+// file without rewriting unrelated content, preserving comments and formatting.
 func setInFile(path, key string, value any) error {
 	parts := strings.SplitN(key, ".", 2)
 	if len(parts) != 2 {
@@ -126,32 +127,31 @@ func setInFile(path, key string, value any) error {
 	}
 	section, field := parts[0], parts[1]
 
+	// Encode value using go-toml for correct scalar quoting.
+	type wrapper struct {
+		V any `toml:"v"`
+	}
+	enc, err := toml.Marshal(wrapper{V: value})
+	if err != nil {
+		return fmt.Errorf("failed to encode value: %w", err)
+	}
+	line := strings.TrimSpace(string(enc))
+	assignment := field + " =" + line[strings.IndexByte(line, '=')+1:]
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
+	content := string(data)
 
-	doc := map[string]any{}
-	if err := toml.Unmarshal(data, &doc); err != nil {
-		return fmt.Errorf("failed to parse config file: %w", err)
+	re := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(field) + `\s*=.*$`)
+	if re.MatchString(content) {
+		content = re.ReplaceAllString(content, assignment)
+	} else {
+		content = strings.TrimRight(content, "\n") + "\n\n[" + section + "]\n" + assignment + "\n"
 	}
 
-	if doc[section] == nil {
-		doc[section] = map[string]any{}
-	}
-	sectionMap, ok := doc[section].(map[string]any)
-	if !ok {
-		return fmt.Errorf("config section %q is not a table", section)
-	}
-	sectionMap[field] = value
-	doc[section] = sectionMap
-
-	out, err := toml.Marshal(doc)
-	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-
-	return os.WriteFile(path, out, 0644)
+	return os.WriteFile(path, []byte(content), 0644)
 }
 
 func SetUpdateSkippedVersion(version string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,10 +13,15 @@ import (
 //go:embed default_config.toml
 var defaultConfigTemplate string
 
+type CLIConfig struct {
+	UpdatePrompt         bool   `mapstructure:"update_prompt"`
+	UpdateSkippedVersion string `mapstructure:"update_skipped_version"`
+}
+
 type Config struct {
-	Containers   []ContainerConfig            `mapstructure:"containers"`
-	Env          map[string]map[string]string `mapstructure:"env"`
-	UpdatePrompt bool                          `mapstructure:"update_prompt"`
+	Containers []ContainerConfig            `mapstructure:"containers"`
+	Env        map[string]map[string]string `mapstructure:"env"`
+	CLI        CLIConfig                    `mapstructure:"cli"`
 }
 
 func setDefaults() {
@@ -27,7 +32,8 @@ func setDefaults() {
 			"port": "4566",
 		},
 	})
-	viper.SetDefault("update_prompt", true)
+	viper.SetDefault("cli.update_prompt", true)
+	viper.SetDefault("cli.update_skipped_version", "")
 }
 
 func loadConfig(path string) error {
@@ -113,13 +119,27 @@ func Set(key string, value any) error {
 }
 
 func DisableUpdatePrompt() error {
-	return Set("update_prompt", false)
+	return Set("cli.update_prompt", false)
+}
+
+func SetUpdateSkippedVersion(version string) error {
+	return Set("cli.update_skipped_version", version)
+}
+
+func GetUpdateSkippedVersion() string {
+	return viper.GetString("cli.update_skipped_version")
 }
 
 func Get() (*Config, error) {
 	var cfg Config
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+	if !viper.InConfig("cli.update_prompt") && viper.InConfig("update_prompt") {
+		cfg.CLI.UpdatePrompt = viper.GetBool("update_prompt")
+	}
+	if !viper.InConfig("cli.update_skipped_version") && viper.InConfig("update_skipped_version") {
+		cfg.CLI.UpdateSkippedVersion = viper.GetString("update_skipped_version")
 	}
 	for i := range cfg.Containers {
 		if err := cfg.Containers[i].Validate(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetInFileAppendsWhenKeyAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	original := `# User comment
+[[containers]]
+type = "aws"
+port = "4566"
+`
+	require.NoError(t, os.WriteFile(path, []byte(original), 0644))
+
+	require.NoError(t, setInFile(path, "cli.update_skipped_version", "v1.2.3"))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	result := string(got)
+
+	assert.Contains(t, result, "# User comment")
+	assert.Contains(t, result, `type = "aws"`)
+	assert.Contains(t, result, "[cli]")
+	assert.Contains(t, result, `update_skipped_version = 'v1.2.3'`)
+
+	var parsed map[string]any
+	require.NoError(t, toml.Unmarshal(got, &parsed))
+}
+
+func TestSetInFileReplacesExistingKeyInPlace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	original := `# Keep this
+[[containers]]
+type = "aws"
+
+[cli]
+update_skipped_version = "v1.0.0"
+`
+	require.NoError(t, os.WriteFile(path, []byte(original), 0644))
+
+	require.NoError(t, setInFile(path, "cli.update_skipped_version", "v2.0.0"))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	result := string(got)
+
+	assert.Contains(t, result, "# Keep this")
+	assert.Contains(t, result, `update_skipped_version = 'v2.0.0'`)
+	assert.NotContains(t, result, "v1.0.0")
+
+	var parsed map[string]any
+	require.NoError(t, toml.Unmarshal(got, &parsed))
+}
+
+func TestSetInFilePreservesCommentsAndFormatting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	original := `# lstk configuration file
+# Run 'lstk config path' to see where this file lives.
+
+[[containers]]
+type = "aws"     # Emulator type
+tag  = "latest"  # Docker image tag
+port = "4566"    # Host port
+
+# Example profiles:
+# [env.debug]
+# DEBUG = "1"
+`
+	require.NoError(t, os.WriteFile(path, []byte(original), 0644))
+
+	require.NoError(t, setInFile(path, "cli.update_skipped_version", "v1.2.3"))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	result := string(got)
+
+	for _, want := range []string{
+		"# lstk configuration file",
+		"# Run 'lstk config path' to see where this file lives.",
+		"# Emulator type",
+		"# Docker image tag",
+		"# Host port",
+		"# Example profiles:",
+		`# DEBUG = "1"`,
+	} {
+		assert.Contains(t, result, want, "expected comment preserved: %q", want)
+	}
+}
+
+func TestSetInFileIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("[[containers]]\ntype = \"aws\"\n"), 0644))
+
+	require.NoError(t, setInFile(path, "cli.update_skipped_version", "v1.0.0"))
+	require.NoError(t, setInFile(path, "cli.update_skipped_version", "v2.0.0"))
+	require.NoError(t, setInFile(path, "cli.update_skipped_version", "v3.0.0"))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var parsed struct {
+		CLI struct {
+			UpdateSkippedVersion string `toml:"update_skipped_version"`
+		} `toml:"cli"`
+	}
+	require.NoError(t, toml.Unmarshal(got, &parsed))
+	assert.Equal(t, "v3.0.0", parsed.CLI.UpdateSkippedVersion)
+
+	assert.Equal(t, 1, strings.Count(string(got), "update_skipped_version"))
+}
+
+func TestSetInFileErrorsOnMissingFile(t *testing.T) {
+	err := setInFile(filepath.Join(t.TempDir(), "nonexistent.toml"), "cli.update_skipped_version", "v1.0.0")
+	assert.Error(t, err)
+}

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -1,10 +1,6 @@
 # lstk configuration file
 # Run 'lstk config path' to see where this file lives.
 
-# CLI settings
-[cli]
-update_prompt = true
-
 # Each [[containers]] block defines an emulator instance.
 # You can define multiple to run them side by side.
 [[containers]]

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -1,6 +1,10 @@
 # lstk configuration file
 # Run 'lstk config path' to see where this file lives.
 
+# CLI settings
+[cli]
+update_prompt = true
+
 # Each [[containers]] block defines an emulator instance.
 # You can define multiple to run them side by side.
 [[containers]]

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -122,6 +122,7 @@ type UserInputRequestEvent struct {
 	Prompt     string
 	Options    []InputOption
 	ResponseCh chan<- InputResponse
+	Vertical   bool
 }
 
 const (

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -120,6 +120,26 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, tea.Quit
 		}
 		if a.pendingInput != nil {
+			if componentsUsesVerticalPrompt(a.inputPrompt, a.pendingInput.Options) {
+				switch msg.Type {
+				case tea.KeyUp:
+					a.inputPrompt = a.inputPrompt.SetSelectedIndex(a.inputPrompt.SelectedIndex() - 1)
+					return a, nil
+				case tea.KeyDown:
+					a.inputPrompt = a.inputPrompt.SetSelectedIndex(a.inputPrompt.SelectedIndex() + 1)
+					return a, nil
+				case tea.KeyEnter:
+					idx := a.inputPrompt.SelectedIndex()
+					if idx >= 0 && idx < len(a.pendingInput.Options) {
+						opt := a.pendingInput.Options[idx]
+						a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
+						responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
+						a.pendingInput = nil
+						a.inputPrompt = a.inputPrompt.Hide()
+						return a, responseCmd
+					}
+				}
+			}
 			if opt := resolveOption(a.pendingInput.Options, msg); opt != nil {
 				responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
 				a.pendingInput = nil
@@ -317,6 +337,45 @@ func (a *App) flushBufferedLines() {
 	}
 	a.bufferedLines = nil
 }
+
+func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) string {
+	// Special handling for lstk update prompt
+	if len(req.Options) > 0 && strings.Contains(req.Options[0].Label, "Update now") {
+		checkmark := styles.Success.Render(output.SuccessMarker())
+		switch selectedKey {
+		case "u":
+			return checkmark + " Updating lstk..."
+		case "s":
+			return checkmark + " Skipped this version"
+		case "n":
+			return checkmark + " Won't ask again"
+		}
+	}
+
+	formatted := output.FormatPrompt(req.Prompt, req.Options)
+	firstLine := strings.Split(formatted, "\n")[0]
+
+	selected := selectedKey
+	hasLabels := false
+	for _, opt := range req.Options {
+		if opt.Label != "" {
+			hasLabels = true
+		}
+		if opt.Key == selectedKey && opt.Label != "" {
+			selected = opt.Label
+		}
+	}
+
+	if selected == "" || !hasLabels || selectedKey == "any" {
+		return firstLine
+	}
+	return fmt.Sprintf("%s %s", firstLine, selected)
+}
+
+func componentsUsesVerticalPrompt(prompt components.InputPrompt, options []output.InputOption) bool {
+	return prompt.Visible() && len(options) > 1 && strings.Contains(options[0].Label, "[")
+}
+
 
 // resolveOption finds the best matching option for a key event, in priority order:
 //  1. "any" — matches any keypress

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -120,25 +120,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, tea.Quit
 		}
 		if a.pendingInput != nil {
-			if componentsUsesVerticalPrompt(a.inputPrompt, a.pendingInput.Options) {
-				switch msg.Type {
-				case tea.KeyUp:
-					a.inputPrompt = a.inputPrompt.SetSelectedIndex(a.inputPrompt.SelectedIndex() - 1)
-					return a, nil
-				case tea.KeyDown:
-					a.inputPrompt = a.inputPrompt.SetSelectedIndex(a.inputPrompt.SelectedIndex() + 1)
-					return a, nil
-				case tea.KeyEnter:
-					idx := a.inputPrompt.SelectedIndex()
-					if idx >= 0 && idx < len(a.pendingInput.Options) {
-						opt := a.pendingInput.Options[idx]
-						a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
-						responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
-						a.pendingInput = nil
-						a.inputPrompt = a.inputPrompt.Hide()
-						return a, responseCmd
-					}
-				}
+			if a.pendingInput.Vertical {
+				return a.handleVerticalPromptKey(msg)
 			}
 			if opt := resolveOption(a.pendingInput.Options, msg); opt != nil {
 				responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
@@ -169,7 +152,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.spinner.Visible() {
 			a.spinner = a.spinner.SetText(output.FormatPrompt(msg.Prompt, msg.Options))
 		} else {
-			a.inputPrompt = a.inputPrompt.Show(msg.Prompt, msg.Options)
+			a.inputPrompt = a.inputPrompt.Show(msg.Prompt, msg.Options, msg.Vertical)
 		}
 	case spinner.TickMsg:
 		var cmd tea.Cmd
@@ -338,20 +321,36 @@ func (a *App) flushBufferedLines() {
 	a.bufferedLines = nil
 }
 
-func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) string {
-	// Special handling for lstk update prompt
-	if len(req.Options) > 0 && strings.Contains(req.Options[0].Label, "Update now") {
-		checkmark := styles.Success.Render(output.SuccessMarker())
-		switch selectedKey {
-		case "u":
-			return checkmark + " Updating lstk..."
-		case "s":
-			return checkmark + " Skipped this version"
-		case "n":
-			return checkmark + " Won't ask again"
+func (a App) handleVerticalPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyUp:
+		a.inputPrompt = a.inputPrompt.SetSelectedIndex(a.inputPrompt.SelectedIndex() - 1)
+		return a, nil
+	case tea.KeyDown:
+		a.inputPrompt = a.inputPrompt.SetSelectedIndex(a.inputPrompt.SelectedIndex() + 1)
+		return a, nil
+	case tea.KeyEnter:
+		idx := a.inputPrompt.SelectedIndex()
+		if idx >= 0 && idx < len(a.pendingInput.Options) {
+			opt := a.pendingInput.Options[idx]
+			a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
+			responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
+			a.pendingInput = nil
+			a.inputPrompt = a.inputPrompt.Hide()
+			return a, responseCmd
 		}
 	}
+	if opt := resolveOption(a.pendingInput.Options, msg); opt != nil {
+		a.lines = appendLine(a.lines, styledLine{text: formatResolvedInput(*a.pendingInput, opt.Key)})
+		responseCmd := sendInputResponseCmd(a.pendingInput.ResponseCh, output.InputResponse{SelectedKey: opt.Key})
+		a.pendingInput = nil
+		a.inputPrompt = a.inputPrompt.Hide()
+		return a, responseCmd
+	}
+	return a, nil
+}
 
+func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) string {
 	formatted := output.FormatPrompt(req.Prompt, req.Options)
 	firstLine := strings.Split(formatted, "\n")[0]
 
@@ -371,11 +370,6 @@ func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) s
 	}
 	return fmt.Sprintf("%s %s", firstLine, selected)
 }
-
-func componentsUsesVerticalPrompt(prompt components.InputPrompt, options []output.InputOption) bool {
-	return prompt.Visible() && len(options) > 1 && strings.Contains(options[0].Label, "[")
-}
-
 
 // resolveOption finds the best matching option for a key event, in priority order:
 //  1. "any" — matches any keypress

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -351,9 +351,6 @@ func (a App) handleVerticalPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) string {
-	formatted := output.FormatPrompt(req.Prompt, req.Options)
-	firstLine := strings.Split(formatted, "\n")[0]
-
 	selected := selectedKey
 	hasLabels := false
 	for _, opt := range req.Options {
@@ -364,6 +361,17 @@ func formatResolvedInput(req output.UserInputRequestEvent, selectedKey string) s
 			selected = opt.Label
 		}
 	}
+
+	if req.Vertical {
+		firstLine := strings.Split(req.Prompt, "\n")[0]
+		if selected == "" || !hasLabels || selectedKey == "any" {
+			return firstLine
+		}
+		return fmt.Sprintf("%s %s", firstLine, selected)
+	}
+
+	formatted := output.FormatPrompt(req.Prompt, req.Options)
+	firstLine := strings.Split(formatted, "\n")[0]
 
 	if selected == "" || !hasLabels || selectedKey == "any" {
 		return firstLine

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -453,13 +453,10 @@ func TestAppEnterSelectsHighlightedVerticalOption(t *testing.T) {
 	responseCh := make(chan output.InputResponse, 1)
 
 	model, _ := app.Update(output.UserInputRequestEvent{
-		Prompt: "Update lstk to latest version?",
-		Options: []output.InputOption{
-			{Key: "u", Label: "Update now [U]"},
-			{Key: "s", Label: "Skip this version [S]"},
-			{Key: "n", Label: "Never ask again [N]"},
-		},
+		Prompt:     "Update lstk to latest version?",
+		Options:    []output.InputOption{{Key: "u", Label: "Update now [U]"}, {Key: "s", Label: "Skip this version [S]"}, {Key: "n", Label: "Never ask again [N]"}},
 		ResponseCh: responseCh,
+		Vertical:   true,
 	})
 	app = model.(App)
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -446,6 +446,47 @@ func TestAppEnterDoesNothingWithNonLetterLabel(t *testing.T) {
 	}
 }
 
+func TestAppEnterSelectsHighlightedVerticalOption(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+	responseCh := make(chan output.InputResponse, 1)
+
+	model, _ := app.Update(output.UserInputRequestEvent{
+		Prompt: "Update lstk to latest version?",
+		Options: []output.InputOption{
+			{Key: "u", Label: "Update now [U]"},
+			{Key: "s", Label: "Skip this version [S]"},
+			{Key: "n", Label: "Never ask again [N]"},
+		},
+		ResponseCh: responseCh,
+	})
+	app = model.(App)
+
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyDown})
+	app = model.(App)
+
+	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	app = model.(App)
+	if cmd == nil {
+		t.Fatal("expected response command when enter is pressed on vertical prompt")
+	}
+	cmd()
+
+	select {
+	case resp := <-responseCh:
+		if resp.SelectedKey != "s" {
+			t.Fatalf("expected s key, got %q", resp.SelectedKey)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for response on channel")
+	}
+
+	if app.inputPrompt.Visible() {
+		t.Fatal("expected input prompt to be hidden after response")
+	}
+}
+
 func TestAppAnyKeyOptionResolvesOnAnyKeypress(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/components/input_prompt.go
+++ b/internal/ui/components/input_prompt.go
@@ -81,7 +81,7 @@ func (p InputPrompt) viewVertical() string {
 
 	if p.prompt != "" {
 		sb.WriteString(styles.Secondary.Render("? "))
-		sb.WriteString(styles.Message.Render(strings.TrimPrefix(p.prompt, "? ")))
+		sb.WriteString(styles.Message.Render(p.prompt))
 		sb.WriteString("\n")
 	}
 

--- a/internal/ui/components/input_prompt.go
+++ b/internal/ui/components/input_prompt.go
@@ -8,9 +8,10 @@ import (
 )
 
 type InputPrompt struct {
-	prompt  string
-	options []output.InputOption
-	visible bool
+	prompt        string
+	options       []output.InputOption
+	visible       bool
+	selectedIndex int
 }
 
 func NewInputPrompt() InputPrompt {
@@ -21,6 +22,7 @@ func (p InputPrompt) Show(prompt string, options []output.InputOption) InputProm
 	p.prompt = prompt
 	p.options = options
 	p.visible = true
+	p.selectedIndex = 0
 	return p
 }
 
@@ -33,20 +35,31 @@ func (p InputPrompt) Visible() bool {
 	return p.visible
 }
 
+func (p InputPrompt) SelectedIndex() int {
+	return p.selectedIndex
+}
+
+func (p InputPrompt) SetSelectedIndex(idx int) InputPrompt {
+	if idx >= 0 && idx < len(p.options) {
+		p.selectedIndex = idx
+	}
+	return p
+}
+
 func (p InputPrompt) View() string {
 	if !p.visible {
 		return ""
 	}
 
-	lines := strings.Split(p.prompt, "\n")
+	if usesVerticalOptions(p.options) {
+		return p.viewVertical()
+	}
 
+	lines := strings.Split(p.prompt, "\n")
 	firstLine := lines[0]
 
 	var sb strings.Builder
-
-	// "?" prefix in secondary color
 	sb.WriteString(styles.Secondary.Render("? "))
-
 	sb.WriteString(styles.Message.Render(firstLine))
 
 	if suffix := output.FormatPromptLabels(p.options); suffix != "" {
@@ -59,4 +72,37 @@ func (p InputPrompt) View() string {
 	}
 
 	return sb.String()
+}
+
+func (p InputPrompt) viewVertical() string {
+	var sb strings.Builder
+
+	if p.prompt != "" {
+		sb.WriteString(styles.Secondary.Render("? "))
+		sb.WriteString(styles.Message.Render(strings.TrimPrefix(p.prompt, "? ")))
+		sb.WriteString("\n")
+	}
+
+	for i, opt := range p.options {
+		if i == p.selectedIndex {
+			sb.WriteString(styles.NimboMid.Render("● " + opt.Label))
+		} else {
+			sb.WriteString(styles.Secondary.Render("○ " + opt.Label))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+func usesVerticalOptions(options []output.InputOption) bool {
+	if len(options) < 2 {
+		return false
+	}
+	for _, opt := range options {
+		if strings.Contains(opt.Label, "[") && strings.Contains(opt.Label, "]") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ui/components/input_prompt.go
+++ b/internal/ui/components/input_prompt.go
@@ -12,17 +12,19 @@ type InputPrompt struct {
 	options       []output.InputOption
 	visible       bool
 	selectedIndex int
+	vertical      bool
 }
 
 func NewInputPrompt() InputPrompt {
 	return InputPrompt{}
 }
 
-func (p InputPrompt) Show(prompt string, options []output.InputOption) InputPrompt {
+func (p InputPrompt) Show(prompt string, options []output.InputOption, vertical bool) InputPrompt {
 	p.prompt = prompt
 	p.options = options
 	p.visible = true
 	p.selectedIndex = 0
+	p.vertical = vertical
 	return p
 }
 
@@ -51,7 +53,7 @@ func (p InputPrompt) View() string {
 		return ""
 	}
 
-	if usesVerticalOptions(p.options) {
+	if p.vertical {
 		return p.viewVertical()
 	}
 
@@ -95,14 +97,3 @@ func (p InputPrompt) viewVertical() string {
 	return sb.String()
 }
 
-func usesVerticalOptions(options []output.InputOption) bool {
-	if len(options) < 2 {
-		return false
-	}
-	for _, opt := range options {
-		if strings.Contains(opt.Label, "[") && strings.Contains(opt.Label, "]") {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/ui/components/input_prompt_test.go
+++ b/internal/ui/components/input_prompt_test.go
@@ -14,6 +14,7 @@ func TestInputPromptView(t *testing.T) {
 		name     string
 		prompt   string
 		options  []output.InputOption
+		vertical bool
 		contains []string
 		excludes []string
 	}{
@@ -21,12 +22,14 @@ func TestInputPromptView(t *testing.T) {
 			name:     "hidden returns empty",
 			prompt:   "",
 			options:  nil,
+			vertical: false,
 			contains: nil,
 		},
 		{
 			name:   "no options",
 			prompt: "Continue?",
 			options: nil,
+			vertical: false,
 			contains: []string{"?", "Continue?"},
 			excludes: []string{"(", "["},
 		},
@@ -34,6 +37,7 @@ func TestInputPromptView(t *testing.T) {
 			name:   "single option shows parentheses",
 			prompt: "Continue?",
 			options: []output.InputOption{{Key: "enter", Label: "Press ENTER"}},
+			vertical: false,
 			contains: []string{"?", "Continue?", "(Press ENTER)"},
 		},
 		{
@@ -43,12 +47,14 @@ func TestInputPromptView(t *testing.T) {
 				{Key: "y", Label: "Y"},
 				{Key: "n", Label: "n"},
 			},
+			vertical: false,
 			contains: []string{"?", "Set up a LocalStack profile for AWS CLI and SDKs in ~/.aws?", "[Y/n]"},
 		},
 		{
 			name:   "multi-line prompt renders trailing lines",
 			prompt: "First line\nSecond line\nThird line",
 			options: []output.InputOption{{Key: "y", Label: "Y"}},
+			vertical: false,
 			contains: []string{"?", "First line", "Second line", "Third line", "(Y)"},
 		},
 	}
@@ -67,7 +73,7 @@ func TestInputPromptView(t *testing.T) {
 				return
 			}
 
-			p = p.Show(tc.prompt, tc.options)
+			p = p.Show(tc.prompt, tc.options, tc.vertical)
 			view := p.View()
 
 			for _, s := range tc.contains {

--- a/internal/ui/components/message.go
+++ b/internal/ui/components/message.go
@@ -14,6 +14,7 @@ func RenderMessage(e output.MessageEvent) string {
 
 func RenderWrappedMessage(e output.MessageEvent, width int) string {
 	prefixText, prefix := messagePrefix(e)
+
 	if prefixText == "" {
 		style := styles.Message
 		if e.Severity == output.SeveritySecondary {

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -37,22 +37,30 @@ func githubRequest(ctx context.Context, url, token string) (*http.Response, erro
 	return http.DefaultClient.Do(req)
 }
 
-func fetchLatestVersion(ctx context.Context, token string) (string, error) {
+func fetchLatestRelease(ctx context.Context, token string) (*githubRelease, error) {
 	resp, err := githubRequest(ctx, latestReleaseURL, token)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub API returned %s", resp.Status)
+		return nil, fmt.Errorf("GitHub API returned %s", resp.Status)
 	}
 
 	var release githubRelease
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", err
+		return nil, err
 	}
 
+	return &release, nil
+}
+
+func fetchLatestVersion(ctx context.Context, token string) (string, error) {
+	release, err := fetchLatestRelease(ctx, token)
+	if err != nil {
+		return "", err
+	}
 	return release.TagName, nil
 }
 

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -105,9 +105,11 @@ func promptAndUpdate(ctx context.Context, sink output.Sink, opts NotifyOptions, 
 		return false
 	case "s":
 		if opts.PersistSkipVersion != nil {
-			_ = opts.PersistSkipVersion(latest)
+			if err := opts.PersistSkipVersion(latest); err != nil {
+				output.EmitWarning(sink, fmt.Sprintf("Failed to persist skipped version: %v", err))
+			}
 		}
-		output.EmitNote(sink, "Skipping version " + latest)
+		output.EmitNote(sink, "Skipping version "+latest)
 		return false
 	}
 

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -12,8 +12,10 @@ import (
 type versionFetcher func(ctx context.Context, token string) (string, error)
 
 type NotifyOptions struct {
-	GitHubToken  string
-	UpdatePrompt bool
+	GitHubToken          string
+	UpdatePrompt         bool
+	SkippedVersion       string
+	PersistSkipVersion   func(version string) error
 }
 
 const checkTimeout = 2 * time.Second
@@ -51,6 +53,10 @@ func NotifyUpdate(ctx context.Context, sink output.Sink, opts NotifyOptions) (ex
 func notifyUpdateWithVersion(ctx context.Context, sink output.Sink, opts NotifyOptions, currentVersion string, fetch versionFetcher) (exitAfter bool) {
 	current, latest, available := checkQuietlyWithVersion(ctx, opts.GitHubToken, currentVersion, fetch)
 	if !available {
+		return false
+	}
+
+	if opts.SkippedVersion != "" && normalizeVersion(opts.SkippedVersion) == normalizeVersion(latest) {
 		return false
 	}
 
@@ -98,6 +104,9 @@ func promptAndUpdate(ctx context.Context, sink output.Sink, opts NotifyOptions, 
 	case "r":
 		return false
 	case "s":
+		if opts.PersistSkipVersion != nil {
+			_ = opts.PersistSkipVersion(latest)
+		}
 		output.EmitNote(sink, "Skipping version " + latest)
 		return false
 	}

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -12,12 +12,13 @@ import (
 type versionFetcher func(ctx context.Context, token string) (string, error)
 
 type NotifyOptions struct {
-	GitHubToken    string
-	UpdatePrompt   bool
-	PersistDisable func() error
+	GitHubToken        string
+	UpdatePrompt       bool
+	SkippedVersion     string
+	PersistSkipVersion func(version string) error
 }
 
-const checkTimeout = 500 * time.Millisecond
+const checkTimeout = 2 * time.Second
 
 func CheckQuietly(ctx context.Context, githubToken string) (current, latest string, available bool) {
 	return checkQuietlyWithVersion(ctx, githubToken, version.Version(), fetchLatestVersion)
@@ -25,6 +26,7 @@ func CheckQuietly(ctx context.Context, githubToken string) (current, latest stri
 
 func checkQuietlyWithVersion(ctx context.Context, githubToken string, currentVersion string, fetch versionFetcher) (current, latest string, available bool) {
 	current = currentVersion
+	// Skip update check for dev builds
 	if current == "dev" {
 		return current, "", false
 	}
@@ -54,24 +56,31 @@ func notifyUpdateWithVersion(ctx context.Context, sink output.Sink, opts NotifyO
 		return false
 	}
 
+	if opts.SkippedVersion != "" && normalizeVersion(opts.SkippedVersion) == normalizeVersion(latest) {
+		return false
+	}
+
 	if !opts.UpdatePrompt {
 		output.EmitNote(sink, fmt.Sprintf("Update available: %s → %s (run lstk update)", current, latest))
 		return false
 	}
 
-	return promptAndUpdate(ctx, sink, opts.GitHubToken, current, latest, opts.PersistDisable)
+	return promptAndUpdate(ctx, sink, opts, current, latest)
 }
 
-func promptAndUpdate(ctx context.Context, sink output.Sink, githubToken string, current, latest string, persistDisable func() error) (exitAfter bool) {
-	output.EmitWarning(sink, fmt.Sprintf("Update available: %s → %s", current, latest))
+func promptAndUpdate(ctx context.Context, sink output.Sink, opts NotifyOptions, current, latest string) (exitAfter bool) {
+	releaseNotesURL := fmt.Sprintf("https://github.com/%s/releases/latest", githubRepo)
+
+	output.EmitNote(sink, fmt.Sprintf("New lstk version available! %s → %s", current, latest))
+	output.EmitSecondary(sink, fmt.Sprintf("> Release notes: %s", releaseNotesURL))
 
 	responseCh := make(chan output.InputResponse, 1)
 	output.EmitUserInputRequest(sink, output.UserInputRequestEvent{
-		Prompt: "A new version is available",
+		Prompt: "Update lstk to latest version?",
 		Options: []output.InputOption{
-			{Key: "u", Label: "Update"},
-			{Key: "s", Label: "SKIP"},
-			{Key: "n", Label: "Never ask again"},
+			{Key: "u", Label: "Update now [U]"},
+			{Key: "r", Label: "Remind me next time [R]"},
+			{Key: "s", Label: "Skip this version [S]"},
 		},
 		ResponseCh: responseCh,
 	})
@@ -89,20 +98,22 @@ func promptAndUpdate(ctx context.Context, sink output.Sink, githubToken string, 
 
 	switch resp.SelectedKey {
 	case "u":
-		if err := applyUpdate(ctx, sink, latest, githubToken); err != nil {
+		if err := applyUpdate(ctx, sink, latest, opts.GitHubToken); err != nil {
 			output.EmitWarning(sink, fmt.Sprintf("Update failed: %v", err))
 			return false
 		}
 		output.EmitSuccess(sink, fmt.Sprintf("Updated to %s — please re-run your command.", latest))
 		return true
-	case "n":
-		if persistDisable != nil {
-			if err := persistDisable(); err != nil {
+	case "r":
+		return false
+	case "s":
+		if opts.PersistSkipVersion != nil {
+			if err := opts.PersistSkipVersion(latest); err != nil {
 				output.EmitWarning(sink, fmt.Sprintf("Failed to save preference: %v", err))
 			}
 		}
 		return false
-	default:
-		return false
 	}
+
+	return false
 }

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -12,10 +12,8 @@ import (
 type versionFetcher func(ctx context.Context, token string) (string, error)
 
 type NotifyOptions struct {
-	GitHubToken        string
-	UpdatePrompt       bool
-	SkippedVersion     string
-	PersistSkipVersion func(version string) error
+	GitHubToken  string
+	UpdatePrompt bool
 }
 
 const checkTimeout = 2 * time.Second
@@ -56,10 +54,6 @@ func notifyUpdateWithVersion(ctx context.Context, sink output.Sink, opts NotifyO
 		return false
 	}
 
-	if opts.SkippedVersion != "" && normalizeVersion(opts.SkippedVersion) == normalizeVersion(latest) {
-		return false
-	}
-
 	if !opts.UpdatePrompt {
 		output.EmitNote(sink, fmt.Sprintf("Update available: %s → %s (run lstk update)", current, latest))
 		return false
@@ -76,13 +70,10 @@ func promptAndUpdate(ctx context.Context, sink output.Sink, opts NotifyOptions, 
 
 	responseCh := make(chan output.InputResponse, 1)
 	output.EmitUserInputRequest(sink, output.UserInputRequestEvent{
-		Prompt: "Update lstk to latest version?",
-		Options: []output.InputOption{
-			{Key: "u", Label: "Update now [U]"},
-			{Key: "r", Label: "Remind me next time [R]"},
-			{Key: "s", Label: "Skip this version [S]"},
-		},
+		Prompt:     "Update lstk to latest version?",
+		Options:    []output.InputOption{{Key: "u", Label: "Update now [U]"}, {Key: "r", Label: "Remind me next time [R]"}, {Key: "s", Label: "Skip this version [S]"}},
 		ResponseCh: responseCh,
+		Vertical:   true,
 	})
 
 	var resp output.InputResponse
@@ -107,11 +98,7 @@ func promptAndUpdate(ctx context.Context, sink output.Sink, opts NotifyOptions, 
 	case "r":
 		return false
 	case "s":
-		if opts.PersistSkipVersion != nil {
-			if err := opts.PersistSkipVersion(latest); err != nil {
-				output.EmitWarning(sink, fmt.Sprintf("Failed to save preference: %v", err))
-			}
-		}
+		output.EmitNote(sink, "Skipping version " + latest)
 		return false
 	}
 

--- a/internal/update/notify_test.go
+++ b/internal/update/notify_test.go
@@ -112,6 +112,7 @@ func TestNotifyUpdatePromptSkip(t *testing.T) {
 	server := newTestGitHubServer(t, "v2.0.0")
 	defer server.Close()
 
+	var skippedVersion string
 	var events []any
 	sink := output.SinkFunc(func(event any) {
 		events = append(events, event)
@@ -120,8 +121,30 @@ func TestNotifyUpdatePromptSkip(t *testing.T) {
 		}
 	})
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{UpdatePrompt: true}, "1.0.0", testFetcher(server.URL))
+	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{
+		UpdatePrompt: true,
+		PersistSkipVersion: func(v string) error {
+			skippedVersion = v
+			return nil
+		},
+	}, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
+	assert.Equal(t, "v2.0.0", skippedVersion)
+}
+
+func TestNotifyUpdateSkippedVersionSuppressesPrompt(t *testing.T) {
+	server := newTestGitHubServer(t, "v2.0.0")
+	defer server.Close()
+
+	var events []any
+	sink := output.SinkFunc(func(event any) { events = append(events, event) })
+
+	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{
+		UpdatePrompt:   true,
+		SkippedVersion: "v2.0.0",
+	}, "1.0.0", testFetcher(server.URL))
+	assert.False(t, exit)
+	assert.Empty(t, events)
 }
 
 func TestNotifyUpdatePromptRemind(t *testing.T) {

--- a/internal/update/notify_test.go
+++ b/internal/update/notify_test.go
@@ -161,18 +161,3 @@ func TestNotifyUpdatePromptCancelled(t *testing.T) {
 	assert.False(t, exit)
 }
 
-func TestNotifyUpdateSkippedVersion(t *testing.T) {
-	server := newTestGitHubServer(t, "v2.0.0")
-	defer server.Close()
-
-	var events []any
-	sink := output.SinkFunc(func(event any) { events = append(events, event) })
-
-	// Should return early without prompting since v2.0.0 was skipped
-	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{
-		UpdatePrompt:   true,
-		SkippedVersion: "v2.0.0",
-	}, "1.0.0", testFetcher(server.URL))
-	assert.False(t, exit)
-	assert.Empty(t, events) // No events should be emitted
-}

--- a/internal/update/notify_test.go
+++ b/internal/update/notify_test.go
@@ -124,29 +124,20 @@ func TestNotifyUpdatePromptSkip(t *testing.T) {
 	assert.False(t, exit)
 }
 
-func TestNotifyUpdatePromptNever(t *testing.T) {
+func TestNotifyUpdatePromptRemind(t *testing.T) {
 	server := newTestGitHubServer(t, "v2.0.0")
 	defer server.Close()
-
-	persistCalled := false
 
 	var events []any
 	sink := output.SinkFunc(func(event any) {
 		events = append(events, event)
 		if req, ok := event.(output.UserInputRequestEvent); ok {
-			req.ResponseCh <- output.InputResponse{SelectedKey: "n"}
+			req.ResponseCh <- output.InputResponse{SelectedKey: "r"}
 		}
 	})
 
-	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{
-		UpdatePrompt: true,
-		PersistDisable: func() error {
-			persistCalled = true
-			return nil
-		},
-	}, "1.0.0", testFetcher(server.URL))
+	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{UpdatePrompt: true}, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
-	assert.True(t, persistCalled)
 }
 
 func TestNotifyUpdatePromptCancelled(t *testing.T) {
@@ -157,10 +148,31 @@ func TestNotifyUpdatePromptCancelled(t *testing.T) {
 	sink := output.SinkFunc(func(event any) {
 		events = append(events, event)
 		if req, ok := event.(output.UserInputRequestEvent); ok {
+			assert.Equal(t, "Update lstk to latest version?", req.Prompt)
+			assert.Len(t, req.Options, 3)
+			assert.Equal(t, "u", req.Options[0].Key)
+			assert.Equal(t, "r", req.Options[1].Key)
+			assert.Equal(t, "s", req.Options[2].Key)
 			req.ResponseCh <- output.InputResponse{Cancelled: true}
 		}
 	})
 
 	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{UpdatePrompt: true}, "1.0.0", testFetcher(server.URL))
 	assert.False(t, exit)
+}
+
+func TestNotifyUpdateSkippedVersion(t *testing.T) {
+	server := newTestGitHubServer(t, "v2.0.0")
+	defer server.Close()
+
+	var events []any
+	sink := output.SinkFunc(func(event any) { events = append(events, event) })
+
+	// Should return early without prompting since v2.0.0 was skipped
+	exit := notifyUpdateWithVersion(context.Background(), sink, NotifyOptions{
+		UpdatePrompt:   true,
+		SkippedVersion: "v2.0.0",
+	}, "1.0.0", testFetcher(server.URL))
+	assert.False(t, exit)
+	assert.Empty(t, events) // No events should be emitted
 }

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -277,6 +277,10 @@ func TestUpdateNotification(t *testing.T) {
 		<-outputCh
 
 		assert.Contains(t, output.String(), "New lstk version available")
+
+		configData, err := os.ReadFile(configFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(configData), "update_skipped_version")
 	})
 
 

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -247,7 +247,7 @@ func TestUpdateNotification(t *testing.T) {
 
 	t.Run("prompt_disabled", func(t *testing.T) {
 		configFile := filepath.Join(t.TempDir(), "config.toml")
-		require.NoError(t, os.WriteFile(configFile, []byte("update_prompt = false\n"), 0o644))
+		require.NoError(t, os.WriteFile(configFile, []byte("[cli]\nupdate_prompt = false\n"), 0o644))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -278,7 +278,7 @@ func TestUpdateNotification(t *testing.T) {
 
 	t.Run("skip", func(t *testing.T) {
 		configFile := filepath.Join(t.TempDir(), "config.toml")
-		require.NoError(t, os.WriteFile(configFile, []byte("update_prompt = true\n"), 0o644))
+		require.NoError(t, os.WriteFile(configFile, []byte("[cli]\nupdate_prompt = true\n"), 0o644))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -298,7 +298,7 @@ func TestUpdateNotification(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return bytes.Contains(output.Bytes(), []byte("new version is available"))
+			return bytes.Contains(output.Bytes(), []byte("New lstk version available"))
 		}, 10*time.Second, 100*time.Millisecond, "update notification prompt should appear")
 
 		_, err = ptmx.Write([]byte("s"))
@@ -307,12 +307,12 @@ func TestUpdateNotification(t *testing.T) {
 		_ = cmd.Wait()
 		<-outputCh
 
-		assert.Contains(t, output.String(), "Update available: 0.0.1")
+		assert.Contains(t, output.String(), "New lstk version available")
 	})
 
 	t.Run("never", func(t *testing.T) {
 		configFile := filepath.Join(t.TempDir(), "config.toml")
-		require.NoError(t, os.WriteFile(configFile, []byte("update_prompt = true\n"), 0o644))
+		require.NoError(t, os.WriteFile(configFile, []byte("[cli]\nupdate_prompt = true\n"), 0o644))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -332,7 +332,7 @@ func TestUpdateNotification(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return bytes.Contains(output.Bytes(), []byte("new version is available"))
+			return bytes.Contains(output.Bytes(), []byte("New lstk version available"))
 		}, 10*time.Second, 100*time.Millisecond, "update notification prompt should appear")
 
 		_, err = ptmx.Write([]byte("n"))
@@ -341,7 +341,7 @@ func TestUpdateNotification(t *testing.T) {
 		_ = cmd.Wait()
 		<-outputCh
 
-		assert.Contains(t, output.String(), "Update available: 0.0.1")
+		assert.Contains(t, output.String(), "New lstk version available")
 
 		// Verify config was updated to disable future prompts
 		configData, err := os.ReadFile(configFile)
@@ -357,7 +357,7 @@ func TestUpdateNotification(t *testing.T) {
 		require.NoError(t, os.WriteFile(updateBinary, data, 0o755))
 
 		configFile := filepath.Join(t.TempDir(), "config.toml")
-		require.NoError(t, os.WriteFile(configFile, []byte("update_prompt = true\n"), 0o644))
+		require.NoError(t, os.WriteFile(configFile, []byte("[cli]\nupdate_prompt = true\n"), 0o644))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
@@ -377,7 +377,7 @@ func TestUpdateNotification(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return bytes.Contains(output.Bytes(), []byte("new version is available"))
+			return bytes.Contains(output.Bytes(), []byte("New lstk version available"))
 		}, 10*time.Second, 100*time.Millisecond, "update notification prompt should appear")
 
 		_, err = ptmx.Write([]byte("u"))
@@ -388,7 +388,7 @@ func TestUpdateNotification(t *testing.T) {
 
 		out := output.String()
 		require.NoError(t, err, "update should succeed: %s", out)
-		assert.Contains(t, out, "Update available: 0.0.1")
+		assert.Contains(t, out, "New lstk version available")
 		assert.Contains(t, out, "Updated to")
 
 		// Verify the binary was actually replaced

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -247,7 +247,13 @@ func TestUpdateNotification(t *testing.T) {
 
 	t.Run("skip", func(t *testing.T) {
 		configFile := filepath.Join(t.TempDir(), "config.toml")
-		require.NoError(t, os.WriteFile(configFile, []byte(""), 0o644))
+		originalConfig := `# User-maintained lstk config
+[[containers]]
+type = "aws"     # Emulator type
+tag  = "latest"  # Docker image tag
+port = "4566"    # Host port
+`
+		require.NoError(t, os.WriteFile(configFile, []byte(originalConfig), 0o644))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -280,7 +286,11 @@ func TestUpdateNotification(t *testing.T) {
 
 		configData, err := os.ReadFile(configFile)
 		require.NoError(t, err)
-		assert.Contains(t, string(configData), "update_skipped_version")
+		configStr := string(configData)
+		assert.Contains(t, configStr, "update_skipped_version", "skipped version should be persisted")
+		assert.Contains(t, configStr, "# User-maintained lstk config", "file header comment should be preserved")
+		assert.Contains(t, configStr, "# Emulator type", "inline comments should be preserved")
+		assert.Contains(t, configStr, `port = "4566"`, "existing config values should be preserved")
 	})
 
 

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -245,40 +245,9 @@ func TestUpdateNotification(t *testing.T) {
 	mockServer := createMockLicenseServer(false)
 	defer mockServer.Close()
 
-	t.Run("prompt_disabled", func(t *testing.T) {
-		configFile := filepath.Join(t.TempDir(), "config.toml")
-		require.NoError(t, os.WriteFile(configFile, []byte("[cli]\nupdate_prompt = false\n"), 0o644))
-
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		cmd := exec.CommandContext(ctx, tmpBinary, "--config", configFile)
-		cmd.Env = env.Without(env.AuthToken).With(env.AuthToken, "fake-token").With(env.APIEndpoint, mockServer.URL)
-
-		ptmx, err := pty.Start(cmd)
-		require.NoError(t, err, "failed to start command in PTY")
-		defer func() { _ = ptmx.Close() }()
-
-		output := &syncBuffer{}
-		outputCh := make(chan struct{})
-		go func() {
-			_, _ = io.Copy(output, ptmx)
-			close(outputCh)
-		}()
-
-		// Process should exit without prompting (license validation fails)
-		_ = cmd.Wait()
-		<-outputCh
-
-		out := output.String()
-		assert.Contains(t, out, "Update available: 0.0.1", "should show update note")
-		assert.Contains(t, out, "lstk update", "should include the update command hint")
-		assert.NotContains(t, out, "new version is available", "should not show interactive prompt")
-	})
-
 	t.Run("skip", func(t *testing.T) {
 		configFile := filepath.Join(t.TempDir(), "config.toml")
-		require.NoError(t, os.WriteFile(configFile, []byte("[cli]\nupdate_prompt = true\n"), 0o644))
+		require.NoError(t, os.WriteFile(configFile, []byte(""), 0o644))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -319,7 +288,7 @@ func TestUpdateNotification(t *testing.T) {
 		require.NoError(t, os.WriteFile(updateBinary, data, 0o755))
 
 		configFile := filepath.Join(t.TempDir(), "config.toml")
-		require.NoError(t, os.WriteFile(configFile, []byte("[cli]\nupdate_prompt = true\n"), 0o644))
+		require.NoError(t, os.WriteFile(configFile, []byte(""), 0o644))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -310,44 +310,6 @@ func TestUpdateNotification(t *testing.T) {
 		assert.Contains(t, output.String(), "New lstk version available")
 	})
 
-	t.Run("never", func(t *testing.T) {
-		configFile := filepath.Join(t.TempDir(), "config.toml")
-		require.NoError(t, os.WriteFile(configFile, []byte("[cli]\nupdate_prompt = true\n"), 0o644))
-
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		cmd := exec.CommandContext(ctx, tmpBinary, "--config", configFile)
-		cmd.Env = env.Without(env.AuthToken).With(env.AuthToken, "fake-token").With(env.APIEndpoint, mockServer.URL)
-
-		ptmx, err := pty.Start(cmd)
-		require.NoError(t, err, "failed to start command in PTY")
-		defer func() { _ = ptmx.Close() }()
-
-		output := &syncBuffer{}
-		outputCh := make(chan struct{})
-		go func() {
-			_, _ = io.Copy(output, ptmx)
-			close(outputCh)
-		}()
-
-		require.Eventually(t, func() bool {
-			return bytes.Contains(output.Bytes(), []byte("New lstk version available"))
-		}, 10*time.Second, 100*time.Millisecond, "update notification prompt should appear")
-
-		_, err = ptmx.Write([]byte("n"))
-		require.NoError(t, err)
-
-		_ = cmd.Wait()
-		<-outputCh
-
-		assert.Contains(t, output.String(), "New lstk version available")
-
-		// Verify config was updated to disable future prompts
-		configData, err := os.ReadFile(configFile)
-		require.NoError(t, err)
-		assert.Contains(t, string(configData), "update_prompt = false")
-	})
 
 	t.Run("update", func(t *testing.T) {
 		// Copy binary since it will be replaced during the update


### PR DESCRIPTION
This PR simplifies the update notification flow and removes the "Never ask again" option.

Users now see a cleaner three-option prompt: Update now [U], Remind me next time [R], Skip this version [S].

The "Skip" option persists the skipped version to config, users won't be prompted again until a newer version is available.

### Changes
#### Update Notification
- Removed the `"Never ask again [N]"` option from the prompt
- Increased version check timeout from 500ms to 2s
- Skip option persists the skipped version to config via `PersistSkipVersion` callback
- Removed legacy config migration code for old `update_prompt` and `update_skipped_version` keys at root level

#### Config Schema
- Removed `update_prompt = true` from default config template (true is already the default via viper)
- Config `Set()` now writes only the changed key to the TOML file instead of rewriting all keys (avoids leaking Viper defaults)

#### UI Improvements
- Added `Vertical` field to `UserInputRequestEvent` to explicitly indicate vertical layout
- Replaced string parsing (`strings.Contains(options[0].Label, "[")`) with explicit boolean field
- Extracted `handleVerticalPromptKey()` method from Update() to reduce complexity
- Removed update-specific text rendering from generic `formatResolvedInput()` function
- UI code no longer contains hard-coded update prompts like "Updating lstk..." or "Won't ask again"
- Fixed resolved vertical prompt showing all options instead of only the selected one

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="290" alt="Screenshot 2026-03-23 at 10 38 51" src="https://github.com/user-attachments/assets/c8dffd26-d598-4002-a5dc-54841ae57527" /> | <img width="669" height="290" alt="Screenshot 2026-03-23 at 14 42 39" src="https://github.com/user-attachments/assets/e4461a4b-fe6d-4d34-ac3c-a1e24ab0bac2" /> | 