### PR TITLE
Fix automated releases

### DIFF
--- a/.github/actions/create-release-tag/action.yml
+++ b/.github/actions/create-release-tag/action.yml
@@ -1,0 +1,64 @@
+name: Create Release Tag
+description: Compute the next version tag, create it, and push it.
+
+inputs:
+  bump:
+    description: Version bump type (patch or minor)
+    required: true
+
+outputs:
+  tag:
+    description: The created tag
+    value: ${{ steps.next_tag.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Git user
+      shell: bash
+      run: |
+        git config user.name "localstack[bot]"
+        git config user.email "localstack-bot@users.noreply.github.com"
+
+    - name: Compute next version tag
+      id: next_tag
+      shell: bash
+      env:
+        BUMP: ${{ inputs.bump }}
+      run: |
+        set -euo pipefail
+
+        latest="$(git tag --list "v0.*.*" --sort=-v:refname | grep -E "^v0\.[0-9]+\.[0-9]+$" | head -n 1 || true)"
+        if [[ -z "${latest}" ]]; then
+          minor=1
+          patch=0
+        else
+          current_minor="$(echo "${latest}" | cut -d. -f2)"
+          current_patch="$(echo "${latest}" | cut -d. -f3)"
+          if [[ "${BUMP}" == "minor" ]]; then
+            minor="$(( current_minor + 1 ))"
+            patch=0
+          else
+            minor="${current_minor}"
+            patch="$(( current_patch + 1 ))"
+          fi
+        fi
+
+        tag="v0.${minor}.${patch}"
+        if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+          echo "Tag ${tag} already exists"
+          exit 1
+        fi
+
+        echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+    - name: Create and push tag
+      shell: bash
+      run: |
+        tag="${{ steps.next_tag.outputs.tag }}"
+        git tag -a "${tag}" -m "Release ${tag}"
+        git push origin "${tag}"
+
+    - name: Print created tag
+      shell: bash
+      run: echo "Created tag ${{ steps.next_tag.outputs.tag }}"

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -62,8 +62,19 @@ jobs:
     name: Create release tag
     needs: [check-changes, ci]
     if: needs.check-changes.outputs.has_changes == 'true'
-    uses: ./.github/workflows/create-release-tag.yml
-    with:
-      release_ref: main
-      bump: patch
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.PRO_ACCESS_TOKEN }}
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Create release tag
+        uses: ./.github/actions/create-release-tag
+        with:
+          bump: patch

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -14,24 +14,9 @@ on:
         options:
           - patch
           - minor
-  workflow_call:
-    inputs:
-      release_ref:
-        description: Git ref to tag
-        required: true
-        default: main
-        type: string
-      bump:
-        description: Version bump type (patch or minor)
-        required: true
-        type: string
 
 permissions:
   contents: write
-
-env:
-  git_user_name: localstack[bot]
-  git_user_email: localstack-bot@users.noreply.github.com
 
 concurrency:
   group: create-release-tag
@@ -49,53 +34,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
 
-      - name: Configure Git user
-        env:
-          GIT_USER_NAME: ${{ env.git_user_name }}
-          GIT_USER_EMAIL: ${{ env.git_user_email }}
-        run: |
-          git config user.name "${GIT_USER_NAME}"
-          git config user.email "${GIT_USER_EMAIL}"
-
       - name: Fetch tags
         run: git fetch --tags --force
 
-      - name: Compute next version tag
-        id: next_tag
-        env:
-          BUMP: ${{ inputs.bump }}
-        run: |
-          set -euo pipefail
-
-          latest="$(git tag --list "v0.*.*" --sort=-v:refname | grep -E "^v0\.[0-9]+\.[0-9]+$" | head -n 1 || true)"
-          if [[ -z "${latest}" ]]; then
-            minor=1
-            patch=0
-          else
-            current_minor="$(echo "${latest}" | cut -d. -f2)"
-            current_patch="$(echo "${latest}" | cut -d. -f3)"
-            if [[ "${BUMP}" == "minor" ]]; then
-              minor="$(( current_minor + 1 ))"
-              patch=0
-            else
-              minor="${current_minor}"
-              patch="$(( current_patch + 1 ))"
-            fi
-          fi
-
-          tag="v0.${minor}.${patch}"
-          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
-            echo "Tag ${tag} already exists"
-            exit 1
-          fi
-
-          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
-
-      - name: Create and push tag
-        run: |
-          tag="${{ steps.next_tag.outputs.tag }}"
-          git tag -a "${tag}" -m "Release ${tag}"
-          git push origin "${tag}"
-
-      - name: Print created tag
-        run: echo "Created tag ${{ steps.next_tag.outputs.tag }}"
+      - name: Create release tag
+        uses: ./.github/actions/create-release-tag
+        with:
+          bump: ${{ inputs.bump }}


### PR DESCRIPTION
## Motivation

The first run of the automated weekly release (#170) failed because GitHub Actions does not reliably queue a job that uses `uses:` (reusable workflow call) when it depends via `needs` on another job that also uses `uses:`. The `create-tag` job never appeared in the run.

## Changes

- Extract tag creation logic into a composite action (`.github/actions/create-release-tag/`) shared by both workflows
- Convert `create-tag` in `automated-release.yml` back to a regular job that calls the composite action — fixing the GitHub limitation without duplicating logic
- Simplify `create-release-tag.yml` to use the same composite action; remove the `workflow_call` trigger that is no longer needed

## Tests

Cannot be tested from a feature branch: the `create-tag` job always checks out `main`, so the composite action file must exist on `main` to be found. This PR must be merged first, then triggered via:

```
gh workflow run automated-release.yml --repo localstack/lstk
```

Towards DRG-667