### PR TITLE
Remove browser output from TUI

### DIFF
--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -5,6 +5,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"strings"
 
@@ -44,6 +45,8 @@ func (l *loginProvider) Login(ctx context.Context) (string, error) {
 		Code:     authReq.Code,
 		URL:      authURL,
 	})
+	browser.Stdout = io.Discard
+	browser.Stderr = io.Discard
 	if err := browser.OpenURL(authURL); err != nil {
 		output.EmitWarning(l.sink, fmt.Sprintf("Failed to open browser automatically. Open this URL manually to continue: %s", authURL))
 	}


### PR DESCRIPTION
## Motivation

When `browser.OpenURL()` launches a browser, the subprocess inherits lstk's stdout/stderr, causing messages like Chrome's sandbox warning (`Sandbox: CanCreateUserNamespace() unshare(CLONE_NEWPID): EPERM`) to leak into the TUI.

## Changes

- Set `browser.Stdout` and `browser.Stderr` to `io.Discard` before calling `browser.OpenURL()`

## Tests

Manually verified that no browser subprocess noise appears in the TUI during `lstk auth login`.

Closes DRG-609