### PR TITLE
Test PERSISTENCE env vars

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -536,13 +536,18 @@ func awaitStartup(ctx context.Context, rt runtime.Runtime, sink output.Sink, con
 }
 
 // filterHostEnv returns the subset of host environment entries that should be
-// forwarded to the emulator container. It keeps CI and LOCALSTACK_* variables
+// forwarded to the emulator container. It keeps CI, LOCALSTACK_*, and persistence-related variables
 // but explicitly drops LOCALSTACK_AUTH_TOKEN so the host value cannot overwrite
 // the token resolved by lstk (which may come from the keyring).
 func filterHostEnv(envList []string) []string {
 	var out []string
 	for _, e := range envList {
-		if strings.HasPrefix(e, "CI=") || (strings.HasPrefix(e, "LOCALSTACK_") && !strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=")) {
+		if strings.HasPrefix(e, "CI=") ||
+			(strings.HasPrefix(e, "LOCALSTACK_") && !strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=")) ||
+			strings.HasPrefix(e, "PERSISTENCE=") ||
+			strings.HasPrefix(e, "SNAPSHOT_SAVE_STRATEGY=") ||
+			strings.HasPrefix(e, "SNAPSHOT_LOAD_STRATEGY=") ||
+			strings.HasPrefix(e, "SNAPSHOT_FLUSH_INTERVAL=") {
 			out = append(out, e)
 		}
 	}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -536,18 +536,14 @@ func awaitStartup(ctx context.Context, rt runtime.Runtime, sink output.Sink, con
 }
 
 // filterHostEnv returns the subset of host environment entries that should be
-// forwarded to the emulator container. It keeps CI, LOCALSTACK_*, and persistence-related variables
+// forwarded to the emulator container. It keeps CI and LOCALSTACK_* variables
 // but explicitly drops LOCALSTACK_AUTH_TOKEN so the host value cannot overwrite
 // the token resolved by lstk (which may come from the keyring).
 func filterHostEnv(envList []string) []string {
 	var out []string
 	for _, e := range envList {
 		if strings.HasPrefix(e, "CI=") ||
-			(strings.HasPrefix(e, "LOCALSTACK_") && !strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=")) ||
-			strings.HasPrefix(e, "PERSISTENCE=") ||
-			strings.HasPrefix(e, "SNAPSHOT_SAVE_STRATEGY=") ||
-			strings.HasPrefix(e, "SNAPSHOT_LOAD_STRATEGY=") ||
-			strings.HasPrefix(e, "SNAPSHOT_FLUSH_INTERVAL=") {
+			(strings.HasPrefix(e, "LOCALSTACK_") && !strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=")) {
 			out = append(out, e)
 		}
 	}

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -159,6 +159,10 @@ func TestFilterHostEnv(t *testing.T) {
 		"PATH=/usr/bin",
 		"HOME=/home/user",
 		"CI_PIPELINE=foo",
+		"PERSISTENCE=1",
+		"SNAPSHOT_SAVE_STRATEGY=ON_SHUTDOWN",
+		"SNAPSHOT_LOAD_STRATEGY=ON_STARTUP",
+		"SNAPSHOT_FLUSH_INTERVAL=30",
 	}
 
 	got := filterHostEnv(input)
@@ -171,5 +175,9 @@ func TestFilterHostEnv(t *testing.T) {
 	assert.NotContains(t, got, "PATH=/usr/bin")
 	assert.NotContains(t, got, "HOME=/home/user")
 	assert.NotContains(t, got, "CI_PIPELINE=foo", "only exact CI= must be forwarded, not CI_*")
+	assert.Contains(t, got, "PERSISTENCE=1")
+	assert.Contains(t, got, "SNAPSHOT_SAVE_STRATEGY=ON_SHUTDOWN")
+	assert.Contains(t, got, "SNAPSHOT_LOAD_STRATEGY=ON_STARTUP")
+	assert.Contains(t, got, "SNAPSHOT_FLUSH_INTERVAL=30")
 }
 

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -160,8 +160,6 @@ func TestFilterHostEnv(t *testing.T) {
 		"PATH=/usr/bin",
 		"HOME=/home/user",
 		"CI_PIPELINE=foo",
-		"PERSISTENCE=1",
-		"SNAPSHOT_SAVE_STRATEGY=ON_SHUTDOWN",
 	}
 
 	got := filterHostEnv(input)

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -156,13 +156,12 @@ func TestFilterHostEnv(t *testing.T) {
 		"LOCALSTACK_DISABLE_EVENTS=1",
 		"LOCALSTACK_API_ENDPOINT=https://example.test",
 		"LOCALSTACK_AUTH_TOKEN=host-token",
+		"LOCALSTACK_PERSISTENCE=1",
 		"PATH=/usr/bin",
 		"HOME=/home/user",
 		"CI_PIPELINE=foo",
 		"PERSISTENCE=1",
 		"SNAPSHOT_SAVE_STRATEGY=ON_SHUTDOWN",
-		"SNAPSHOT_LOAD_STRATEGY=ON_STARTUP",
-		"SNAPSHOT_FLUSH_INTERVAL=30",
 	}
 
 	got := filterHostEnv(input)
@@ -170,14 +169,10 @@ func TestFilterHostEnv(t *testing.T) {
 	assert.Contains(t, got, "CI=true")
 	assert.Contains(t, got, "LOCALSTACK_DISABLE_EVENTS=1")
 	assert.Contains(t, got, "LOCALSTACK_API_ENDPOINT=https://example.test")
+	assert.Contains(t, got, "LOCALSTACK_PERSISTENCE=1")
 	assert.NotContains(t, got, "LOCALSTACK_AUTH_TOKEN=host-token",
 		"host LOCALSTACK_AUTH_TOKEN must be filtered so it cannot overwrite the lstk-resolved token")
 	assert.NotContains(t, got, "PATH=/usr/bin")
 	assert.NotContains(t, got, "HOME=/home/user")
 	assert.NotContains(t, got, "CI_PIPELINE=foo", "only exact CI= must be forwarded, not CI_*")
-	assert.Contains(t, got, "PERSISTENCE=1")
-	assert.Contains(t, got, "SNAPSHOT_SAVE_STRATEGY=ON_SHUTDOWN")
-	assert.Contains(t, got, "SNAPSHOT_LOAD_STRATEGY=ON_STARTUP")
-	assert.Contains(t, got, "SNAPSHOT_FLUSH_INTERVAL=30")
 }
-

--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -17,7 +17,7 @@ const (
 	AnalyticsEndpoint Key = "LSTK_ANALYTICS_ENDPOINT"
 	DisableEvents     Key = "LOCALSTACK_DISABLE_EVENTS"
 	Home              Key = "HOME"
-	Persistence       Key = "PERSISTENCE"
+	Persistence       Key = "LOCALSTACK_PERSISTENCE"
 )
 
 func Get(key Key) string {

--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -17,6 +17,7 @@ const (
 	AnalyticsEndpoint Key = "LSTK_ANALYTICS_ENDPOINT"
 	DisableEvents     Key = "LOCALSTACK_DISABLE_EVENTS"
 	Home              Key = "HOME"
+	Persistence       Key = "PERSISTENCE"
 )
 
 func Get(key Key) string {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -365,7 +365,7 @@ func TestStartCommandForwardsPersistenceEnvFromHost(t *testing.T) {
 	require.True(t, inspect.State.Running)
 
 	envVars := containerEnvToMap(inspect.Config.Env)
-	assert.Equal(t, "1", envVars["PERSISTENCE"])
+	assert.Equal(t, "1", envVars["LOCALSTACK_PERSISTENCE"])
 }
 
 func TestStartCommandSetsPersistenceEnvFromConfig(t *testing.T) {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -343,6 +343,67 @@ func TestStartCommandPassesCIAndLocalStackEnvVars(t *testing.T) {
 	assert.NotEmpty(t, envVars["LOCALSTACK_AUTH_TOKEN"])
 }
 
+func TestStartCommandForwardsPersistenceEnvFromHost(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL).
+		With(env.Persistence, "1"),
+		"start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
+	require.NoError(t, err, "failed to inspect container")
+	require.True(t, inspect.State.Running)
+
+	envVars := containerEnvToMap(inspect.Config.Env)
+	assert.Equal(t, "1", envVars["PERSISTENCE"])
+}
+
+func TestStartCommandSetsPersistenceEnvFromConfig(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	configContent := `
+[env.persistence]
+PERSISTENCE = "1"
+
+[[containers]]
+type = "aws"
+tag = "latest"
+port = "4566"
+env = ["persistence"]
+`
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
+	require.NoError(t, err, "failed to inspect container")
+	require.True(t, inspect.State.Running)
+
+	envVars := containerEnvToMap(inspect.Config.Env)
+	assert.Equal(t, "1", envVars["PERSISTENCE"])
+}
+
 // hasBindTarget checks if any bind mount targets the given container path.
 func hasBindTarget(binds []string, containerPath string) bool {
 	for _, b := range binds {


### PR DESCRIPTION
Persistence and related snapshot configuration vars may be passed in host env prefixed with LOCALSTACK* or through config.toml env vars.

This PR adds a couple of related tests.