### PR TITLE
Enable Snowflake emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ test:
 test-integration: $(BUILD_DIR)/$(BINARY_NAME)
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
 	if [ "$$(uname)" = "Darwin" ]; then \
-		cd test/integration && LSTK_KEYRING=file go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 $(if $(RUN),-run $(RUN)) ./...; \
+		cd test/integration && LSTK_KEYRING=file go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 -timeout 15m $(if $(RUN),-run $(RUN)) ./...; \
 	else \
-		cd test/integration && go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 $(if $(RUN),-run $(RUN)) ./...; \
+		cd test/integration && go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 -timeout 15m $(if $(RUN),-run $(RUN)) ./...; \
 	fi
 
 otel:

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -14,7 +14,7 @@ func newSetupCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
 		Short: "Set up emulator CLI integration",
-		Long:  "Set up emulator CLI integration (e.g., AWS, Snowflake, Azure). Currently only AWS is supported.",
+		Long:  "Set up emulator CLI integration. Currently only AWS is supported.",
 	}
 	cmd.AddCommand(newSetupAWSCmd(cfg, tel))
 	return cmd

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -67,27 +67,9 @@ type MachineInfo struct {
 	PlatformRelease string `json:"platform_release,omitempty"`
 }
 
-type LicenseProductEntry struct {
-	Name string `json:"name"`
-}
-
 type LicenseResponse struct {
-	LicenseType string                `json:"license_type"`
-	Products    []LicenseProductEntry `json:"products"`
-	RawBytes    json.RawMessage       `json:"-"`
-}
-
-// HasProduct reports whether the license response includes a product with the given name.
-func (r *LicenseResponse) HasProduct(name string) bool {
-	if r == nil {
-		return false
-	}
-	for _, p := range r.Products {
-		if p.Name == name {
-			return true
-		}
-	}
-	return false
+	LicenseType string          `json:"license_type"`
+	RawBytes    json.RawMessage `json:"-"`
 }
 
 var planDisplayNames = map[string]string{

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -67,9 +67,27 @@ type MachineInfo struct {
 	PlatformRelease string `json:"platform_release,omitempty"`
 }
 
+type LicenseProductEntry struct {
+	Name string `json:"name"`
+}
+
 type LicenseResponse struct {
-	LicenseType string          `json:"license_type"`
-	RawBytes    json.RawMessage `json:"-"`
+	LicenseType string                `json:"license_type"`
+	Products    []LicenseProductEntry `json:"products"`
+	RawBytes    json.RawMessage       `json:"-"`
+}
+
+// HasProduct reports whether the license response includes a product with the given name.
+func (r *LicenseResponse) HasProduct(name string) bool {
+	if r == nil {
+		return false
+	}
+	for _, p := range r.Products {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 var planDisplayNames = map[string]string{

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -17,6 +17,10 @@ const (
 
 	DefaultAWSPort = "4566"
 	dockerRegistry = "localstack"
+
+	// SnowflakeAddonProduct is the product name returned in license responses when the
+	// subscription includes the Snowflake emulator add-on.
+	SnowflakeAddonProduct = "localstack.snowflake"
 )
 
 var emulatorDisplayNames = map[EmulatorType]string{
@@ -26,11 +30,20 @@ var emulatorDisplayNames = map[EmulatorType]string{
 }
 
 var emulatorImages = map[EmulatorType]string{
-	EmulatorAWS: "localstack-pro",
+	EmulatorAWS:       "localstack-pro",
+	EmulatorSnowflake: "snowflake",
+}
+
+// emulatorLicenseProductNames maps emulator types to the product name used in license requests.
+// Snowflake is an add-on to localstack-pro, so it shares the same license product name.
+var emulatorLicenseProductNames = map[EmulatorType]string{
+	EmulatorAWS:       "localstack-pro",
+	EmulatorSnowflake: "localstack-pro",
 }
 
 var emulatorHealthPaths = map[EmulatorType]string{
-	EmulatorAWS: "/_localstack/health",
+	EmulatorAWS:       "/_localstack/health",
+	EmulatorSnowflake: "/_localstack/health",
 }
 
 type ContainerConfig struct {
@@ -117,7 +130,7 @@ func (c *ContainerConfig) HealthPath() (string, error) {
 
 func (c *ContainerConfig) ContainerPort() (string, error) {
 	switch c.Type {
-	case EmulatorAWS:
+	case EmulatorAWS, EmulatorSnowflake:
 		return DefaultAWSPort + "/tcp", nil
 	default:
 		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
@@ -139,3 +152,14 @@ func (c *ContainerConfig) ProductName() (string, error) {
 	}
 	return productName, nil
 }
+
+// LicenseProductName returns the product name to use in license API requests.
+// This differs from ProductName for emulators like Snowflake that are add-ons to localstack-pro.
+func (c *ContainerConfig) LicenseProductName() (string, error) {
+	name, ok := emulatorLicenseProductNames[c.Type]
+	if !ok {
+		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
+	}
+	return name, nil
+}
+

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -17,10 +17,6 @@ const (
 
 	DefaultAWSPort = "4566"
 	dockerRegistry = "localstack"
-
-	// SnowflakeAddonProduct is the product name returned in license responses when the
-	// subscription includes the Snowflake emulator add-on.
-	SnowflakeAddonProduct = "localstack.snowflake"
 )
 
 var emulatorDisplayNames = map[EmulatorType]string{
@@ -32,13 +28,6 @@ var emulatorDisplayNames = map[EmulatorType]string{
 var emulatorImages = map[EmulatorType]string{
 	EmulatorAWS:       "localstack-pro",
 	EmulatorSnowflake: "snowflake",
-}
-
-// emulatorLicenseProductNames maps emulator types to the product name used in license requests.
-// Snowflake is an add-on to localstack-pro, so it shares the same license product name.
-var emulatorLicenseProductNames = map[EmulatorType]string{
-	EmulatorAWS:       "localstack-pro",
-	EmulatorSnowflake: "localstack-pro",
 }
 
 var emulatorHealthPaths = map[EmulatorType]string{
@@ -151,15 +140,5 @@ func (c *ContainerConfig) ProductName() (string, error) {
 		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
 	}
 	return productName, nil
-}
-
-// LicenseProductName returns the product name to use in license API requests.
-// This differs from ProductName for emulators like Snowflake that are add-ons to localstack-pro.
-func (c *ContainerConfig) LicenseProductName() (string, error) {
-	name, ok := emulatorLicenseProductNames[c.Type]
-	if !ok {
-		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
-	}
-	return name, nil
 }
 

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -12,12 +12,6 @@ port = "4566"    # Host port the emulator will be accessible on
 # volume = ""    # Host directory for persistent state (default: OS cache dir)
 # env = []       # Named environment profiles to apply (see [env.*] sections below)
 
-# To use the Snowflake emulator instead, comment out the AWS block above and uncomment this one.
-# [[containers]]
-# type = "snowflake"
-# tag  = "latest"
-# port = "4566"
-
 # Environment profiles let you group environment variables and reference
 # them by name in one or more containers via the 'env' field above.
 #

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -2,7 +2,9 @@
 # Run 'lstk config path' to see where this file lives.
 
 # Each [[containers]] block defines an emulator instance.
-# You can define multiple to run them side by side.
+# Currently, running AWS and Snowflake at the same time is not fully supported —
+# enable only one [[containers]] block at a time.
+
 [[containers]]
 type = "aws"     # Emulator type. Currently supported: "aws", "snowflake"
 tag  = "latest"  # Docker image tag, e.g. "latest", "2026.03"
@@ -10,13 +12,11 @@ port = "4566"    # Host port the emulator will be accessible on
 # volume = ""    # Host directory for persistent state (default: OS cache dir)
 # env = []       # Named environment profiles to apply (see [env.*] sections below)
 
-# Example: add a Snowflake emulator.
-# Snowflake listens on port 4566 inside the container, same as AWS,
-# so use a different host port when running both at the same time.
+# To use the Snowflake emulator instead, comment out the AWS block above and uncomment this one.
 # [[containers]]
 # type = "snowflake"
 # tag  = "latest"
-# port = "4567"
+# port = "4566"
 
 # Environment profiles let you group environment variables and reference
 # them by name in one or more containers via the 'env' field above.

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -4,11 +4,19 @@
 # Each [[containers]] block defines an emulator instance.
 # You can define multiple to run them side by side.
 [[containers]]
-type = "aws"     # Emulator type. Currently supported: "aws"
+type = "aws"     # Emulator type. Currently supported: "aws", "snowflake"
 tag  = "latest"  # Docker image tag, e.g. "latest", "2026.03"
 port = "4566"    # Host port the emulator will be accessible on
 # volume = ""    # Host directory for persistent state (default: OS cache dir)
 # env = []       # Named environment profiles to apply (see [env.*] sections below)
+
+# Example: add a Snowflake emulator.
+# Snowflake listens on port 4566 inside the container, same as AWS,
+# so use a different host port when running both at the same time.
+# [[containers]]
+# type = "snowflake"
+# tag  = "latest"
+# port = "4567"
 
 # Environment profiles let you group environment variables and reference
 # them by name in one or more containers via the 'env' field above.

--- a/internal/container/label.go
+++ b/internal/container/label.go
@@ -24,13 +24,17 @@ func ResolveEmulatorLabel(ctx context.Context, client api.PlatformAPI, container
 
 	c := containers[0]
 
-	productName, err := c.ProductName()
+	licenseProductName, err := c.LicenseProductName()
 	if err != nil {
 		return NoLicenseLabel, false
 	}
 
 	tag := c.Tag
 	if tag == "" || tag == "latest" {
+		// Platform catalog API does not support Snowflake yet; skip the header label lookup.
+		if c.Type == config.EmulatorSnowflake {
+			return NoLicenseLabel, false
+		}
 		apiCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		v, err := client.GetLatestCatalogVersion(apiCtx, string(c.Type))
 		cancel()
@@ -43,7 +47,7 @@ func ResolveEmulatorLabel(ctx context.Context, client api.PlatformAPI, container
 
 	hostname, _ := os.Hostname()
 	licReq := &api.LicenseRequest{
-		Product:     api.ProductInfo{Name: productName, Version: tag},
+		Product:     api.ProductInfo{Name: licenseProductName, Version: tag},
 		Credentials: api.CredentialsInfo{Token: token},
 		Machine:     api.MachineInfo{Hostname: hostname, Platform: stdruntime.GOOS, PlatformRelease: stdruntime.GOARCH},
 	}

--- a/internal/container/label.go
+++ b/internal/container/label.go
@@ -31,9 +31,8 @@ func ResolveEmulatorLabel(ctx context.Context, client api.PlatformAPI, container
 
 	tag := c.Tag
 	if tag == "" || tag == "latest" {
-		// Platform catalog API does not support Snowflake yet; skip the header label lookup.
 		if c.Type == config.EmulatorSnowflake {
-			return NoLicenseLabel, false
+			return "LocalStack Snowflake", false
 		}
 		apiCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		v, err := client.GetLatestCatalogVersion(apiCtx, string(c.Type))

--- a/internal/container/label.go
+++ b/internal/container/label.go
@@ -32,7 +32,7 @@ func ResolveEmulatorLabel(ctx context.Context, client api.PlatformAPI, container
 	tag := c.Tag
 	if tag == "" || tag == "latest" {
 		if c.Type == config.EmulatorSnowflake {
-			return "LocalStack Snowflake", false
+			return "LocalStack", false
 		}
 		apiCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		v, err := client.GetLatestCatalogVersion(apiCtx, string(c.Type))

--- a/internal/container/label.go
+++ b/internal/container/label.go
@@ -24,7 +24,7 @@ func ResolveEmulatorLabel(ctx context.Context, client api.PlatformAPI, container
 
 	c := containers[0]
 
-	licenseProductName, err := c.LicenseProductName()
+	productName, err := c.ProductName()
 	if err != nil {
 		return NoLicenseLabel, false
 	}
@@ -46,7 +46,7 @@ func ResolveEmulatorLabel(ctx context.Context, client api.PlatformAPI, container
 
 	hostname, _ := os.Hostname()
 	licReq := &api.LicenseRequest{
-		Product:     api.ProductInfo{Name: licenseProductName, Version: tag},
+		Product:     api.ProductInfo{Name: productName, Version: tag},
 		Credentials: api.CredentialsInfo{Token: token},
 		Machine:     api.MachineInfo{Hostname: hostname, Platform: stdruntime.GOOS, PlatformRelease: stdruntime.GOARCH},
 	}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -235,22 +235,24 @@ func runPostStartSetups(ctx context.Context, sink output.Sink, containers []conf
 			if err := setup(ctx, sink, interactive, resolvedHost); err != nil {
 				return err
 			}
-			emitPostStartPointers(sink, resolvedHost, webAppURL)
+			emitPostStartPointers(sink, resolvedHost, webAppURL, true)
 		}
 	}
 	return nil
 }
 
-func emitPostStartPointers(sink output.Sink, resolvedHost, webAppURL string) {
+func emitPostStartPointers(sink output.Sink, resolvedHost, webAppURL string, showTip bool) {
 	output.EmitSecondary(sink, fmt.Sprintf("• Endpoint: %s", resolvedHost))
 	if webAppURL != "" {
 		output.EmitSecondary(sink, fmt.Sprintf("• Web app: %s", strings.TrimRight(webAppURL, "/")))
 	}
-	tips := []string{
-		"> Tip: View emulator logs: lstk logs --follow",
-		"> Tip: View deployed resources: lstk status",
+	if showTip {
+		tips := []string{
+			"> Tip: View emulator logs: lstk logs --follow",
+			"> Tip: View deployed resources: lstk status",
+		}
+		output.EmitSecondary(sink, tips[rand.IntN(len(tips))])
 	}
-	output.EmitSecondary(sink, tips[rand.IntN(len(tips))])
 }
 
 func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *telemetry.Client, containers []runtime.ContainerConfig) (map[string]bool, error) {
@@ -377,7 +379,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			if !dnsOK {
 				output.EmitNote(sink, endpoint.DNSRebindNote)
 			}
-			emitPostStartPointers(sink, resolvedHost, webAppURL)
+			emitPostStartPointers(sink, resolvedHost, webAppURL, c.EmulatorType == string(config.EmulatorAWS))
 			continue
 		}
 

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -114,11 +114,6 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			return err
 		}
 
-		licenseProductName, err := c.LicenseProductName()
-		if err != nil {
-			return err
-		}
-
 		containerPort, err := c.ContainerPort()
 		if err != nil {
 			return err
@@ -162,9 +157,8 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			HealthPath:         healthPath,
 			Env:                env,
 			Tag:                c.Tag,
-			ProductName:        productName,
-			LicenseProductName: licenseProductName,
-			Binds:              binds,
+			ProductName: productName,
+			Binds:       binds,
 			ExtraPorts:         servicePortRange(),
 		}
 	}
@@ -473,7 +467,7 @@ func validateLicense(ctx context.Context, sink output.Sink, opts StartOptions, t
 	hostname, _ := os.Hostname()
 	licenseReq := &api.LicenseRequest{
 		Product: api.ProductInfo{
-			Name:    containerConfig.LicenseProductName,
+			Name:    containerConfig.ProductName,
 			Version: version,
 		},
 		Credentials: api.CredentialsInfo{
@@ -494,17 +488,6 @@ func validateLicense(ctx context.Context, sink output.Sink, opts StartOptions, t
 		}
 		emitEmulatorStartError(ctx, tel, containerConfig, telemetry.ErrCodeLicenseInvalid, err.Error())
 		return fmt.Errorf("license validation failed for %s:%s: %w", containerConfig.ProductName, version, err)
-	}
-
-	if containerConfig.EmulatorType == string(config.EmulatorSnowflake) {
-		if !licenseResp.HasProduct(config.SnowflakeAddonProduct) {
-			licErr := &api.LicenseError{
-				Status:  http.StatusForbidden,
-				Message: "your subscription does not include the Snowflake emulator",
-			}
-			emitEmulatorStartError(ctx, tel, containerConfig, telemetry.ErrCodeLicenseInvalid, licErr.Error())
-			return fmt.Errorf("license validation failed for %s:%s: %w", containerConfig.ProductName, version, licErr)
-		}
 	}
 
 	if licenseResp != nil && len(licenseResp.RawBytes) > 0 {

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -297,16 +297,14 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *
 func tryPrePullLicenseValidation(ctx context.Context, sink output.Sink, opts StartOptions, tel *telemetry.Client, containers []runtime.ContainerConfig, token, licenseFilePath string) ([]runtime.ContainerConfig, error) {
 	var needsPostPull []runtime.ContainerConfig
 	for _, c := range containers {
+		if c.EmulatorType == string(config.EmulatorSnowflake) {
+			continue
+		}
+
 		if c.Tag != "" && c.Tag != "latest" {
 			if err := validateLicense(ctx, sink, opts, tel, c, token, licenseFilePath); err != nil {
 				return nil, err
 			}
-			continue
-		}
-
-		// Platform catalog API does not support Snowflake yet; fall through to post-pull image inspection.
-		if c.EmulatorType == string(config.EmulatorSnowflake) {
-			needsPostPull = append(needsPostPull, c)
 			continue
 		}
 
@@ -331,6 +329,10 @@ func tryPrePullLicenseValidation(ctx context.Context, sink output.Sink, opts Sta
 // Fallback path: inspects each pulled image for its version, then validates the license.
 func validateLicensesFromImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, tel *telemetry.Client, containers []runtime.ContainerConfig, token, licenseFilePath string) error {
 	for _, c := range containers {
+		if c.EmulatorType == string(config.EmulatorSnowflake) {
+			continue
+		}
+
 		v, err := rt.GetImageVersion(ctx, c.Image)
 		if err != nil {
 			return fmt.Errorf("could not resolve version from image %s: %w", c.Image, err)

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -114,6 +114,11 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			return err
 		}
 
+		licenseProductName, err := c.LicenseProductName()
+		if err != nil {
+			return err
+		}
+
 		containerPort, err := c.ContainerPort()
 		if err != nil {
 			return err
@@ -149,17 +154,18 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		binds = append(binds, runtime.BindMount{HostPath: volumeDir, ContainerPath: "/var/lib/localstack"})
 
 		containers[i] = runtime.ContainerConfig{
-			Image:         image,
-			Name:          containerName,
-			EmulatorType:  string(c.Type),
-			Port:          c.Port,
-			ContainerPort: containerPort,
-			HealthPath:    healthPath,
-			Env:           env,
-			Tag:           c.Tag,
-			ProductName:   productName,
-			Binds:         binds,
-			ExtraPorts:    servicePortRange(),
+			Image:              image,
+			Name:               containerName,
+			EmulatorType:       string(c.Type),
+			Port:               c.Port,
+			ContainerPort:      containerPort,
+			HealthPath:         healthPath,
+			Env:                env,
+			Tag:                c.Tag,
+			ProductName:        productName,
+			LicenseProductName: licenseProductName,
+			Binds:              binds,
+			ExtraPorts:         servicePortRange(),
 		}
 	}
 
@@ -295,6 +301,12 @@ func tryPrePullLicenseValidation(ctx context.Context, sink output.Sink, opts Sta
 			if err := validateLicense(ctx, sink, opts, tel, c, token, licenseFilePath); err != nil {
 				return nil, err
 			}
+			continue
+		}
+
+		// Platform catalog API does not support Snowflake yet; fall through to post-pull image inspection.
+		if c.EmulatorType == string(config.EmulatorSnowflake) {
+			needsPostPull = append(needsPostPull, c)
 			continue
 		}
 
@@ -459,7 +471,7 @@ func validateLicense(ctx context.Context, sink output.Sink, opts StartOptions, t
 	hostname, _ := os.Hostname()
 	licenseReq := &api.LicenseRequest{
 		Product: api.ProductInfo{
-			Name:    containerConfig.ProductName,
+			Name:    containerConfig.LicenseProductName,
 			Version: version,
 		},
 		Credentials: api.CredentialsInfo{
@@ -480,6 +492,17 @@ func validateLicense(ctx context.Context, sink output.Sink, opts StartOptions, t
 		}
 		emitEmulatorStartError(ctx, tel, containerConfig, telemetry.ErrCodeLicenseInvalid, err.Error())
 		return fmt.Errorf("license validation failed for %s:%s: %w", containerConfig.ProductName, version, err)
+	}
+
+	if containerConfig.EmulatorType == string(config.EmulatorSnowflake) {
+		if !licenseResp.HasProduct(config.SnowflakeAddonProduct) {
+			licErr := &api.LicenseError{
+				Status:  http.StatusForbidden,
+				Message: "your subscription does not include the Snowflake emulator",
+			}
+			emitEmulatorStartError(ctx, tel, containerConfig, telemetry.ErrCodeLicenseInvalid, licErr.Error())
+			return fmt.Errorf("license validation failed for %s:%s: %w", containerConfig.ProductName, version, licErr)
+		}
 	}
 
 	if licenseResp != nil && len(licenseResp.RawBytes) > 0 {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -36,7 +36,7 @@ func TestEmitPostStartPointers_WithWebApp(t *testing.T) {
 	var out bytes.Buffer
 	sink := output.NewPlainSink(&out)
 
-	emitPostStartPointers(sink, "localhost.localstack.cloud:4566", "https://app.localstack.cloud/")
+	emitPostStartPointers(sink, "localhost.localstack.cloud:4566", "https://app.localstack.cloud/", true)
 
 	got := out.String()
 	assert.Contains(t, got, "• Endpoint: localhost.localstack.cloud:4566\n")
@@ -48,7 +48,7 @@ func TestEmitPostStartPointers_WithoutWebApp(t *testing.T) {
 	var out bytes.Buffer
 	sink := output.NewPlainSink(&out)
 
-	emitPostStartPointers(sink, "127.0.0.1:4566", "")
+	emitPostStartPointers(sink, "127.0.0.1:4566", "", true)
 
 	got := out.String()
 	assert.Contains(t, got, "• Endpoint: 127.0.0.1:4566\n")
@@ -136,6 +136,18 @@ func TestSelectContainersToStart_QueuesContainerWhenNoneRunningOnPort(t *testing
 
 	require.NoError(t, err)
 	assert.Equal(t, []runtime.ContainerConfig{c}, result, "container should be queued for start")
+}
+
+func TestEmitPostStartPointers_NoTip(t *testing.T) {
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	emitPostStartPointers(sink, "localhost.localstack.cloud:4566", "https://app.localstack.cloud/", false)
+
+	got := out.String()
+	assert.Contains(t, got, "• Endpoint: localhost.localstack.cloud:4566\n")
+	assert.Contains(t, got, "• Web app: https://app.localstack.cloud\n")
+	assert.NotContains(t, got, "> Tip:")
 }
 
 func TestServicePortRange_ReturnsExpectedPorts(t *testing.T) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -23,18 +23,17 @@ type PortMapping struct {
 }
 
 type ContainerConfig struct {
-	Image              string
-	Name               string
-	EmulatorType       string   // e.g., "aws", "snowflake" — used for telemetry
-	Port               string
-	ContainerPort      string   // internal port the emulator listens on inside the container (e.g. "4566/tcp")
-	HealthPath         string
-	Env                []string // e.g., ["KEY=value", "FOO=bar"]
-	Tag                string
-	ProductName        string
-	LicenseProductName string
-	Binds              []BindMount
-	ExtraPorts         []PortMapping
+	Image         string
+	Name          string
+	EmulatorType  string   // e.g., "aws", "snowflake" — used for telemetry
+	Port          string
+	ContainerPort string   // internal port the emulator listens on inside the container (e.g. "4566/tcp")
+	HealthPath    string
+	Env           []string // e.g., ["KEY=value", "FOO=bar"]
+	Tag           string
+	ProductName   string
+	Binds         []BindMount
+	ExtraPorts    []PortMapping
 }
 
 type PullProgress struct {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -23,17 +23,18 @@ type PortMapping struct {
 }
 
 type ContainerConfig struct {
-	Image         string
-	Name          string
-	EmulatorType  string // e.g., "aws", "snowflake" — used for telemetry
-	Port          string
-	ContainerPort string // internal port the emulator listens on inside the container (e.g. "4566/tcp")
-	HealthPath    string
-	Env           []string // e.g., ["KEY=value", "FOO=bar"]
-	Tag           string
-	ProductName   string
-	Binds         []BindMount
-	ExtraPorts    []PortMapping
+	Image              string
+	Name               string
+	EmulatorType       string   // e.g., "aws", "snowflake" — used for telemetry
+	Port               string
+	ContainerPort      string   // internal port the emulator listens on inside the container (e.g. "4566/tcp")
+	HealthPath         string
+	Env                []string // e.g., ["KEY=value", "FOO=bar"]
+	Tag                string
+	ProductName        string
+	LicenseProductName string
+	Binds              []BindMount
+	ExtraPorts         []PortMapping
 }
 
 type PullProgress struct {

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -307,7 +307,7 @@ func createMockLicenseServer(success bool) *httptest.Server {
 			if success {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"license_type":"ultimate","products":[{"name":"localstack.snowflake"}]}`))
+				_, _ = w.Write([]byte(`{"license_type":"ultimate"}`))
 			} else {
 				w.WriteHeader(http.StatusForbidden)
 			}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -307,7 +307,7 @@ func createMockLicenseServer(success bool) *httptest.Server {
 			if success {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"license_type":"ultimate"}`))
+				_, _ = w.Write([]byte(`{"license_type":"ultimate","products":[{"name":"localstack.snowflake"}]}`))
 			} else {
 				w.WriteHeader(http.StatusForbidden)
 			}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -230,6 +230,23 @@ func startExternalContainer(t *testing.T, ctx context.Context, imgName, name, ho
 	})
 }
 
+func startTestSnowflakeContainer(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	reader, err := dockerClient.ImagePull(ctx, testImage, image.PullOptions{})
+	require.NoError(t, err, "failed to pull test image")
+	_, _ = io.Copy(io.Discard, reader)
+	_ = reader.Close()
+
+	resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
+		Image: testImage,
+		Cmd:   []string{"sleep", "infinity"},
+	}, nil, nil, nil, snowflakeContainerName)
+	require.NoError(t, err, "failed to create snowflake test container")
+	err = dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
+	require.NoError(t, err, "failed to start snowflake test container")
+}
+
 func testContext(t *testing.T) context.Context {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -475,7 +475,7 @@ func TestStartCommandSucceedsForSnowflake(t *testing.T) {
 	mockServer := createMockLicenseServer(true)
 	defer mockServer.Close()
 
-	const hostPort = "4567"
+	const hostPort = "4566"
 	configFile := writeSnowflakeConfig(t, hostPort)
 
 	ctx := testContext(t)
@@ -494,5 +494,3 @@ func TestStartCommandSucceedsForSnowflake(t *testing.T) {
 	t.Cleanup(func() { _ = resp.Body.Close() })
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
-
-

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const snowflakeContainerName = "localstack-snowflake"
+
 func TestStartCommandSucceedsWithValidToken(t *testing.T) {
 	requireDocker(t)
 	_ = env.Require(t, env.AuthToken)
@@ -441,3 +443,72 @@ func cleanup() {
 	_ = dockerClient.ContainerRemove(ctx, containerName, container.RemoveOptions{Force: true})
 	_ = DeleteAuthTokenFromKeyring()
 }
+
+func cleanupSnowflake() {
+	ctx := context.Background()
+	_ = dockerClient.ContainerStop(ctx, snowflakeContainerName, container.StopOptions{})
+	_ = dockerClient.ContainerRemove(ctx, snowflakeContainerName, container.RemoveOptions{Force: true})
+}
+
+func writeSnowflakeConfig(t *testing.T, hostPort string) string {
+	t.Helper()
+	content := fmt.Sprintf(`
+[[containers]]
+type = "snowflake"
+tag  = "latest"
+port = %q
+`, hostPort)
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(content), 0644))
+	return configFile
+}
+
+func TestStartCommandSucceedsForSnowflake(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	cleanupSnowflake()
+	t.Cleanup(cleanup)
+	t.Cleanup(cleanupSnowflake)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	const hostPort = "4567"
+	configFile := writeSnowflakeConfig(t, hostPort)
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, snowflakeContainerName)
+	require.NoError(t, err, "failed to inspect snowflake container")
+	require.True(t, inspect.State.Running, "snowflake container should be running")
+	assert.Contains(t, inspect.Config.Image, "localstack/snowflake",
+		"expected localstack/snowflake image, got %s", inspect.Config.Image)
+
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/_localstack/health", hostPort))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestStartCommandFailsForSnowflakeWithoutAddon(t *testing.T) {
+	requireDocker(t)
+	cleanupSnowflake()
+	t.Cleanup(cleanupSnowflake)
+
+	// License response without the Snowflake add-on product.
+	mockServer := createMockLicenseServerWithBody(`{"license_type":"ultimate","products":[]}`)
+	defer mockServer.Close()
+
+	configFile := writeSnowflakeConfig(t, "4567")
+
+	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AuthToken, "fake-token").With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
+	require.Error(t, err, "expected lstk start to fail when Snowflake add-on is not in license")
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "subscription does not include the Snowflake emulator")
+}
+

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -495,20 +495,4 @@ func TestStartCommandSucceedsForSnowflake(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestStartCommandFailsForSnowflakeWithoutAddon(t *testing.T) {
-	requireDocker(t)
-	cleanupSnowflake()
-	t.Cleanup(cleanupSnowflake)
-
-	// License response without the Snowflake add-on product.
-	mockServer := createMockLicenseServerWithBody(`{"license_type":"ultimate","products":[]}`)
-	defer mockServer.Close()
-
-	configFile := writeSnowflakeConfig(t, "4567")
-
-	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AuthToken, "fake-token").With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
-	require.Error(t, err, "expected lstk start to fail when Snowflake add-on is not in license")
-	requireExitCode(t, 1, err)
-	assert.Contains(t, stderr, "subscription does not include the Snowflake emulator")
-}
 

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -463,6 +463,25 @@ port = %q
 	return configFile
 }
 
+func TestStartCommandForSnowflakeSkipsLicenseValidation(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	cleanupSnowflake()
+	t.Cleanup(cleanup)
+	t.Cleanup(cleanupSnowflake)
+
+	// Mock server that rejects all license requests — this would cause lstk start to fail for AWS.
+	mockServer := createMockLicenseServer(false)
+	defer mockServer.Close()
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", writeSnowflakeConfig(t, "4566"), "start")
+	require.NoError(t, err, "lstk start should succeed for snowflake even when the license server rejects the request: %s", stderr)
+	requireExitCode(t, 0, err)
+}
+
 func TestStartCommandSucceedsForSnowflake(t *testing.T) {
 	requireDocker(t)
 	_ = env.Require(t, env.AuthToken)

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -155,6 +155,25 @@ func TestStatusCommandWorksWithExternalContainer(t *testing.T) {
 	assert.Contains(t, stdout, "3.5.0")
 }
 
+func TestStatusCommandForSnowflakeShowsNoResources(t *testing.T) {
+	requireDocker(t)
+	cleanupSnowflake()
+	t.Cleanup(cleanupSnowflake)
+
+	ctx := testContext(t)
+	startTestSnowflakeContainer(t, ctx)
+
+	stdout, stderr, err := runLstk(t, ctx, "", nil, "--config", writeSnowflakeConfig(t, "4566"), "status")
+	require.NoError(t, err, "lstk status failed for snowflake: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	assert.Contains(t, stdout, "Snowflake")
+	assert.Contains(t, stdout, "running")
+	// Snowflake does not expose AWS resources — no resource table or empty-state message.
+	assert.NotContains(t, stdout, "SERVICE")
+	assert.NotContains(t, stdout, "No resources deployed")
+}
+
 func TestStatusCommandShowsNoResourcesWhenEmpty(t *testing.T) {
 	requireDocker(t)
 	cleanup()


### PR DESCRIPTION
Enable support for Snowflake emulator.

ℹ️ Licensing checks are skipped for snowflake at the moment, there are efforts to improve this but not in lstk scope for now. Improvements will be incorporated by lstk when ready on the platform side of the things.

There is going to be follow up PRs to smoothen multi-emulator experience (PRO-198, DRG-381)