### PR TITLE
Only show spinner when fetching from API

### DIFF
--- a/internal/container/status.go
+++ b/internal/container/status.go
@@ -18,17 +18,13 @@ func Status(ctx context.Context, rt runtime.Runtime, containers []config.Contain
 	ctx, cancel := context.WithTimeout(ctx, statusTimeout)
 	defer cancel()
 
-	output.EmitSpinnerStart(sink, "Fetching LocalStack status")
-
 	for _, c := range containers {
 		name := c.Name()
 		running, err := rt.IsRunning(ctx, name)
 		if err != nil {
-			output.EmitSpinnerStop(sink)
 			return fmt.Errorf("checking %s running: %w", name, err)
 		}
 		if !running {
-			output.EmitSpinnerStop(sink)
 			output.EmitError(sink, output.ErrorEvent{
 				Title: fmt.Sprintf("%s is not running", c.DisplayName()),
 				Actions: []output.ErrorAction{
@@ -59,8 +55,8 @@ func Status(ctx context.Context, rt runtime.Runtime, containers []config.Contain
 		var rows []emulator.Resource
 		switch c.Type {
 		case config.EmulatorAWS:
+			output.EmitSpinnerStart(sink, "Fetching LocalStack status")
 			if v, err := emulatorClient.FetchVersion(ctx, host); err != nil {
-				output.EmitSpinnerStop(sink)
 				output.EmitWarning(sink, fmt.Sprintf("Could not fetch version: %v", err))
 			} else {
 				version = v
@@ -68,13 +64,11 @@ func Status(ctx context.Context, rt runtime.Runtime, containers []config.Contain
 
 			var fetchErr error
 			rows, fetchErr = emulatorClient.FetchResources(ctx, host)
+			output.EmitSpinnerStop(sink)
 			if fetchErr != nil {
-				output.EmitSpinnerStop(sink)
 				return fetchErr
 			}
 		}
-
-		output.EmitSpinnerStop(sink)
 
 		output.EmitInstanceInfo(sink, output.InstanceInfoEvent{
 			EmulatorName:  c.DisplayName(),


### PR DESCRIPTION
 Fix spinner UX so it only appears when actually fetching data from LocalStack, not during preliminary validation checks.

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="210" alt="Screenshot 2026-03-25 at 01 15 55" src="https://github.com/user-attachments/assets/2357fac2-703e-4a21-8836-447fcbf3ad82" /> | <img width="669" height="210" alt="Screenshot 2026-03-25 at 01 08 15" src="https://github.com/user-attachments/assets/b48919a6-9379-4e10-bee0-e1afc6d2cd59" /> | 