### PR TITLE
Windows: show correct Docker Desktop start command

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -83,19 +83,30 @@ func (d *DockerRuntime) EmitUnhealthyError(sink output.Sink, err error) {
 	actions := []output.ErrorAction{
 		{Label: "Install Docker:", Value: "https://docs.docker.com/get-docker/"},
 	}
+	summary := err.Error()
 	switch stdruntime.GOOS {
 	case "darwin":
 		actions = append([]output.ErrorAction{{Label: "Start Docker Desktop:", Value: "open -a Docker"}}, actions...)
 	case "linux":
 		actions = append([]output.ErrorAction{{Label: "Start Docker:", Value: "sudo systemctl start docker"}}, actions...)
 	case "windows":
-		actions = append([]output.ErrorAction{{Label: "Start Docker Desktop:", Value: "Start-Process 'Docker Desktop'"}}, actions...)
+		actions = append([]output.ErrorAction{{Label: "Start Docker Desktop:", Value: windowsDockerStartCommand(os.Getenv)}}, actions...)
+		// Suppress the raw error: on Windows it's a named-pipe message that users can't act on.
+		summary = ""
 	}
 	output.EmitError(sink, output.ErrorEvent{
 		Title:   "Docker is not available",
-		Summary: err.Error(),
+		Summary: summary,
 		Actions: actions,
 	})
+}
+
+// PSModulePath is always set by PowerShell and never by cmd.exe; use it to pick the right start command.
+func windowsDockerStartCommand(getenv func(string) string) string {
+	if getenv("PSModulePath") != "" {
+		return "Start-Process 'Docker Desktop'"
+	}
+	return `start "" "Docker Desktop"`
 }
 
 func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progress chan<- PullProgress) error {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	stdruntime "runtime"
 	"strconv"
@@ -90,7 +91,7 @@ func (d *DockerRuntime) EmitUnhealthyError(sink output.Sink, err error) {
 	case "linux":
 		actions = append([]output.ErrorAction{{Label: "Start Docker:", Value: "sudo systemctl start docker"}}, actions...)
 	case "windows":
-		actions = append([]output.ErrorAction{{Label: "Start Docker Desktop:", Value: windowsDockerStartCommand(os.Getenv)}}, actions...)
+		actions = append([]output.ErrorAction{{Label: "Start Docker Desktop:", Value: windowsDockerStartCommand(os.Getenv, exec.LookPath)}}, actions...)
 		// Suppress the raw error: on Windows it's a named-pipe message that users can't act on.
 		summary = ""
 	}
@@ -102,11 +103,16 @@ func (d *DockerRuntime) EmitUnhealthyError(sink output.Sink, err error) {
 }
 
 // PSModulePath is always set by PowerShell and never by cmd.exe; use it to pick the right start command.
-func windowsDockerStartCommand(getenv func(string) string) string {
-	if getenv("PSModulePath") != "" {
-		return "Start-Process 'Docker Desktop'"
+// Prefers "docker desktop start" (documented CLI method); falls back to the full executable path.
+func windowsDockerStartCommand(getenv func(string) string, lookPath func(string) (string, error)) string {
+	if _, err := lookPath("docker"); err == nil {
+		return "docker desktop start"
 	}
-	return `start "" "Docker Desktop"`
+	const exePath = `C:\Program Files\Docker\Docker\Docker Desktop.exe`
+	if getenv("PSModulePath") != "" {
+		return "& '" + exePath + "'"
+	}
+	return `"` + exePath + `"`
 }
 
 func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progress chan<- PullProgress) error {

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -54,3 +54,17 @@ func TestSocketPath_ReturnsEmptyForTCPHost(t *testing.T) {
 
 	assert.Equal(t, "", rt.SocketPath())
 }
+
+func TestWindowsDockerStartCommand_PowerShell(t *testing.T) {
+	getenv := func(key string) string {
+		if key == "PSModulePath" {
+			return `C:\Windows\System32\WindowsPowerShell\v1.0\Modules`
+		}
+		return ""
+	}
+	assert.Equal(t, "Start-Process 'Docker Desktop'", windowsDockerStartCommand(getenv))
+}
+
+func TestWindowsDockerStartCommand_Cmd(t *testing.T) {
+	assert.Equal(t, `start "" "Docker Desktop"`, windowsDockerStartCommand(func(string) string { return "" }))
+}

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,16 +56,23 @@ func TestSocketPath_ReturnsEmptyForTCPHost(t *testing.T) {
 	assert.Equal(t, "", rt.SocketPath())
 }
 
-func TestWindowsDockerStartCommand_PowerShell(t *testing.T) {
+func TestWindowsDockerStartCommand_DockerAvailable(t *testing.T) {
+	lookPath := func(string) (string, error) { return "/usr/bin/docker", nil }
+	assert.Equal(t, "docker desktop start", windowsDockerStartCommand(func(string) string { return "" }, lookPath))
+}
+
+func TestWindowsDockerStartCommand_PowerShellFallback(t *testing.T) {
+	lookPath := func(string) (string, error) { return "", errors.New("not found") }
 	getenv := func(key string) string {
 		if key == "PSModulePath" {
 			return `C:\Windows\System32\WindowsPowerShell\v1.0\Modules`
 		}
 		return ""
 	}
-	assert.Equal(t, "Start-Process 'Docker Desktop'", windowsDockerStartCommand(getenv))
+	assert.Equal(t, `& 'C:\Program Files\Docker\Docker\Docker Desktop.exe'`, windowsDockerStartCommand(getenv, lookPath))
 }
 
-func TestWindowsDockerStartCommand_Cmd(t *testing.T) {
-	assert.Equal(t, `start "" "Docker Desktop"`, windowsDockerStartCommand(func(string) string { return "" }))
+func TestWindowsDockerStartCommand_CmdFallback(t *testing.T) {
+	lookPath := func(string) (string, error) { return "", errors.New("not found") }
+	assert.Equal(t, `"C:\Program Files\Docker\Docker\Docker Desktop.exe"`, windowsDockerStartCommand(func(string) string { return "" }, lookPath))
 }

--- a/test/integration/docker_windows_test.go
+++ b/test/integration/docker_windows_test.go
@@ -1,0 +1,63 @@
+package integration_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// windowsDockerErrorEnv returns an Environ with an invalid DOCKER_HOST and no PSModulePath.
+func windowsDockerErrorEnv() env.Environ {
+	return env.Without(env.Key("PSModulePath"), env.Key("DOCKER_HOST")).
+		With(env.AuthToken, "fake-token").
+		With(env.Key("DOCKER_HOST"), "tcp://localhost:1")
+}
+
+// Verifies that with PSModulePath set, lstk suggests the PowerShell start command.
+func TestWindowsDockerErrorShowsPowerShellCommand(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only test")
+	}
+
+	environ := windowsDockerErrorEnv().
+		With(env.Key("PSModulePath"), `C:\Windows\System32\WindowsPowerShell\v1.0\Modules`)
+
+	stdout, _, err := runLstk(t, testContext(t), "", environ, "start")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stdout, "Start-Process 'Docker Desktop'")
+	assert.NotContains(t, stdout, `start "" "Docker Desktop"`)
+}
+
+// Verifies that without PSModulePath, lstk suggests the cmd.exe start command.
+func TestWindowsDockerErrorShowsCmdCommand(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only test")
+	}
+
+	environ := windowsDockerErrorEnv()
+
+	stdout, _, err := runLstk(t, testContext(t), "", environ, "start")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stdout, `start "" "Docker Desktop"`)
+	assert.NotContains(t, stdout, "Start-Process 'Docker Desktop'")
+}
+
+// Verifies that the verbose Docker error message is suppressed on Windows.
+func TestWindowsDockerErrorOmitsVerboseSummary(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only test")
+	}
+
+	environ := windowsDockerErrorEnv()
+
+	stdout, _, err := runLstk(t, testContext(t), "", environ, "start")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stdout, "Docker is not available")
+	assert.NotContains(t, stdout, "cannot connect to Docker daemon")
+}

