### PR TITLE
Add doctor command for environment checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Running `lstk` will automatically handle configuration setup and start LocalStac
 
 ## Features
 
-- **Start / stop / status** — manage LocalStack emulators with a single command
+- **Start / stop / status / doctor** — manage and diagnose LocalStack emulators with a single command set
 - **Interactive TUI** — a Bubble Tea-powered terminal UI shown in an interactive terminal for commands like `start`, `login`, `status`, etc.
 - **Plain output** for CI/CD and scripting (auto-detected in non-interactive environments or forced with `--non-interactive`)
 - **Log streaming** — tail emulator logs in real-time with `--follow`; use `--verbose` to show all logs without filtering
@@ -162,6 +162,9 @@ lstk stop
 
 # Show emulator status and deployed resources
 lstk status
+
+# Diagnose config, Docker, auth, and emulator connectivity
+lstk doctor
 
 # Stream emulator logs
 lstk logs --follow

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/doctor"
+	"github.com/localstack/lstk/internal/emulator/aws"
+	"github.com/localstack/lstk/internal/env"
+	"github.com/localstack/lstk/internal/log"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
+	"github.com/localstack/lstk/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newDoctorCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Diagnose your LocalStack environment",
+		Long:  "Run read-only checks for configuration, Docker, authentication, and emulator connectivity.",
+		RunE: commandWithTelemetry("doctor", tel, func(cmd *cobra.Command, args []string) error {
+			configState, containers, err := loadDoctorConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			rt, rtErr := runtime.NewDockerRuntime(cfg.DockerHost)
+			opts := doctor.Options{
+				Config:           configState,
+				Containers:       containers,
+				LocalStackHost:   cfg.LocalStackHost,
+				EnvAuthToken:     cfg.AuthToken,
+				ForceFileKeyring: cfg.ForceFileKeyring,
+				Logger:           logger,
+				RuntimeInitError: rtErr,
+			}
+
+			awsClient := aws.NewClient(&http.Client{})
+			if isInteractiveMode(cfg) {
+				return ui.RunDoctor(cmd.Context(), rt, awsClient, opts)
+			}
+			return doctor.Run(cmd.Context(), rt, awsClient, output.NewPlainSink(os.Stdout), opts)
+		}),
+	}
+}
+
+func loadDoctorConfig(cmd *cobra.Command) (doctor.ConfigState, []config.ContainerConfig, error) {
+	explicitPath, err := cmd.Flags().GetString("config")
+	if err != nil {
+		return doctor.ConfigState{}, nil, err
+	}
+
+	if explicitPath != "" {
+		return loadDoctorConfigPath(explicitPath)
+	}
+
+	existingPath, found, err := config.ExistingConfigFilePath()
+	if err != nil {
+		return doctor.ConfigState{}, nil, err
+	}
+	if found {
+		return loadDoctorConfigPath(existingPath)
+	}
+
+	resolvedPath, err := config.ConfigFilePath()
+	if err != nil {
+		return doctor.ConfigState{}, nil, err
+	}
+
+	return doctor.ConfigState{
+		Path:   resolvedPath,
+		Exists: false,
+	}, nil, nil
+}
+
+func loadDoctorConfigPath(path string) (doctor.ConfigState, []config.ContainerConfig, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return doctor.ConfigState{}, nil, fmt.Errorf("failed to resolve config path: %w", err)
+	}
+
+	state := doctor.ConfigState{
+		Path:   absPath,
+		Exists: true,
+	}
+
+	if _, err := os.Stat(absPath); err != nil {
+		state.Exists = false
+		state.LoadError = err
+		return state, nil, nil
+	}
+
+	if err := config.InitFromPath(absPath); err != nil {
+		state.LoadError = err
+		return state, nil, nil
+	}
+
+	appConfig, err := config.Get()
+	if err != nil {
+		state.LoadError = err
+		return state, nil, nil
+	}
+
+	state.Loaded = true
+	return state, appConfig.Containers, nil
+}

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -51,6 +51,15 @@ func TestSubcommandHelpUsesSubcommandUsageLine(t *testing.T) {
 	assertNotContains(t, out, "LSTK - LocalStack command-line interface")
 }
 
