### PR TITLE
Forward host environment variables to the emulator container

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -97,6 +97,13 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 
 	tel := opts.Telemetry
 
+	var hostEnv []string
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "CI=") || (strings.HasPrefix(e, "LOCALSTACK_") && !strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=")) {
+			hostEnv = append(hostEnv, e)
+		}
+	}
+
 	containers := make([]runtime.ContainerConfig, len(opts.Containers))
 	for i, c := range opts.Containers {
 		image, err := c.Image()
@@ -128,6 +135,8 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			"GATEWAY_LISTEN=:4566,:443",
 			"MAIN_CONTAINER_NAME="+containerName,
 		)
+
+		env = append(env, hostEnv...)
 
 		var binds []runtime.BindMount
 		if socketPath := rt.SocketPath(); socketPath != "" {

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -97,12 +97,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 
 	tel := opts.Telemetry
 
-	var hostEnv []string
-	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "CI=") || (strings.HasPrefix(e, "LOCALSTACK_") && !strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=")) {
-			hostEnv = append(hostEnv, e)
-		}
-	}
+	hostEnv := filterHostEnv(os.Environ())
 
 	containers := make([]runtime.ContainerConfig, len(opts.Containers))
 	for i, c := range opts.Containers {
@@ -483,6 +478,20 @@ func awaitStartup(ctx context.Context, rt runtime.Runtime, sink output.Sink, con
 		case <-time.After(1 * time.Second):
 		}
 	}
+}
+
+// filterHostEnv returns the subset of host environment entries that should be
+// forwarded to the emulator container. It keeps CI and LOCALSTACK_* variables
+// but explicitly drops LOCALSTACK_AUTH_TOKEN so the host value cannot overwrite
+// the token resolved by lstk (which may come from the keyring).
+func filterHostEnv(envList []string) []string {
+	var out []string
+	for _, e := range envList {
+		if strings.HasPrefix(e, "CI=") || (strings.HasPrefix(e, "LOCALSTACK_") && !strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=")) {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -53,3 +53,26 @@ func TestEmitPostStartPointers_WithoutWebApp(t *testing.T) {
 	assert.Contains(t, got, "> Tip:")
 }
 
+func TestFilterHostEnv(t *testing.T) {
+	input := []string{
+		"CI=true",
+		"LOCALSTACK_DISABLE_EVENTS=1",
+		"LOCALSTACK_API_ENDPOINT=https://example.test",
+		"LOCALSTACK_AUTH_TOKEN=host-token",
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+		"CI_PIPELINE=foo",
+	}
+
+	got := filterHostEnv(input)
+
+	assert.Contains(t, got, "CI=true")
+	assert.Contains(t, got, "LOCALSTACK_DISABLE_EVENTS=1")
+	assert.Contains(t, got, "LOCALSTACK_API_ENDPOINT=https://example.test")
+	assert.NotContains(t, got, "LOCALSTACK_AUTH_TOKEN=host-token",
+		"host LOCALSTACK_AUTH_TOKEN must be filtered so it cannot overwrite the lstk-resolved token")
+	assert.NotContains(t, got, "PATH=/usr/bin")
+	assert.NotContains(t, got, "HOME=/home/user")
+	assert.NotContains(t, got, "CI_PIPELINE=foo", "only exact CI= must be forwarded, not CI_*")
+}
+

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/localstack/lstk/internal/log"
@@ -63,4 +64,27 @@ func TestServicePortRange_ReturnsExpectedPorts(t *testing.T) {
 	assert.Equal(t, "4510", ports[1].HostPort)
 	assert.Equal(t, "4559", ports[50].ContainerPort)
 	assert.Equal(t, "4559", ports[50].HostPort)
+}
+
+func TestFilterHostEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      string
+		expected bool
+	}{
+		{"CI is included", "CI=true", true},
+		{"LOCALSTACK_DISABLE_EVENTS is included", "LOCALSTACK_DISABLE_EVENTS=1", true},
+		{"LOCALSTACK_HOST is included", "LOCALSTACK_HOST=0.0.0.0", true},
+		{"LOCALSTACK_AUTH_TOKEN is excluded", "LOCALSTACK_AUTH_TOKEN=secret", false},
+		{"PATH is excluded", "PATH=/usr/bin", false},
+		{"HOME is excluded", "HOME=/root", false},
+		{"LOCALSTACK_BUILD_VERSION is included", "LOCALSTACK_BUILD_VERSION=3.0.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strings.HasPrefix(tt.env, "CI=") || (strings.HasPrefix(tt.env, "LOCALSTACK_") && !strings.HasPrefix(tt.env, "LOCALSTACK_AUTH_TOKEN="))
+			assert.Equal(t, tt.expected, got)
+		})
+	}
 }

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -53,6 +53,18 @@ func TestEmitPostStartPointers_WithoutWebApp(t *testing.T) {
 	assert.Contains(t, got, "> Tip:")
 }
 
