### PR TITLE
Add hidden docs command for man page and markdown generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 bin/
 dist/
 *.test
+completions/
+manpages/
 
 .idea

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,8 @@ before:
     - sh -c "go run . completion bash > completions/lstk.bash"
     - sh -c "go run . completion zsh > completions/lstk.zsh"
     - sh -c "go run . completion fish > completions/lstk.fish"
+    - mkdir -p manpages
+    - sh -c "go run . docs --format man --dir ./manpages"
 
 builds:
   - id: lstk
@@ -41,6 +43,7 @@ archives:
           - zip
     files:
       - completions/*
+      - manpages/*
 
 checksum:
   name_template: checksums.txt

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	cobradoc "github.com/spf13/cobra/doc"
+)
+
+func newDocsCmd() *cobra.Command {
+	var dir string
+	var format string
+
+	cmd := &cobra.Command{
+		Use:    "docs",
+		Short:  "Generate command documentation",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return err
+			}
+
+			switch format {
+			case "man":
+				header := &cobradoc.GenManHeader{
+					Title:   "lstk",
+					Section: "1",
+					Source:  "lstk",
+				}
+				return cobradoc.GenManTree(cmd.Root(), header, dir)
+			case "markdown":
+				return cobradoc.GenMarkdownTree(cmd.Root(), dir)
+			default:
+				return fmt.Errorf("unsupported format: %s (use 'man' or 'markdown')", format)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&dir, "dir", "./manpages", "Output directory")
+	cmd.Flags().StringVar(&format, "format", "man", "Output format (man, markdown)")
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 		newLogsCmd(cfg, tel),
 		newConfigCmd(cfg, tel),
 		newUpdateCmd(cfg, tel),
+		newDocsCmd(),
 	)
 
 	return root

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.6.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -68,6 +69,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
@@ -123,6 +124,8 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=

--- a/test/integration/docs_test.go
+++ b/test/integration/docs_test.go
@@ -1,0 +1,49 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocsCommandGeneratesManPages(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "manpages")
+
+	_, stderr, err := runLstk(t, testContext(t), "", os.Environ(), "docs", "--format", "man", "--dir", dir)
+	require.NoError(t, err, stderr)
+	requireExitCode(t, 0, err)
+
+	assert.FileExists(t, filepath.Join(dir, "lstk.1"))
+	assert.FileExists(t, filepath.Join(dir, "lstk-start.1"))
+	assert.FileExists(t, filepath.Join(dir, "lstk-stop.1"))
+}
+
+func TestDocsCommandGeneratesMarkdown(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "markdown")
+
+	_, stderr, err := runLstk(t, testContext(t), "", os.Environ(), "docs", "--format", "markdown", "--dir", dir)
+	require.NoError(t, err, stderr)
+	requireExitCode(t, 0, err)
+
+	assert.FileExists(t, filepath.Join(dir, "lstk.md"))
+	assert.FileExists(t, filepath.Join(dir, "lstk_start.md"))
+	assert.FileExists(t, filepath.Join(dir, "lstk_stop.md"))
+}
+
+func TestDocsCommandRejectsInvalidFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	_, _, err := runLstk(t, testContext(t), "", os.Environ(), "docs", "--format", "invalid", "--dir", dir)
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+}
+
+func TestDocsCommandIsHidden(t *testing.T) {
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--help")
+	require.NoError(t, err, stderr)
+
+	assert.NotContains(t, stdout, "docs")
+}


### PR DESCRIPTION
## Motivation

lstk had no man pages or generated documentation. Users installing via Homebrew or release archives couldn't run `man lstk` to get help.

## Changes

- Add hidden `lstk docs` subcommand with `--format` (man/markdown) and `--dir` flags using `cobra/doc`
- Integrate man page generation into GoReleaser pipeline (before-hook runs `go run . docs`, archives include `manpages/*`)
- Add `completions/` and `manpages/` to `.gitignore`

The `docs` command is hidden (not shown in `--help`) following the same pattern as Helm's `helm docs` command. Cobra automatically excludes it from the generated documentation.

## Tests

4 new integration tests:
- Man page generation produces expected `.1` files
- Markdown generation produces expected `.md` files
- Invalid format is rejected with exit code 1
- Command is hidden from `--help` output

## Related

- [FLC-499](https://linear.app/localstack/issue/FLC-499/generate-lstk-man-page-with-cobra)