### PR TITLE
Fix docker socket mount for Windows

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -72,9 +72,18 @@ func probeSocket(candidates ...string) string {
 }
 
 func (d *DockerRuntime) SocketPath() string {
-	host := d.client.DaemonHost()
+	return socketPathFromHost(d.client.DaemonHost())
+}
+
+// Resolves the host-side Docker socket path to bind-mount into containers.
+// On Unix, it strips the unix:// prefix. On Windows, Docker Desktop connects via a named pipe
+// but exposes the socket at /var/run/docker.sock for Linux containers to bind-mount (via WSL2).
+func socketPathFromHost(host string) string {
 	if strings.HasPrefix(host, "unix://") {
 		return strings.TrimPrefix(host, "unix://")
+	}
+	if strings.HasPrefix(host, "npipe://") {
+		return "/var/run/docker.sock"
 	}
 	return ""
 }

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -56,6 +56,14 @@ func TestSocketPath_ReturnsEmptyForTCPHost(t *testing.T) {
 	assert.Equal(t, "", rt.SocketPath())
 }
 
+func TestSocketPathFromHost_ReturnsDockerSockForWindowsNamedPipe(t *testing.T) {
+	assert.Equal(t, "/var/run/docker.sock", socketPathFromHost("npipe:////./pipe/docker_engine"))
+}
+
+func TestSocketPathFromHost_ExtractsUnixPath(t *testing.T) {
+	assert.Equal(t, "/var/run/docker.sock", socketPathFromHost("unix:///var/run/docker.sock"))
+}
+
 func TestWindowsDockerStartCommand_DockerAvailable(t *testing.T) {
 	lookPath := func(string) (string, error) { return "/usr/bin/docker", nil }
 	assert.Equal(t, "docker desktop start", windowsDockerStartCommand(func(string) string { return "" }, lookPath))


### PR DESCRIPTION
Attempt to fix the docker socket mount for Windows. 
Currently it evaluates as "", and as a result users can't work with Lambda and other services that spin containers.