+func TestRootHelpIncludesDoctorCommand(t *testing.T) {
+	out, err := executeWithArgs(t, "--help")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assertContains(t, out, "doctor")
+}
+
 func assertContains(t *testing.T, s, want string) {
 	t.Helper()
 	if !strings.Contains(s, want) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 	root.AddCommand(
 		newStartCmd(cfg, tel, logger),
 		newStopCmd(cfg, tel),
+		newDoctorCmd(cfg, tel, logger),
 		newLoginCmd(cfg, tel, logger),
 		newLogoutCmd(cfg, tel, logger),
 		newStatusCmd(cfg, tel),

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -48,6 +48,22 @@ func ConfigFilePath() (string, error) {
 	return absCreationPath, nil
 }
 
+func ExistingConfigFilePath() (string, bool, error) {
+	existingPath, found, err := firstExistingConfigPath()
+	if err != nil {
+		return "", false, err
+	}
+	if !found {
+		return "", false, nil
+	}
+
+	absPath, err := filepath.Abs(existingPath)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to resolve absolute config path: %w", err)
+	}
+	return absPath, true, nil
+}
+
 func ConfigDir() (string, error) {
 	configPath, err := ConfigFilePath()
 	if err != nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,377 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/localstack/lstk/internal/auth"
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/emulator"
+	"github.com/localstack/lstk/internal/endpoint"
+	"github.com/localstack/lstk/internal/log"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+const (
+	doctorTimeout          = 30 * time.Second
+	dockerCheckTimeout     = 5 * time.Second
+	emulatorInspectTimeout = 3 * time.Second
+	emulatorHealthTimeout  = 5 * time.Second
+)
+
+const (
+	statusOK   = "OK"
+	statusWarn = "WARN"
+	statusFail = "FAIL"
+)
+
+type ConfigState struct {
+	Path      string
+	Exists    bool
+	Loaded    bool
+	LoadError error
+}
+
+type Options struct {
+	Config           ConfigState
+	Containers       []config.ContainerConfig
+	LocalStackHost   string
+	EnvAuthToken     string
+	ForceFileKeyring bool
+	Logger           log.Logger
+	RuntimeInitError error
+}
+
+type row struct {
+	check  string
+	status string
+	detail string
+}
+
+func Run(ctx context.Context, rt runtime.Runtime, emulatorClient emulator.Client, sink output.Sink, opts Options) error {
+	ctx, cancel := context.WithTimeout(ctx, doctorTimeout)
+	defer cancel()
+
+	var rows []row
+	output.EmitInfo(sink, "Checking configuration")
+	rows = append(rows, configRow(opts.Config))
+	output.EmitInfo(sink, "Checking Docker runtime")
+	dockerStatus, dockerReady := dockerRow(ctx, rt, opts.RuntimeInitError)
+	rows = append(rows, dockerStatus)
+	output.EmitInfo(sink, "Checking authentication")
+	rows = append(rows, authRows(opts)...)
+
+	if opts.Config.Loaded && len(opts.Containers) > 0 {
+		output.EmitInfo(sink, "Checking configured emulators")
+		rows = append(rows, emulatorRows(ctx, rt, emulatorClient, opts.Containers, opts.LocalStackHost, dockerReady)...)
+	} else if opts.Config.Loaded && len(opts.Containers) == 0 {
+		rows = append(rows, row{
+			check:  "Configured emulators",
+			status: statusWarn,
+			detail: "No emulators defined in config",
+		})
+	}
+
+	tableRows := make([][]string, 0, len(rows))
+	failures := 0
+	warnings := 0
+	for _, r := range rows {
+		tableRows = append(tableRows, []string{r.check, r.status, r.detail})
+		switch r.status {
+		case statusFail:
+			failures++
+		case statusWarn:
+			warnings++
+		}
+	}
+
+	output.EmitInfo(sink, "Running LocalStack diagnostics")
+	output.EmitTable(sink, output.TableEvent{
+		Headers: []string{"Check", "Status", "Detail"},
+		Rows:    tableRows,
+	})
+
+	switch {
+	case failures > 0:
+		output.EmitWarning(sink, "Doctor found issues that require attention")
+		return output.NewSilentError(errors.New("doctor found issues"))
+	case warnings > 0:
+		output.EmitNote(sink, "Doctor completed with warnings")
+	default:
+		output.EmitSuccess(sink, "Doctor found no issues")
+	}
+
+	return nil
+}
+
+func configRow(state ConfigState) row {
+	switch {
+	case state.LoadError != nil:
+		return row{
+			check:  "Config file",
+			status: statusFail,
+			detail: fmt.Sprintf("%s (%v)", fallbackValue(state.Path, "unknown"), state.LoadError),
+		}
+	case state.Exists:
+		return row{
+			check:  "Config file",
+			status: statusOK,
+			detail: state.Path,
+		}
+	default:
+		return row{
+			check:  "Config file",
+			status: statusWarn,
+			detail: fmt.Sprintf("Not found at %s; doctor is read-only and will not create it", fallbackValue(state.Path, "unknown")),
+		}
+	}
+}
+
+func dockerRow(ctx context.Context, rt runtime.Runtime, initErr error) (row, bool) {
+	detail := dockerDetail(rt)
+	if initErr != nil {
+		return row{
+			check:  "Docker runtime",
+			status: statusFail,
+			detail: fmt.Sprintf("%s (%v)", detail, initErr),
+		}, false
+	}
+
+	if rt == nil {
+		return row{
+			check:  "Docker runtime",
+			status: statusFail,
+			detail: "Runtime is not initialized",
+		}, false
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, dockerCheckTimeout)
+	defer cancel()
+
+	if err := rt.IsHealthy(checkCtx); err != nil {
+		if timedOut(checkCtx, err) {
+			return row{
+				check:  "Docker runtime",
+				status: statusFail,
+				detail: fmt.Sprintf("%s (health check timed out after %s)", detail, dockerCheckTimeout),
+			}, false
+		}
+		return row{
+			check:  "Docker runtime",
+			status: statusFail,
+			detail: fmt.Sprintf("%s (%v)", detail, err),
+		}, false
+	}
+
+	return row{
+		check:  "Docker runtime",
+		status: statusOK,
+		detail: detail,
+	}, true
+}
+
+func authRows(opts Options) []row {
+	rows := []row{{
+		check:  "LOCALSTACK_AUTH_TOKEN",
+		status: statusWarn,
+		detail: "Not set",
+	}}
+	if opts.EnvAuthToken != "" {
+		rows[0].status = statusOK
+		rows[0].detail = "Set in the environment"
+	}
+
+	storage, err := auth.NewTokenStorage(opts.ForceFileKeyring, opts.Logger)
+	if err != nil {
+		rows = append(rows, row{
+			check:  "Stored auth token",
+			status: statusWarn,
+			detail: fmt.Sprintf("Could not inspect token storage: %v", err),
+		})
+		return rows
+	}
+
+	token, err := storage.GetAuthToken()
+	switch {
+	case err == nil && token != "":
+		detail := "Token available in local storage"
+		if opts.ForceFileKeyring {
+			detail = "Token available in file storage"
+		}
+		rows = append(rows, row{
+			check:  "Stored auth token",
+			status: statusOK,
+			detail: detail,
+		})
+	case errors.Is(err, auth.ErrTokenNotFound):
+		if opts.EnvAuthToken != "" {
+			return rows
+		}
+		rows = append(rows, row{
+			check:  "Stored auth token",
+			status: statusWarn,
+			detail: "Not found in local storage",
+		})
+	default:
+		rows = append(rows, row{
+			check:  "Stored auth token",
+			status: statusWarn,
+			detail: fmt.Sprintf("Could not read token storage: %v", err),
+		})
+	}
+
+	return rows
+}
+
+func emulatorRows(ctx context.Context, rt runtime.Runtime, emulatorClient emulator.Client, containers []config.ContainerConfig, localStackHost string, dockerReady bool) []row {
+	if !dockerReady || rt == nil {
+		return []row{{
+			check:  "Configured emulators",
+			status: statusWarn,
+			detail: "Skipping emulator checks until Docker is available",
+		}}
+	}
+
+	type result struct {
+		index int
+		rows  []row
+	}
+
+	results := make([][]row, len(containers))
+	resultCh := make(chan result, len(containers))
+
+	var wg sync.WaitGroup
+	for i, c := range containers {
+		wg.Add(1)
+		go func(index int, container config.ContainerConfig) {
+			defer wg.Done()
+			resultCh <- result{
+				index: index,
+				rows:  emulatorCheckRows(ctx, rt, emulatorClient, container, localStackHost),
+			}
+		}(i, c)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	for result := range resultCh {
+		results[result.index] = result.rows
+	}
+
+	var rows []row
+	for _, resultRows := range results {
+		rows = append(rows, resultRows...)
+	}
+
+	return rows
+}
+
+func emulatorCheckRows(ctx context.Context, rt runtime.Runtime, emulatorClient emulator.Client, c config.ContainerConfig, localStackHost string) []row {
+	name := c.Name()
+	label := c.DisplayName()
+
+	runningCtx, cancel := context.WithTimeout(ctx, emulatorInspectTimeout)
+	running, err := rt.IsRunning(runningCtx, name)
+	cancel()
+	if err != nil {
+		if timedOut(runningCtx, err) {
+			return []row{{
+				check:  label,
+				status: statusFail,
+				detail: fmt.Sprintf("Checking %s timed out after %s", name, emulatorInspectTimeout),
+			}}
+		}
+		return []row{{
+			check:  label,
+			status: statusFail,
+			detail: fmt.Sprintf("Could not inspect %s: %v", name, err),
+		}}
+	}
+	if !running {
+		return []row{{
+			check:  label,
+			status: statusWarn,
+			detail: fmt.Sprintf("%s is not running", name),
+		}}
+	}
+
+	port := c.Port
+	if containerPort, err := c.ContainerPort(); err == nil {
+		boundPortCtx, cancel := context.WithTimeout(ctx, emulatorInspectTimeout)
+		if actualPort, err := rt.GetBoundPort(boundPortCtx, name, containerPort); err == nil && actualPort != "" {
+			port = actualPort
+		}
+		cancel()
+	}
+	host, dnsOK := endpoint.ResolveHost(port, localStackHost)
+	detail := fmt.Sprintf("%s is running at %s", name, host)
+	if localStackHost == "" && !dnsOK {
+		detail += " (DNS fallback to 127.0.0.1)"
+	}
+
+	rows := []row{{
+		check:  label,
+		status: statusOK,
+		detail: detail,
+	}}
+
+	if c.Type != config.EmulatorAWS || emulatorClient == nil {
+		return rows
+	}
+
+	healthCtx, cancel := context.WithTimeout(ctx, emulatorHealthTimeout)
+	version, err := emulatorClient.FetchVersion(healthCtx, host)
+	cancel()
+	if err != nil {
+		if timedOut(healthCtx, err) {
+			rows = append(rows, row{
+				check:  label + " health",
+				status: statusWarn,
+				detail: fmt.Sprintf("Health check for %s timed out after %s", host, emulatorHealthTimeout),
+			})
+			return rows
+		}
+		rows = append(rows, row{
+			check:  label + " health",
+			status: statusWarn,
+			detail: fmt.Sprintf("Health check failed for %s: %v", host, err),
+		})
+		return rows
+	}
+
+	rows = append(rows, row{
+		check:  label + " health",
+		status: statusOK,
+		detail: fmt.Sprintf("%s · version %s", host, version),
+	})
+	return rows
+}
+
+func dockerDetail(rt runtime.Runtime) string {
+	if rt == nil {
+		return "Docker client unavailable"
+	}
+	if socketPath := rt.SocketPath(); socketPath != "" {
+		return "Connected via unix://" + socketPath
+	}
+	return "Connected via Docker host configuration"
+}
+
+func fallbackValue(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func timedOut(ctx context.Context, err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded)
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,153 @@
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/emulator"
+	"github.com/localstack/lstk/internal/log"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+type fakeEmulatorClient struct {
+	version      string
+	err          error
+	fetchVersion func(context.Context, string) (string, error)
+}
+
+func (f fakeEmulatorClient) FetchVersion(ctx context.Context, host string) (string, error) {
+	if f.fetchVersion != nil {
+		return f.fetchVersion(ctx, host)
+	}
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.version, nil
+}
+
+func (f fakeEmulatorClient) FetchResources(context.Context, string) ([]emulator.Resource, error) {
+	return nil, nil
+}
+
+func TestRunReturnsSilentErrorWhenCriticalChecksFail(t *testing.T) {
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	err := Run(context.Background(), nil, nil, sink, Options{
+		Config: ConfigState{
+			Path:      "/tmp/config.toml",
+			Exists:    true,
+			LoadError: errors.New("invalid config"),
+		},
+		Logger:           log.Nop(),
+		RuntimeInitError: errors.New("docker init failed"),
+	})
+
+	require.Error(t, err)
+	assert.True(t, output.IsSilent(err))
+	assert.Contains(t, out.String(), "Config file")
+	assert.Contains(t, out.String(), "FAIL")
+	assert.Contains(t, out.String(), "docker init failed")
+	assert.Contains(t, out.String(), "Doctor found issues that require attention")
+}
+
+func TestRunReportsRunningEmulatorHealth(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().SocketPath().Return("/var/run/docker.sock").AnyTimes()
+	mockRT.EXPECT().IsHealthy(gomock.Any()).Return(nil)
+	mockRT.EXPECT().IsRunning(gomock.Any(), "localstack-aws").Return(true, nil)
+	mockRT.EXPECT().GetBoundPort(gomock.Any(), "localstack-aws", "4566/tcp").Return("4566", nil)
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	err := Run(context.Background(), mockRT, fakeEmulatorClient{version: "4.14.1"}, sink, Options{
+		Config: ConfigState{
+			Path:   "/tmp/config.toml",
+			Exists: true,
+			Loaded: true,
+		},
+		Containers: []config.ContainerConfig{{
+			Type: config.EmulatorAWS,
+			Port: "4566",
+		}},
+		EnvAuthToken: "test-token",
+		Logger:       log.Nop(),
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "LocalStack AWS Emulator")
+	assert.Contains(t, out.String(), "4.14.1")
+	assert.Contains(t, out.String(), "Doctor found no issues")
+}
+
+func TestDockerRowReportsTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().SocketPath().Return("/var/run/docker.sock").AnyTimes()
+	mockRT.EXPECT().IsHealthy(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	result, ready := dockerRow(ctx, mockRT, nil)
+
+	require.False(t, ready)
+	assert.Equal(t, statusFail, result.status)
+	assert.Contains(t, result.detail, "timed out")
+}
+
+func TestEmulatorRowsPreserveConfiguredOrder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsRunning(gomock.Any(), "localstack-aws").DoAndReturn(func(context.Context, string) (bool, error) {
+		time.Sleep(25 * time.Millisecond)
+		return true, nil
+	})
+	mockRT.EXPECT().IsRunning(gomock.Any(), "localstack-snowflake").Return(true, nil)
+	mockRT.EXPECT().GetBoundPort(gomock.Any(), "localstack-aws", "4566/tcp").Return("4566", nil)
+
+	rows := emulatorRows(context.Background(), mockRT, fakeEmulatorClient{
+		fetchVersion: func(ctx context.Context, host string) (string, error) {
+			if host != "localhost.localstack.cloud:4566" {
+				return "", errors.New("unexpected host")
+			}
+			return "4.14.1", nil
+		},
+	}, []config.ContainerConfig{
+		{Type: config.EmulatorAWS, Port: "4566"},
+		{Type: config.EmulatorSnowflake, Port: "4570"},
+	}, "", true)
+
+	require.Len(t, rows, 3)
+	assert.Equal(t, "LocalStack AWS Emulator", rows[0].check)
+	assert.Equal(t, "LocalStack AWS Emulator health", rows[1].check)
+	assert.Equal(t, "LocalStack Snowflake Emulator", rows[2].check)
+}
+
+func TestRunReportsProgressMessages(t *testing.T) {
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	err := Run(context.Background(), nil, nil, sink, Options{
+		Config: ConfigState{Path: "/tmp/config.toml", Exists: false},
+		Logger: log.Nop(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, out.String(), "Checking configuration")
+	assert.Contains(t, out.String(), "Checking Docker runtime")
+	assert.Contains(t, out.String(), "Checking authentication")
+}

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -6,6 +6,13 @@ import (
 	"time"
 )
 
+const (
+	ansiGreen  = "\x1b[32m"
+	ansiYellow = "\x1b[33m"
+	ansiRed    = "\x1b[31m"
+	ansiReset  = "\x1b[0m"
+)
+
 // FormatEventLine converts an output event into a single display line.
 func FormatEventLine(event any) (string, bool) {
 	switch e := event.(type) {
@@ -194,6 +201,10 @@ func formatTable(e TableEvent) (string, bool) {
 }
 
 func formatTableWidth(e TableEvent, totalWidth int) string {
+	return formatTableWidthStyled(e, totalWidth, false)
+}
+
+func formatTableWidthStyled(e TableEvent, totalWidth int, colorizeStatus bool) string {
 	ncols := len(e.Headers)
 	if ncols == 0 {
 		return ""
@@ -239,6 +250,7 @@ func formatTableWidth(e TableEvent, totalWidth int) string {
 	}
 
 	var sb strings.Builder
+	statusCol := statusColumnIndex(e.Headers)
 	writeRow := func(cols []string) {
 		sb.WriteString("  ")
 		for i := range ncols {
@@ -247,7 +259,11 @@ func formatTableWidth(e TableEvent, totalWidth int) string {
 				cell = cols[i]
 			}
 			val := truncate(cell, widths[i])
-			sb.WriteString(val)
+			renderedVal := val
+			if colorizeStatus && i == statusCol {
+				renderedVal = colorizeStatusANSI(val)
+			}
+			sb.WriteString(renderedVal)
 			if i < ncols-1 {
 				padding := widths[i] - displayWidth(val) + 2
 				for range padding {
@@ -266,4 +282,26 @@ func formatTableWidth(e TableEvent, totalWidth int) string {
 		writeRow(row)
 	}
 	return sb.String()
+}
+
+func statusColumnIndex(headers []string) int {
+	for i, h := range headers {
+		if strings.EqualFold(strings.TrimSpace(h), "status") {
+			return i
+		}
+	}
+	return -1
+}
+
+func colorizeStatusANSI(status string) string {
+	switch strings.TrimSpace(status) {
+	case "OK":
+		return ansiGreen + status + ansiReset
+	case "WARN":
+		return ansiYellow + status + ansiReset
+	case "FAIL":
+		return ansiRed + status + ansiReset
+	default:
+		return status
+	}
 }

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	ansiGreen  = "\x1b[32m"
+	ansiGreen  = "\x1b[38;2;95;215;0m"
 	ansiYellow = "\x1b[33m"
 	ansiRed    = "\x1b[31m"
 	ansiReset  = "\x1b[0m"

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -237,3 +237,27 @@ func TestFormatTableWidth(t *testing.T) {
 		}
 	})
 }
+
+func TestFormatTableWidthStyledColorsStatusColumn(t *testing.T) {
+	t.Parallel()
+
+	got := formatTableWidthStyled(TableEvent{
+		Headers: []string{"Check", "Status", "Detail"},
+		Rows: [][]string{
+			{"Config file", "OK", "/tmp/config.toml"},
+			{"Docker runtime", "WARN", "Not available"},
+			{"Health", "FAIL", "Timed out"},
+		},
+	}, 120, true)
+
+	assertContains := func(t *testing.T, s, want string) {
+		t.Helper()
+		if !strings.Contains(s, want) {
+			t.Fatalf("expected %q to contain %q", s, want)
+		}
+	}
+
+	assertContains(t, got, ansiGreen+"OK"+ansiReset)
+	assertContains(t, got, ansiYellow+"WARN"+ansiReset)
+	assertContains(t, got, ansiRed+"FAIL"+ansiReset)
+}

--- a/internal/output/plain_sink.go
+++ b/internal/output/plain_sink.go
@@ -30,10 +30,22 @@ func (s *PlainSink) setErr(err error) {
 }
 
 func (s *PlainSink) emit(event any) {
-	line, ok := FormatEventLine(event)
+	line, ok := s.formatEvent(event)
 	if !ok {
 		return
 	}
 	_, err := fmt.Fprintln(s.out, line)
 	s.setErr(err)
+}
+
+func (s *PlainSink) formatEvent(event any) (string, bool) {
+	switch e := event.(type) {
+	case TableEvent:
+		if len(e.Rows) == 0 {
+			return "", false
+		}
+		return formatTableWidthStyled(e, terminalWidthForWriter(s.out), writerSupportsANSI(s.out)), true
+	default:
+		return FormatEventLine(event)
+	}
 }

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -1,16 +1,33 @@
 package output
 
 import (
+	"io"
 	"os"
 
 	"golang.org/x/term"
 )
 
 func terminalWidth() int {
-	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+	return terminalWidthForWriter(os.Stdout)
+}
+
+func terminalWidthForWriter(w io.Writer) int {
+	f, ok := w.(*os.File)
+	if !ok || !term.IsTerminal(int(f.Fd())) {
+		return 0
+	}
+	if w, _, err := term.GetSize(int(f.Fd())); err == nil && w > 0 {
 		return w
 	}
 	return 0
+}
+
+func writerSupportsANSI(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
 }
 
 // truncate clips the string to max runes with a trailing "…" for table cell fitting.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -16,6 +17,8 @@ import (
 )
 
 const maxLines = 200
+
+var statusTokenPattern = regexp.MustCompile(`\b(OK|WARN|FAIL)\b`)
 
 type runDoneMsg struct{}
 
@@ -392,7 +395,7 @@ func (a App) View() string {
 			sb.WriteString(styles.SecondaryMessage.Render(text))
 		} else {
 			text := wrap.HardWrap(line.text, a.width)
-			sb.WriteString(text)
+			sb.WriteString(styleStatusTokens(text))
 		}
 		sb.WriteString("\n")
 	}
@@ -418,4 +421,26 @@ func (a App) View() string {
 
 func (a App) Err() error {
 	return a.err
+}
+
+func styleStatusTokens(text string) string {
+	if !strings.HasPrefix(text, "  ") {
+		return text
+	}
+	if !strings.Contains(text, "OK") && !strings.Contains(text, "WARN") && !strings.Contains(text, "FAIL") {
+		return text
+	}
+
+	return statusTokenPattern.ReplaceAllStringFunc(text, func(token string) string {
+		switch token {
+		case "OK":
+			return styles.Success.Render(token)
+		case "WARN":
+			return styles.Warning.Render(token)
+		case "FAIL":
+			return styles.LogError.Render(token)
+		default:
+			return token
+		}
+	})
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/ui/styles"
 	"github.com/muesli/termenv"
 )
 
@@ -203,6 +204,38 @@ func TestAppMessageEventWrapsOnVisibleWidth(t *testing.T) {
 	}
 	if strings.Contains(view, "backg\nround") {
 		t.Fatalf("expected message to wrap at word boundary, got: %q", view)
+	}
+}
+
+func TestAppTableStatusesAreColored(t *testing.T) {
+	t.Parallel()
+
+	original := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(original) })
+
+	app := NewApp("dev", "", "", nil)
+	app.width = 120
+
+	model, _ := app.Update(output.TableEvent{
+		Headers: []string{"Check", "Status", "Detail"},
+		Rows: [][]string{
+			{"Config file", "OK", "/tmp/config.toml"},
+			{"Docker runtime", "WARN", "Slow response"},
+			{"Health", "FAIL", "Timed out"},
+		},
+	})
+	app = model.(App)
+
+	view := app.View()
+	if !strings.Contains(view, styles.Success.Render("OK")) {
+		t.Fatalf("expected OK status to be colored, got: %q", view)
+	}
+	if !strings.Contains(view, styles.Warning.Render("WARN")) {
+		t.Fatalf("expected WARN status to be colored, got: %q", view)
+	}
+	if !strings.Contains(view, styles.LogError.Render("FAIL")) {
+		t.Fatalf("expected FAIL status to be colored, got: %q", view)
 	}
 }
 

--- a/internal/ui/run_doctor.go
+++ b/internal/ui/run_doctor.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/localstack/lstk/internal/doctor"
+	"github.com/localstack/lstk/internal/emulator"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+const doctorUIRunTimeout = 45 * time.Second
+
+func RunDoctor(parentCtx context.Context, rt runtime.Runtime, emulatorClient emulator.Client, opts doctor.Options) error {
+	ctx, cancel := context.WithTimeout(parentCtx, doctorUIRunTimeout)
+	defer cancel()
+
+	app := NewApp("", "", "", cancel, withoutHeader())
+	p := tea.NewProgram(app, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
+	runErrCh := make(chan error, 1)
+	timeoutErr := fmt.Errorf("diagnostic checks timed out after %s", doctorUIRunTimeout)
+
+	go func() {
+		err := doctor.Run(ctx, rt, emulatorClient, output.NewTUISink(programSender{p: p}), opts)
+		if err != nil && !errors.Is(err, context.Canceled) && ctx.Err() == nil {
+			p.Send(runErrMsg{err: err})
+		} else if ctx.Err() == nil {
+			p.Send(runDoneMsg{})
+		}
+		runErrCh <- err
+	}()
+
+	go func() {
+		<-ctx.Done()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			p.Send(runErrMsg{err: timeoutErr})
+		}
+	}()
+
+	model, err := p.Run()
+	if err != nil {
+		return err
+	}
+
+	if app, ok := model.(App); ok && app.Err() != nil {
+		return output.NewSilentError(app.Err())
+	}
+
+	select {
+	case runErr := <-runErrCh:
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return output.NewSilentError(timeoutErr)
+		}
+		if runErr != nil && !errors.Is(runErr, context.Canceled) {
+			return runErr
+		}
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return output.NewSilentError(timeoutErr)
+		}
+		return ctx.Err()
+	}
+
+	return nil
+}

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -8,7 +8,7 @@ const (
 	NimboDarkColor  = "#3F51C7"
 	NimboMidColor   = "#5E6AD2"
 	NimboLightColor = "#7E88EC"
-	SuccessColor    = "#22C55E"
+	SuccessColor    = "#5FD700"
 )
 
 var (

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -8,7 +8,7 @@ const (
 	NimboDarkColor  = "#3F51C7"
 	NimboMidColor   = "#5E6AD2"
 	NimboLightColor = "#7E88EC"
-	SuccessColor    = "#B7C95C"
+	SuccessColor    = "#22C55E"
 )
 
 var (

--- a/internal/ui/styles/styles_test.go
+++ b/internal/ui/styles/styles_test.go
@@ -14,7 +14,7 @@ func TestNimboColorConstants(t *testing.T) {
 	if NimboLightColor != "#7E88EC" {
 		t.Fatalf("unexpected NimboLightColor: %s", NimboLightColor)
 	}
-	if SuccessColor != "#22C55E" {
+	if SuccessColor != "#5FD700" {
 		t.Fatalf("unexpected SuccessColor: %s", SuccessColor)
 	}
 }

--- a/internal/ui/styles/styles_test.go
+++ b/internal/ui/styles/styles_test.go
@@ -14,4 +14,7 @@ func TestNimboColorConstants(t *testing.T) {
 	if NimboLightColor != "#7E88EC" {
 		t.Fatalf("unexpected NimboLightColor: %s", NimboLightColor)
 	}
+	if SuccessColor != "#22C55E" {
+		t.Fatalf("unexpected SuccessColor: %s", SuccessColor)
+	}
 }

--- a/test/integration/doctor_test.go
+++ b/test/integration/doctor_test.go
@@ -1,0 +1,117 @@
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoctorCommandFailsWhenDockerUnavailable(t *testing.T) {
+	analyticsSrv, events := mockAnalyticsServer(t)
+	environ := append(env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "DOCKER_HOST=unix:///no/such/docker.sock")
+
+	stdout, stderr, err := runLstk(t, testContext(t), "", environ, "doctor")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+	assert.Empty(t, stderr)
+	assert.Contains(t, stdout, "Docker runtime")
+	assert.Contains(t, stdout, "FAIL")
+	assert.Contains(t, stdout, "cannot connect to Docker daemon")
+	assertCommandTelemetry(t, events, "doctor", 1)
+}
+
+func TestDoctorCommandFailsWhenConfigInvalid(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte("[[containers]]\ntype = \"aws\"\n"), 0644))
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+	environ := append(env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "DOCKER_HOST=unix:///no/such/docker.sock")
+
+	stdout, stderr, err := runLstk(t, testContext(t), "", environ, "--config", configFile, "doctor")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+	assert.Empty(t, stderr)
+	assert.Contains(t, stdout, "Config file")
+	assert.Contains(t, stdout, "port is required")
+	assertCommandTelemetry(t, events, "doctor", 1)
+}
+
+func TestDoctorCommandDoesNotCreateConfigFile(t *testing.T) {
+	tmpHome := t.TempDir()
+	workDir := t.TempDir()
+	xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
+	expectedConfigFile := filepath.Join(expectedOSConfigDir(tmpHome, xdgOverride), "config.toml")
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+	environ := env.Environ(append(testEnvWithHome(tmpHome, xdgOverride), "DOCKER_HOST=unix:///no/such/docker.sock")).
+		With(env.AnalyticsEndpoint, analyticsSrv.URL)
+
+	stdout, stderr, err := runLstk(t, testContext(t), workDir, environ, "doctor")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+	assert.Empty(t, stderr)
+	assert.Contains(t, stdout, "doctor is read-only and will not create it")
+	assert.NoFileExists(t, expectedConfigFile)
+	assertCommandTelemetry(t, events, "doctor", 1)
+}
+
+func TestDoctorCommandWarnsWhenEmulatorNotRunning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	writeConfigFile(t, configFile)
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, stderr, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "--config", configFile, "doctor")
+	require.NoError(t, err, stderr)
+	requireExitCode(t, 0, err)
+	assert.Contains(t, stdout, "is not running")
+	assert.Contains(t, stdout, "Doctor completed with warnings")
+	assertCommandTelemetry(t, events, "doctor", 0)
+}
+
+func TestDoctorCommandShowsRunningEmulatorHealth(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_localstack/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"version": "4.14.1", "services": {}}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	writeConfigFile(t, configFile)
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	environ := env.With(env.AnalyticsEndpoint, analyticsSrv.URL).
+		With(env.LocalStackHost, host).
+		With(env.AuthToken, "test-token")
+
+	stdout, stderr, err := runLstk(t, ctx, "", environ, "--config", configFile, "doctor")
+	require.NoError(t, err, stderr)
+	requireExitCode(t, 0, err)
+	assert.Contains(t, stdout, "LocalStack AWS Emulator")
+	assert.Contains(t, stdout, "version 4.14.1")
+	assertCommandTelemetry(t, events, "doctor", 0)
+}


### PR DESCRIPTION
## Motivation

Users need a read-only way to diagnose config, Docker, auth, and emulator connectivity from the CLI.

## Changes

- add a new `lstk doctor` command with read-only config, Docker, auth, and emulator checks
- add timeout handling, per-check limits, concurrent emulator checks, and TUI support
- add unit and integration coverage for doctor success, warning, and failure scenarios

## Tests

- `go test ./cmd/... ./internal/...`
- `cd test/integration && LSTK_KEYRING=file go test -count=1 -run TestDoctor ./...`