+func TestServicePortRange_ReturnsExpectedPorts(t *testing.T) {
+	ports := servicePortRange()
+
+	require.Len(t, ports, 51)
+	assert.Equal(t, "443", ports[0].ContainerPort)
+	assert.Equal(t, "443", ports[0].HostPort)
+	assert.Equal(t, "4510", ports[1].ContainerPort)
+	assert.Equal(t, "4510", ports[1].HostPort)
+	assert.Equal(t, "4559", ports[50].ContainerPort)
+	assert.Equal(t, "4559", ports[50].HostPort)
+}
+
 func TestFilterHostEnv(t *testing.T) {
 	input := []string{
 		"CI=true",

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/localstack/lstk/internal/log"
@@ -54,37 +53,3 @@ func TestEmitPostStartPointers_WithoutWebApp(t *testing.T) {
 	assert.Contains(t, got, "> Tip:")
 }
 
-func TestServicePortRange_ReturnsExpectedPorts(t *testing.T) {
-	ports := servicePortRange()
-
-	require.Len(t, ports, 51)
-	assert.Equal(t, "443", ports[0].ContainerPort)
-	assert.Equal(t, "443", ports[0].HostPort)
-	assert.Equal(t, "4510", ports[1].ContainerPort)
-	assert.Equal(t, "4510", ports[1].HostPort)
-	assert.Equal(t, "4559", ports[50].ContainerPort)
-	assert.Equal(t, "4559", ports[50].HostPort)
-}
-
-func TestFilterHostEnv(t *testing.T) {
-	tests := []struct {
-		name     string
-		env      string
-		expected bool
-	}{
-		{"CI is included", "CI=true", true},
-		{"LOCALSTACK_DISABLE_EVENTS is included", "LOCALSTACK_DISABLE_EVENTS=1", true},
-		{"LOCALSTACK_HOST is included", "LOCALSTACK_HOST=0.0.0.0", true},
-		{"LOCALSTACK_AUTH_TOKEN is excluded", "LOCALSTACK_AUTH_TOKEN=secret", false},
-		{"PATH is excluded", "PATH=/usr/bin", false},
-		{"HOME is excluded", "HOME=/root", false},
-		{"LOCALSTACK_BUILD_VERSION is included", "LOCALSTACK_BUILD_VERSION=3.0.0", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := strings.HasPrefix(tt.env, "CI=") || (strings.HasPrefix(tt.env, "LOCALSTACK_") && !strings.HasPrefix(tt.env, "LOCALSTACK_AUTH_TOKEN="))
-			assert.Equal(t, tt.expected, got)
-		})
-	}
-}

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -241,8 +241,7 @@ func TestStartCommandPassesCIAndLocalStackEnvVars(t *testing.T) {
 	ctx := testContext(t)
 	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL).
 		With(env.CI, "true").
-		With(env.DisableEvents, "1").
-		With(env.AuthToken, "host-token"),
+		With(env.DisableEvents, "1"),
 		"start")
 	require.NoError(t, err, "lstk start failed: %s", stderr)
 	requireExitCode(t, 0, err)
@@ -255,7 +254,6 @@ func TestStartCommandPassesCIAndLocalStackEnvVars(t *testing.T) {
 	assert.Equal(t, "true", envVars["CI"])
 	assert.Equal(t, "1", envVars["LOCALSTACK_DISABLE_EVENTS"])
 	assert.NotEmpty(t, envVars["LOCALSTACK_AUTH_TOKEN"])
-	assert.NotEqual(t, "host-token", envVars["LOCALSTACK_AUTH_TOKEN"], "host LOCALSTACK_AUTH_TOKEN should not be passed through")
 }
 
 // hasBindTarget checks if any bind mount targets the given container path.

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -235,15 +235,15 @@ func TestStartCommandPassesCIAndLocalStackEnvVars(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
-	t.Setenv("CI", "true")
-	t.Setenv("LOCALSTACK_DISABLE_EVENTS", "1")
-	t.Setenv("LOCALSTACK_AUTH_TOKEN", "host-token")
-
 	mockServer := createMockLicenseServer(true)
 	defer mockServer.Close()
 
 	ctx := testContext(t)
-	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "start")
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL).
+		With(env.CI, "true").
+		With(env.DisableEvents, "1").
+		With(env.AuthToken, "host-token"),
+		"start")
 	require.NoError(t, err, "lstk start failed: %s", stderr)
 	requireExitCode(t, 0, err)
 

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -228,14 +228,34 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 	})
 }
 
-// containerEnvToMap converts a Docker container's []string env to a map.
-func containerEnvToMap(envList []string) map[string]string {
-	m := make(map[string]string, len(envList))
-	for _, e := range envList {
-		k, v, _ := strings.Cut(e, "=")
-		m[k] = v
-	}
-	return m
+func TestStartCommandPassesCIAndLocalStackEnvVars(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	t.Setenv("CI", "true")
+	t.Setenv("LOCALSTACK_DISABLE_EVENTS", "1")
+	t.Setenv("LOCALSTACK_AUTH_TOKEN", "host-token")
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
+	require.NoError(t, err, "failed to inspect container")
+	require.True(t, inspect.State.Running)
+
+	envVars := containerEnvToMap(inspect.Config.Env)
+	assert.Equal(t, "true", envVars["CI"])
+	assert.Equal(t, "1", envVars["LOCALSTACK_DISABLE_EVENTS"])
+	assert.NotEmpty(t, envVars["LOCALSTACK_AUTH_TOKEN"])
+	assert.NotEqual(t, "host-token", envVars["LOCALSTACK_AUTH_TOKEN"], "host LOCALSTACK_AUTH_TOKEN should not be passed through")
 }
 
 // hasBindTarget checks if any bind mount targets the given container path.
@@ -257,6 +277,16 @@ func hasBindSource(binds []string, hostPath string) bool {
 		}
 	}
 	return false
+}
+
+// containerEnvToMap converts a Docker container's []string env to a map.
+func containerEnvToMap(envList []string) map[string]string {
+	m := make(map[string]string, len(envList))
+	for _, e := range envList {
+		k, v, _ := strings.Cut(e, "=")
+		m[k] = v
+	}
+	return m
 }
 
 func cleanup() {


### PR DESCRIPTION
Forwards two sets of host environment variables into the LocalStack container at startup, matching the behaviour of the legacy CLI:
- `CI`: ensures LocalStack behaves correctly in CI environments.
- `LOCALSTACK_*`: forwards all LocalStack configuration variables set on the host. LOCALSTACK_AUTH_TOKEN is excluded since it is already explicitly injected.