### PR TITLE
Improve config error for legacy YAML config files

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,9 @@ func Init() error {
 	if err := viper.ReadInConfig(); err != nil {
 		var notFoundErr viper.ConfigFileNotFoundError
 		if !errors.As(err, &notFoundErr) {
+			if used := viper.ConfigFileUsed(); filepath.Ext(used) == ".yaml" || filepath.Ext(used) == ".yml" {
+				return fmt.Errorf("%s is from an old lstk version; lstk now uses TOML format — remove it or replace it with a config.toml file", used)
+			}
 			return fmt.Errorf("failed to read config file: %w", err)
 		}
 

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -191,6 +191,27 @@ tag = "latest"
 	assert.Contains(t, stderr, "port is required")
 }
 
+func TestLegacyYAMLConfigGivesHelpfulError(t *testing.T) {
+	tmpHome := t.TempDir()
+	workDir := t.TempDir()
+	xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
+
+	legacyConfigDir := filepath.Join(tmpHome, ".config", "lstk")
+	require.NoError(t, os.MkdirAll(legacyConfigDir, 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(legacyConfigDir, "config.yaml"),
+		[]byte("emulators:\n  - type: aws\n    port: 4566\n"),
+		0644,
+	))
+
+	e := testEnvWithHome(tmpHome, xdgOverride)
+	_, stderr, err := runLstk(t, testContext(t), workDir, e, "logout")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "config.yaml")
+	assert.Contains(t, stderr, "TOML")
+}
+
 func TestConfigWithMissingOptionalTagSucceeds(t *testing.T) {
 	configContent := `
 [[containers]]


### PR DESCRIPTION
## Motivation

When an old `config.yaml` (from a previous lstk version) exists in the config search path, viper picks it up and tries to parse it as TOML (due to `SetConfigType("toml")`), resulting in a vague error like `failed to read config file: While parsing config: toml: expected character =` with no hint about which file was read or why.

## Changes

- After `ReadInConfig()` fails with a non-NotFound error, check `viper.ConfigFileUsed()` (populated by viper before parsing, even on failure) to detect if a `.yaml`/`.yml` file was picked up
- If so, return a targeted error naming the file and explaining that lstk now uses TOML format
- Add integration test `TestLegacyYAMLConfigGivesHelpfulError` that places a legacy `config.yaml` in `~/.config/lstk/` and asserts the error mentions both the filename and TOML

## Tests

New integration test added; verified it fails before the fix and passes after.

## Related

- [FLC-544](https://linear.app/localstack/issue/FLC-544/improve-config-error-for-legacy-yaml-config-files)