--- a/test/integration/docker_windows_test.go
+++ b/test/integration/docker_windows_test.go
@@ -16,35 +16,16 @@ func windowsDockerErrorEnv() env.Environ {
 		With(env.Key("DOCKER_HOST"), "tcp://localhost:1")
 }
 
-// Verifies that with PSModulePath set, lstk suggests the PowerShell start command.
-func TestWindowsDockerErrorShowsPowerShellCommand(t *testing.T) {
+// Verifies that when docker is in PATH, lstk suggests "docker desktop start".
+func TestWindowsDockerErrorShowsDockerCLICommand(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows-only test")
 	}
 
-	environ := windowsDockerErrorEnv().
-		With(env.Key("PSModulePath"), `C:\Windows\System32\WindowsPowerShell\v1.0\Modules`)
-
-	stdout, _, err := runLstk(t, testContext(t), "", environ, "start")
+	stdout, _, err := runLstk(t, testContext(t), "", windowsDockerErrorEnv(), "start")
 	require.Error(t, err)
 	requireExitCode(t, 1, err)
-	assert.Contains(t, stdout, "Start-Process 'Docker Desktop'")
-	assert.NotContains(t, stdout, `start "" "Docker Desktop"`)
-}
-
-// Verifies that without PSModulePath, lstk suggests the cmd.exe start command.
-func TestWindowsDockerErrorShowsCmdCommand(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows-only test")
-	}
-
-	environ := windowsDockerErrorEnv()
-
-	stdout, _, err := runLstk(t, testContext(t), "", environ, "start")
-	require.Error(t, err)
-	requireExitCode(t, 1, err)
-	assert.Contains(t, stdout, `start "" "Docker Desktop"`)
-	assert.NotContains(t, stdout, "Start-Process 'Docker Desktop'")
+	assert.Contains(t, stdout, "docker desktop start")
 }
 
 // Verifies that the verbose Docker error message is suppressed on Windows.
@@ -53,9 +34,7 @@ func TestWindowsDockerErrorOmitsVerboseSummary(t *testing.T) {
 		t.Skip("Windows-only test")
 	}
 
-	environ := windowsDockerErrorEnv()
-
-	stdout, _, err := runLstk(t, testContext(t), "", environ, "start")
+	stdout, _, err := runLstk(t, testContext(t), "", windowsDockerErrorEnv(), "start")
 	require.Error(t, err)
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stdout, "Docker is not available")


### PR DESCRIPTION
On Windows, lstk now detects if the user is running PowerShell or cmd.exe and suggests the correct command to start Docker Desktop. It used to show the PowerShell command regardless of shell.
We use the `PSModulePath` environment variable, which PowerShell always sets (cmd.exe does not). 

Also took advantage to suppress the verbose Windows Docker error message since it isn't actionable.                                                                     