### PR TITLE
Add restart command

### DIFF
--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/env"
+	"github.com/localstack/lstk/internal/log"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
+	"github.com/localstack/lstk/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newRestartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
+	return &cobra.Command{
+		Use:     "restart",
+		Short:   "Restart emulator",
+		Long:    "Stop and restart emulator and services.",
+		PreRunE: initConfig,
+		RunE: commandWithTelemetry("restart", tel, func(cmd *cobra.Command, args []string) error {
+			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
+			if err != nil {
+				return err
+			}
+
+			appConfig, err := config.Get()
+			if err != nil {
+				return fmt.Errorf("failed to get config: %w", err)
+			}
+
+			stopOpts := container.StopOptions{
+				Telemetry: tel,
+			}
+			startOpts := buildStartOptions(cfg, appConfig, logger, tel)
+
+			if isInteractiveMode(cfg) {
+				return ui.RunRestart(cmd.Context(), rt, stopOpts, startOpts)
+			}
+
+			sink := output.NewPlainSink(os.Stdout)
+			return container.Restart(cmd.Context(), rt, sink, stopOpts, startOpts, false)
+		}),
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 	root.AddCommand(
 		newStartCmd(cfg, tel, logger),
 		newStopCmd(cfg, tel),
+		newRestartCmd(cfg, tel, logger),
 		newLoginCmd(cfg, tel, logger),
 		newLogoutCmd(cfg, tel, logger),
 		newStatusCmd(cfg, tel),
@@ -104,14 +105,8 @@ func Execute(ctx context.Context) error {
 	return nil
 }
 
-func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {
-
-	appConfig, err := config.Get()
-	if err != nil {
-		return fmt.Errorf("failed to get config: %w", err)
-	}
-
-	opts := container.StartOptions{
+func buildStartOptions(cfg *env.Env, appConfig *config.Config, logger log.Logger, tel *telemetry.Client) container.StartOptions {
+	return container.StartOptions{
 		PlatformClient:   api.NewPlatformClient(cfg.APIEndpoint, logger),
 		AuthToken:        cfg.AuthToken,
 		ForceFileKeyring: cfg.ForceFileKeyring,
@@ -122,6 +117,16 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 		Logger:           logger,
 		Telemetry:        tel,
 	}
+}
+
+func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {
+
+	appConfig, err := config.Get()
+	if err != nil {
+		return fmt.Errorf("failed to get config: %w", err)
+	}
+
+	opts := buildStartOptions(cfg, appConfig, logger, tel)
 
 	notifyOpts := update.NotifyOptions{
 		GitHubToken:    cfg.GitHubToken,

--- a/internal/container/restart.go
+++ b/internal/container/restart.go
@@ -1,0 +1,15 @@
+package container
+
+import (
+	"context"
+
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+func Restart(ctx context.Context, rt runtime.Runtime, sink output.Sink, stopOpts StopOptions, startOpts StartOptions, interactive bool) error {
+	if err := Stop(ctx, rt, sink, startOpts.Containers, stopOpts); err != nil {
+		return err
+	}
+	return Start(ctx, rt, sink, startOpts, interactive)
+}

--- a/internal/ui/run_restart.go
+++ b/internal/ui/run_restart.go
@@ -1,0 +1,15 @@
+package ui
+
+import (
+	"context"
+
+	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+func RunRestart(parentCtx context.Context, rt runtime.Runtime, stopOpts container.StopOptions, startOpts container.StartOptions) error {
+	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
+		return container.Restart(ctx, rt, sink, stopOpts, startOpts, true)
+	})
+}

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -1,0 +1,50 @@
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestartCommandSucceeds(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL).With(env.AnalyticsEndpoint, analyticsSrv.URL), "restart")
+	require.NoError(t, err, "lstk restart failed: %s", stderr)
+	requireExitCode(t, 0, err)
+	assert.Contains(t, stdout, "stopped")
+	assert.Contains(t, stdout, "LocalStack")
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
+	require.NoError(t, err, "failed to inspect container after restart")
+	assert.True(t, inspect.State.Running, "container should be running after restart")
+
+	assertCommandTelemetry(t, events, "restart", 0)
+}
+
+func TestRestartCommandFailsWhenNotRunning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "restart")
+	require.Error(t, err, "expected lstk restart to fail when emulator is not running")
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "is not running")
+	assertCommandTelemetry(t, events, "restart", 1)
+}

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -33,7 +33,16 @@ func TestRestartCommandSucceeds(t *testing.T) {
 	require.NoError(t, err, "failed to inspect container after restart")
 	assert.True(t, inspect.State.Running, "container should be running after restart")
 
-	assertCommandTelemetry(t, events, "restart", 0)
+	// Both lstk_lifecycle (stop + start) and lstk_command events should be emitted.
+	byName := collectTelemetryByName(t, events, 2)
+	assert.Contains(t, byName, "lstk_lifecycle")
+	if cmdEvent, ok := byName["lstk_command"]; assert.True(t, ok, "lstk_command event not received") {
+		payload, _ := cmdEvent["payload"].(map[string]any)
+		params, _ := payload["parameters"].(map[string]any)
+		assert.Equal(t, "restart", params["command"])
+		result, _ := payload["result"].(map[string]any)
+		assert.InDelta(t, 0, result["exit_code"], 0)
+	}
 }
 
 func TestRestartCommandFailsWhenNotRunning(t *testing.T) {


### PR DESCRIPTION
Adds `restart` command that stops the running emulator and starts it again in a single command.

The command runs the full stop and start lifecycle: stops the container, re-validates the auth token and license, pulls the image if needed, and waits for the health endpoint before returning. This ensures restart is always safe (no stale state, no skipped validation) rather than just bouncing the container.

<img width="686" height="290" alt="Screenshot 2026-04-22 at 16 52 24" src="https://github.com/user-attachments/assets/75790939-db26-4d62-a6c1-20850da2b840" />
