### PR TITLE
Fix errcheck lint violations in start_test.go

### DIFF
--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -207,7 +207,7 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 	t.Run("http health endpoint", func(t *testing.T) {
 		resp, err := http.Get("http://localhost.localstack.cloud:4566/_localstack/health")
 		require.NoError(t, err)
-		defer resp.Body.Close()
+		defer func() { assert.NoError(t, resp.Body.Close()) }()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
@@ -221,7 +221,7 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 		}
 		resp, err := client.Get("https://localhost.localstack.cloud/_localstack/health")
 		require.NoError(t, err)
-		defer resp.Body.Close()
+		defer func() { assert.NoError(t, resp.Body.Close()) }()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 }


### PR DESCRIPTION
Check error return values from resp.Body.Close() in HTTP health endpoint tests.

Cc @carole-lavillonniere because https://github.com/localstack/lstk/pull/156