### PR TITLE
Show endpoint and tips when emulator is already running

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -226,7 +226,7 @@ func runPostStartSetups(ctx context.Context, sink output.Sink, containers []conf
 		if setup, ok := setups[t]; ok {
 			resolvedHost, dnsOK := endpoint.ResolveHost(firstByType[t].Port, localStackHost)
 			if !dnsOK {
-				output.EmitNote(sink, `Could not resolve "localhost.localstack.cloud" — your system may have DNS rebind protection enabled. Using 127.0.0.1 as the endpoint.`)
+				output.EmitNote(sink, endpoint.DNSRebindNote)
 			}
 			if err := setup(ctx, sink, interactive, resolvedHost); err != nil {
 				return err
@@ -363,7 +363,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			output.EmitNote(sink, "LocalStack is already running")
 			resolvedHost, dnsOK := endpoint.ResolveHost(c.Port, localStackHost)
 			if !dnsOK {
-				output.EmitNote(sink, `Could not resolve "localhost.localstack.cloud" — your system may have DNS rebind protection enabled. Using 127.0.0.1 as the endpoint.`)
+				output.EmitNote(sink, endpoint.DNSRebindNote)
 			}
 			emitPostStartPointers(sink, resolvedHost, webAppURL)
 			continue

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -361,7 +361,10 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 		}
 		if running {
 			output.EmitNote(sink, "LocalStack is already running")
-			resolvedHost, _ := endpoint.ResolveHost(c.Port, localStackHost)
+			resolvedHost, dnsOK := endpoint.ResolveHost(c.Port, localStackHost)
+			if !dnsOK {
+				output.EmitNote(sink, `Could not resolve "localhost.localstack.cloud" — your system may have DNS rebind protection enabled. Using 127.0.0.1 as the endpoint.`)
+			}
 			emitPostStartPointers(sink, resolvedHost, webAppURL)
 			continue
 		}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -159,7 +159,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		}
 	}
 
-	containers, err = selectContainersToStart(ctx, rt, sink, tel, containers)
+	containers, err = selectContainersToStart(ctx, rt, sink, tel, containers, opts.LocalStackHost, opts.WebAppURL)
 	if err != nil {
 		return err
 	}
@@ -352,7 +352,7 @@ func startContainers(ctx context.Context, rt runtime.Runtime, sink output.Sink, 
 	return nil
 }
 
-func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig) ([]runtime.ContainerConfig, error) {
+func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig, localStackHost, webAppURL string) ([]runtime.ContainerConfig, error) {
 	var filtered []runtime.ContainerConfig
 	for _, c := range containers {
 		running, err := rt.IsRunning(ctx, c.Name)
@@ -360,7 +360,9 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			return nil, fmt.Errorf("failed to check container status: %w", err)
 		}
 		if running {
-			output.EmitInfo(sink, "LocalStack is already running")
+			output.EmitNote(sink, "LocalStack is already running")
+			resolvedHost, _ := endpoint.ResolveHost(c.Port, localStackHost)
+			emitPostStartPointers(sink, resolvedHost, webAppURL)
 			continue
 		}
 		if err := ports.CheckAvailable(c.Port); err != nil {

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -4,6 +4,8 @@ import "net"
 
 const Hostname = "localhost.localstack.cloud"
 
+const DNSRebindNote = "Could not resolve localhost.localstack.cloud, falling back to 127.0.0.1."
+
 // ResolveHost returns the best host:port for reaching LocalStack on the given port.
 // If override is non-empty it is returned as-is. Otherwise a DNS check is performed;
 // if Hostname does not resolve to 127.0.0.1 (e.g. DNS rebind protection is active),

--- a/internal/ui/run_awsconfig.go
+++ b/internal/ui/run_awsconfig.go
@@ -28,7 +28,7 @@ func RunConfigProfile(parentCtx context.Context, containers []config.ContainerCo
 
 	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
 		if !dnsOK {
-			output.EmitNote(sink, `Could not resolve "localhost.localstack.cloud" - your system may have DNS rebind protection enabled. Using 127.0.0.1 as the endpoint.`)
+			output.EmitNote(sink, endpoint.DNSRebindNote)
 		}
 		status, err := awsconfig.CheckProfileStatus(resolvedHost)
 		if err != nil {


### PR DESCRIPTION
This will:
1. Show the endpoint, web app URL, and a random tip when the emulator is already running, matching the start output.
1. Render the "already running" message as a note (> Note:) instead of a plain info line

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="300" alt="Screenshot 2026-04-21 at 18 57 44" src="https://github.com/user-attachments/assets/f320979a-29c6-4688-82bc-6591a213d65d" /> | <img width="669" height="301" alt="Screenshot 2026-04-21 at 18 57 49" src="https://github.com/user-attachments/assets/321f4ccf-de84-48df-8de1-a38744b6d138" /> | 