### PR TITLE
Add Lima VM detection for Docker socket path

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -47,12 +47,24 @@ func NewDockerRuntime(dockerHost string) (*DockerRuntime, error) {
 }
 
 func findDockerSocket() string {
+	// Check if running inside a Lima VM - Docker socket is natively available
+	if isLimaVM() {
+		return "/var/run/docker.sock"
+	}
+
 	home, _ := os.UserHomeDir()
 	return probeSocket(
 		filepath.Join(home, ".colima", "default", "docker.sock"),
 		filepath.Join(home, ".colima", "docker.sock"),
 		filepath.Join(home, ".orbstack", "run", "docker.sock"),
+		filepath.Join(home, ".lima", "docker", "sock", "docker.sock"),
 	)
+}
+
+// isLimaVM detects if running inside a Lima virtual machine.
+// Lima sets the LIMA_INSTANCE environment variable in the VM.
+func isLimaVM() bool {
+	return os.Getenv("LIMA_INSTANCE") != ""
 }
 
 func probeSocket(candidates ...string) string {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -47,8 +47,9 @@ func NewDockerRuntime(dockerHost string) (*DockerRuntime, error) {
 }
 
 func findDockerSocket() string {
-	// Check if running inside a Lima VM - Docker socket is natively available
-	if isLimaVM() {
+	// Lima VM: Docker socket is natively available at the standard path.
+	// Lima sets LIMA_INSTANCE inside the VM.
+	if os.Getenv("LIMA_INSTANCE") != "" {
 		return "/var/run/docker.sock"
 	}
 
@@ -59,12 +60,6 @@ func findDockerSocket() string {
 		filepath.Join(home, ".orbstack", "run", "docker.sock"),
 		filepath.Join(home, ".lima", "docker", "sock", "docker.sock"),
 	)
-}
-
-// isLimaVM detects if running inside a Lima virtual machine.
-// Lima sets the LIMA_INSTANCE environment variable in the VM.
-func isLimaVM() bool {
-	return os.Getenv("LIMA_INSTANCE") != ""
 }
 
 func probeSocket(candidates ...string) string {

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -77,7 +77,7 @@ func TestWindowsDockerStartCommand_CmdFallback(t *testing.T) {
 	assert.Equal(t, `"C:\Program Files\Docker\Docker\Docker Desktop.exe"`, windowsDockerStartCommand(func(string) string { return "" }, lookPath))
 }
 
-func TestFindDockerSocket_ReturnsLimaSocketWhenInLimaVM(t *testing.T) {
+func TestFindDockerSocket_LimaVM(t *testing.T) {
 	t.Setenv("LIMA_INSTANCE", "default")
 	sock := findDockerSocket()
 	assert.Equal(t, "/var/run/docker.sock", sock)

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -76,3 +76,32 @@ func TestWindowsDockerStartCommand_CmdFallback(t *testing.T) {
 	lookPath := func(string) (string, error) { return "", errors.New("not found") }
 	assert.Equal(t, `"C:\Program Files\Docker\Docker\Docker Desktop.exe"`, windowsDockerStartCommand(func(string) string { return "" }, lookPath))
 }
+
+func TestIsLimaVM_DetectsLimaInstance(t *testing.T) {
+	t.Setenv("LIMA_INSTANCE", "default")
+	assert.True(t, isLimaVM())
+}
+
+func TestIsLimaVM_ReturnsFalseWhenNotLima(t *testing.T) {
+	t.Setenv("LIMA_INSTANCE", "")
+	assert.False(t, isLimaVM())
+}
+
+func TestFindDockerSocket_ReturnsLimaSocketWhenInLimaVM(t *testing.T) {
+	t.Setenv("LIMA_INSTANCE", "default")
+	sock := findDockerSocket()
+	assert.Equal(t, "/var/run/docker.sock", sock)
+}
+
+func TestFindDockerSocket_IncludesLimaPathOnHost(t *testing.T) {
+	t.Setenv("LIMA_INSTANCE", "")
+
+	// Create the Lima socket path temporarily
+	tmpDir := t.TempDir()
+	limaSock := filepath.Join(tmpDir, "docker.sock")
+	require.NoError(t, os.WriteFile(limaSock, nil, 0o600))
+
+	// Test that probeSocket finds it
+	result := probeSocket(filepath.Join(tmpDir, ".nonexistent", "docker.sock"), limaSock)
+	assert.Equal(t, limaSock, result)
+}

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -77,16 +77,6 @@ func TestWindowsDockerStartCommand_CmdFallback(t *testing.T) {
 	assert.Equal(t, `"C:\Program Files\Docker\Docker\Docker Desktop.exe"`, windowsDockerStartCommand(func(string) string { return "" }, lookPath))
 }
 
-func TestIsLimaVM_DetectsLimaInstance(t *testing.T) {
-	t.Setenv("LIMA_INSTANCE", "default")
-	assert.True(t, isLimaVM())
-}
-
-func TestIsLimaVM_ReturnsFalseWhenNotLima(t *testing.T) {
-	t.Setenv("LIMA_INSTANCE", "")
-	assert.False(t, isLimaVM())
-}
-
 func TestFindDockerSocket_ReturnsLimaSocketWhenInLimaVM(t *testing.T) {
 	t.Setenv("LIMA_INSTANCE", "default")
 	sock := findDockerSocket()
@@ -96,12 +86,13 @@ func TestFindDockerSocket_ReturnsLimaSocketWhenInLimaVM(t *testing.T) {
 func TestFindDockerSocket_IncludesLimaPathOnHost(t *testing.T) {
 	t.Setenv("LIMA_INSTANCE", "")
 
-	// Create the Lima socket path temporarily
 	tmpDir := t.TempDir()
-	limaSock := filepath.Join(tmpDir, "docker.sock")
+	limaSock := filepath.Join(tmpDir, ".lima", "docker", "sock", "docker.sock")
+	require.NoError(t, os.MkdirAll(filepath.Dir(limaSock), 0o700))
 	require.NoError(t, os.WriteFile(limaSock, nil, 0o600))
 
-	// Test that probeSocket finds it
-	result := probeSocket(filepath.Join(tmpDir, ".nonexistent", "docker.sock"), limaSock)
+	t.Setenv("HOME", tmpDir)
+
+	result := findDockerSocket()
 	assert.Equal(t, limaSock, result)
 }


### PR DESCRIPTION
When running lstk inside a Lima VM with --mount-writable, users get:
```
✗ failed to start LocalStack: Error response from daemon: error while creating mount source path '/Users/<user>/.lima/docker/sock/docker.sock': mkdir /Users/<user>/.lima/docker/sock/docker.sock: operation not supported
```
Docker tries to create a Unix socket file on the Lima mount, but the filesystem doesn't support socket creation.

This will add Lima VM detection that:
  1. Checks for the LIMA_INSTANCE environment variable (set by Lima in the VM)
  2. Uses /var/run/docker.sock (native path) when inside a Lima VM
  3. Includes the Lima socket path in the probe list for host-side usage


Fix #175