### PR TITLE
Refactor command telemetry

### DIFF
--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -61,7 +61,7 @@ Create `internal/<package>/<name>.go` (use an existing package if it fits, or cr
 
 In `cmd/root.go`, add the new command to `root.AddCommand(...)`.
 
-If the command constructor needs dependencies (like `*env.Env` or `*telemetry.Client`), add them as parameters matching the existing pattern.
+If the command constructor needs dependencies (like `*env.Env`), add them as parameters matching the existing pattern.
 
 ## Step 4: Add new event types (if needed)
 
@@ -96,9 +96,7 @@ Create `test/integration/<name>_test.go` with:
 
 ## Telemetry
 
-Every new command must emit an `lstk_command` telemetry event. Wrap the command's `RunE` with `commandWithTelemetry(name, tel, fn)` — this handles timing, exit code, and error message automatically.
-
-Start and stop are exceptions: they emit `lstk_lifecycle` events in addition to `lstk_command`, so they manage their own telemetry manually instead of using `commandWithTelemetry`.
+`lstk_command` telemetry is emitted automatically for every command via `instrumentCommands` in `cmd/root.go` — no per-command wiring needed. Do NOT pass `*telemetry.Client` to a new command constructor unless the command emits additional lifecycle events (like `lstk_lifecycle` for start/stop/restart) or needs to update the auth token (like login).
 
 In the corresponding integration test, add an assertion that the `lstk_command` event was emitted.
 

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -12,12 +12,11 @@ import (
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
-	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/terminal"
 	"github.com/spf13/cobra"
 )
 
-func newAWSCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newAWSCmd(cfg *env.Env) *cobra.Command {
 	return &cobra.Command{
 		Use:   "aws [args...]",
 		Short: "Run AWS CLI commands against LocalStack",
@@ -35,7 +34,7 @@ Examples:
   lstk aws s3 mb s3://my-bucket`,
 		DisableFlagParsing: true,
 		PreRunE:            initConfig,
-		RunE: commandWithTelemetry("aws", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
@@ -93,6 +92,6 @@ Examples:
 			}
 
 			return awscli.Exec(cmd.Context(), "http://"+host, profileExists, stdout, stderr, args)
-		}),
+		},
 	}
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,27 +5,26 @@ import (
 
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/env"
-	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newConfigCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newConfigCmd(cfg *env.Env) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage configuration",
 	}
-	cmd.AddCommand(newConfigProfileCmd(cfg, tel))
-	cmd.AddCommand(newConfigPathCmd(cfg, tel))
+	cmd.AddCommand(newConfigProfileCmd(cfg))
+	cmd.AddCommand(newConfigPathCmd())
 	return cmd
 }
 
-func newConfigProfileCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newConfigProfileCmd(cfg *env.Env) *cobra.Command {
 	return &cobra.Command{
 		Use:     "profile",
 		Short:   "Deprecated: use 'lstk setup aws' instead",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("config profile", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			appConfig, err := config.Get()
 			if err != nil {
 				return fmt.Errorf("failed to get config: %w", err)
@@ -37,15 +36,15 @@ func newConfigProfileCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 
 			// Delegate to the same handler as "lstk setup aws"
 			return ui.RunConfigProfile(cmd.Context(), appConfig.Containers, cfg.LocalStackHost)
-		}),
+		},
 	}
 }
 
-func newConfigPathCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newConfigPathCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "path",
 		Short: "Print the configuration file path",
-		RunE: commandWithTelemetry("config path", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			path, err := cmd.Flags().GetString("config")
 			if err != nil {
 				return err
@@ -62,6 +61,6 @@ func newConfigPathCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), configPath)
 			return err
-		}),
+		},
 	}
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -19,7 +19,7 @@ func newLoginCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 		Short:   "Manage login",
 		Long:    "Manage login and store credentials in system keyring",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("login", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if !isInteractiveMode(cfg) {
 				return fmt.Errorf("login requires an interactive terminal")
 			}
@@ -33,6 +33,6 @@ func newLoginCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 				}
 			}
 			return nil
-		}),
+		},
 	}
 }

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -13,17 +13,16 @@ import (
 	"github.com/localstack/lstk/internal/log"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
-	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newLogoutCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
+func newLogoutCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:     "logout",
 		Short:   "Remove stored authentication credentials",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("logout", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
 			appConfig, err := config.Get()
 			if err != nil {
@@ -58,6 +57,6 @@ func newLogoutCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra
 				}
 			}
 			return nil
-		}),
+		},
 	}
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -9,18 +9,17 @@ import (
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
-	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newLogsCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newLogsCmd(cfg *env.Env) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "logs",
 		Short:   "Show emulator logs",
 		Long:    "Show logs from the emulator. Use --follow to stream in real-time.",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("logs", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			follow, err := cmd.Flags().GetBool("follow")
 			if err != nil {
 				return err
@@ -41,7 +40,7 @@ func newLogsCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 				return ui.RunLogs(cmd.Context(), rt, appConfig.Containers, follow, verbose)
 			}
 			return container.Logs(cmd.Context(), rt, output.NewPlainSink(os.Stdout), appConfig.Containers, follow, verbose)
-		}),
+		},
 	}
 	cmd.Flags().BoolP("follow", "f", false, "Follow log output")
 	cmd.Flags().BoolP("verbose", "v", false, "Show all log output without filtering")

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -21,7 +21,7 @@ func newRestartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobr
 		Short:   "Restart emulator",
 		Long:    "Stop and restart emulator and services.",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("restart", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
@@ -43,6 +43,6 @@ func newRestartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobr
 
 			sink := output.NewPlainSink(os.Stdout)
 			return container.Restart(cmd.Context(), rt, sink, stopOpts, startOpts, false)
-		}),
+		},
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -214,6 +214,9 @@ func instrumentCommands(cmd *cobra.Command, tel *telemetry.Client) {
 			}
 
 			commandName := strings.TrimPrefix(c.CommandPath(), c.Root().Name()+" ")
+			if c == c.Root() {
+				commandName = "start"
+			}
 			tel.EmitCommand(c.Context(), commandName, flags, time.Since(startTime).Milliseconds(), exitCode, errorMsg)
 
 			return runErr

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 			if err != nil {
 				return err
 			}
-			return runStart(cmd.Context(), cmd.Flags(), rt, cfg, tel, logger)
+			return startEmulator(cmd.Context(), rt, cfg, tel, logger)
 		},
 	}
 
@@ -63,15 +63,15 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 		newStopCmd(cfg, tel),
 		newRestartCmd(cfg, tel, logger),
 		newLoginCmd(cfg, tel, logger),
-		newLogoutCmd(cfg, tel, logger),
-		newStatusCmd(cfg, tel),
-		newLogsCmd(cfg, tel),
-		newSetupCmd(cfg, tel),
-		newConfigCmd(cfg, tel),
-		newVolumeCmd(cfg, tel),
-		newUpdateCmd(cfg, tel),
+		newLogoutCmd(cfg, logger),
+		newStatusCmd(cfg),
+		newLogsCmd(cfg),
+		newSetupCmd(cfg),
+		newConfigCmd(cfg),
+		newVolumeCmd(cfg),
+		newUpdateCmd(cfg),
 		newDocsCmd(),
-		newAWSCmd(cfg, tel),
+		newAWSCmd(cfg),
 	)
 
 	return root
@@ -118,6 +118,7 @@ func Execute(ctx context.Context) error {
 	root := NewRootCmd(cfg, tel, logger)
 	root.SilenceErrors = true
 	root.SilenceUsage = true
+	instrumentCommands(root, tel)
 	if cfg.TracesEnabled {
 		wrapCommandsWithTracing(root)
 	}
@@ -192,48 +193,34 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 	return container.Start(ctx, rt, sink, opts, false)
 }
 
-func runStart(ctx context.Context, cmdFlags *pflag.FlagSet, rt runtime.Runtime, cfg *env.Env, tel *telemetry.Client, logger log.Logger) error {
-	startTime := time.Now()
+// instrumentCommands walks the Cobra command tree and wraps every RunE with telemetry emission.
+func instrumentCommands(cmd *cobra.Command, tel *telemetry.Client) {
+	if cmd.RunE != nil {
+		original := cmd.RunE
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			startTime := time.Now()
+			runErr := original(c, args)
 
-	var flags []string
-	cmdFlags.Visit(func(f *pflag.Flag) {
-		flags = append(flags, "--"+f.Name)
-	})
+			var flags []string
+			c.Flags().Visit(func(f *pflag.Flag) {
+				flags = append(flags, "--"+f.Name)
+			})
 
-	runErr := startEmulator(ctx, rt, cfg, tel, logger)
+			exitCode := 0
+			errorMsg := ""
+			if runErr != nil {
+				exitCode = 1
+				errorMsg = runErr.Error()
+			}
 
-	exitCode := 0
-	errorMsg := ""
-	if runErr != nil {
-		exitCode = 1
-		errorMsg = runErr.Error()
-	}
-	tel.EmitCommand(ctx, "start", flags, time.Since(startTime).Milliseconds(), exitCode, errorMsg)
+			commandName := strings.TrimPrefix(c.CommandPath(), c.Root().Name()+" ")
+			tel.EmitCommand(c.Context(), commandName, flags, time.Since(startTime).Milliseconds(), exitCode, errorMsg)
 
-	return runErr
-}
-
-// wraps a RunE function so that an lstk_command event is emitted after every invocation
-// used for commands that do not emit lstk_lifecycle events (i.e. status, logs, config path, etc)
-func commandWithTelemetry(name string, tel *telemetry.Client, fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		startTime := time.Now()
-		runErr := fn(cmd, args)
-
-		var flags []string
-		cmd.Flags().Visit(func(f *pflag.Flag) {
-			flags = append(flags, "--"+f.Name)
-		})
-
-		exitCode := 0
-		errorMsg := ""
-		if runErr != nil {
-			exitCode = 1
-			errorMsg = runErr.Error()
+			return runErr
 		}
-		tel.EmitCommand(cmd.Context(), name, flags, time.Since(startTime).Milliseconds(), exitCode, errorMsg)
-
-		return runErr
+	}
+	for _, child := range cmd.Commands() {
+		instrumentCommands(child, tel)
 	}
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -5,28 +5,27 @@ import (
 
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/env"
-	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newSetupCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newSetupCmd(cfg *env.Env) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
 		Short: "Set up emulator CLI integration",
 		Long:  "Set up emulator CLI integration. Currently only AWS is supported.",
 	}
-	cmd.AddCommand(newSetupAWSCmd(cfg, tel))
+	cmd.AddCommand(newSetupAWSCmd(cfg))
 	return cmd
 }
 
-func newSetupAWSCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newSetupAWSCmd(cfg *env.Env) *cobra.Command {
 	return &cobra.Command{
 		Use:     "aws",
 		Short:   "Set up the LocalStack AWS profile",
 		Long:    "Set up the LocalStack AWS profile in ~/.aws/config and ~/.aws/credentials for use with AWS CLI and SDKs.",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("setup aws", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			appConfig, err := config.Get()
 			if err != nil {
 				return fmt.Errorf("failed to get config: %w", err)
@@ -37,6 +36,6 @@ func newSetupAWSCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 			}
 
 			return ui.RunConfigProfile(cmd.Context(), appConfig.Containers, cfg.LocalStackHost)
-		}),
+		},
 	}
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -19,7 +19,7 @@ func newStartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 			if err != nil {
 				return err
 			}
-			return runStart(cmd.Context(), cmd.Flags(), rt, cfg, tel, logger)
+			return startEmulator(cmd.Context(), rt, cfg, tel, logger)
 		},
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,18 +10,17 @@ import (
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
-	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newStatusCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newStatusCmd(cfg *env.Env) *cobra.Command {
 	return &cobra.Command{
 		Use:     "status",
 		Short:   "Show emulator status and deployed resources",
 		Long:    "Show the status of a running emulator and its deployed resources",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("status", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
@@ -37,6 +36,6 @@ func newStatusCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 				return ui.RunStatus(cmd.Context(), rt, appCfg.Containers, cfg.LocalStackHost, awsClient)
 			}
 			return container.Status(cmd.Context(), rt, appCfg.Containers, cfg.LocalStackHost, awsClient, output.NewPlainSink(os.Stdout))
-		}),
+		},
 	}
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/container"
@@ -13,7 +12,6 @@ import (
 	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
@@ -23,7 +21,6 @@ func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Long:    "Stop emulator and services",
 		PreRunE: initConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			startTime := time.Now()
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
@@ -37,28 +34,10 @@ func newStopCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 				Telemetry: tel,
 			}
 
-			var runErr error
-
 			if isInteractiveMode(cfg) {
-				runErr = ui.RunStop(cmd.Context(), rt, appConfig.Containers, stopOpts)
-			} else {
-				runErr = container.Stop(cmd.Context(), rt, output.NewPlainSink(os.Stdout), appConfig.Containers, stopOpts)
+				return ui.RunStop(cmd.Context(), rt, appConfig.Containers, stopOpts)
 			}
-
-			exitCode := 0
-			errorMsg := ""
-			if runErr != nil {
-				exitCode = 1
-				errorMsg = runErr.Error()
-			}
-
-			var flags []string
-			cmd.Flags().Visit(func(f *pflag.Flag) {
-				flags = append(flags, "--"+f.Name)
-			})
-			tel.EmitCommand(cmd.Context(), "stop", flags, time.Since(startTime).Milliseconds(), exitCode, errorMsg)
-
-			return runErr
+			return container.Stop(cmd.Context(), rt, output.NewPlainSink(os.Stdout), appConfig.Containers, stopOpts)
 		},
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
-	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/localstack/lstk/internal/update"
 	"github.com/spf13/cobra"
 )
 
-func newUpdateCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newUpdateCmd(cfg *env.Env) *cobra.Command {
 	var checkOnly bool
 
 	cmd := &cobra.Command{
@@ -19,12 +18,12 @@ func newUpdateCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Update lstk to the latest version",
 		Long:    "Check for and apply updates to the lstk CLI. Respects the original installation method (Homebrew, npm, or direct binary).",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("update", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if isInteractiveMode(cfg) {
 				return ui.RunUpdate(cmd.Context(), checkOnly, cfg.GitHubToken)
 			}
 			return update.Update(cmd.Context(), output.NewPlainSink(os.Stdout), checkOnly, cfg.GitHubToken)
-		}),
+		},
 	}
 
 	cmd.Flags().BoolVar(&checkOnly, "check", false, "Only check for updates without applying them")

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -7,28 +7,27 @@ import (
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
-	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/localstack/lstk/internal/volume"
 	"github.com/spf13/cobra"
 )
 
-func newVolumeCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newVolumeCmd(cfg *env.Env) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "volume",
 		Short: "Manage emulator volume",
 	}
-	cmd.AddCommand(newVolumePathCmd(cfg, tel))
-	cmd.AddCommand(newVolumeClearCmd(cfg, tel))
+	cmd.AddCommand(newVolumePathCmd(cfg))
+	cmd.AddCommand(newVolumeClearCmd(cfg))
 	return cmd
 }
 
-func newVolumePathCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newVolumePathCmd(cfg *env.Env) *cobra.Command {
 	return &cobra.Command{
 		Use:     "path",
 		Short:   "Print the volume directory path",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("volume path", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			appConfig, err := config.Get()
 			if err != nil {
 				return fmt.Errorf("failed to get config: %w", err)
@@ -45,11 +44,11 @@ func newVolumePathCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 				}
 			}
 			return nil
-		}),
+		},
 	}
 }
 
-func newVolumeClearCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
+func newVolumeClearCmd(cfg *env.Env) *cobra.Command {
 	var force bool
 	var emulatorType string
 
@@ -58,7 +57,7 @@ func newVolumeClearCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 		Short:   "Clear emulator volume data",
 		Long:    "Remove all data from the emulator volume directory. This resets cached state such as certificates, downloaded tools, and persistence data.",
 		PreRunE: initConfig,
-		RunE: commandWithTelemetry("volume clear", tel, func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			appConfig, err := config.Get()
 			if err != nil {
 				return fmt.Errorf("failed to get config: %w", err)
@@ -81,7 +80,7 @@ func newVolumeClearCmd(cfg *env.Env, tel *telemetry.Client) *cobra.Command {
 			}
 
 			return ui.RunVolumeClear(cmd.Context(), containers)
-		}),
+		},
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")

--- a/test/integration/telemetry_test.go
+++ b/test/integration/telemetry_test.go
@@ -53,52 +53,61 @@ func TestStartCommandSendsTelemetryEvent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Pre-start a container so lstk start exits immediately after telemetry fires,
-	// without needing a real token or license server.
+	// Pre-start a container so both invocations exit immediately without a real token.
 	startTestContainer(t, ctx)
 
 	analyticsSrv, events := mockAnalyticsServer(t)
 
-	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = env.With(env.AuthToken, "fake-token").
-		With(env.AnalyticsEndpoint, analyticsSrv.URL)
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "lstk start failed: %s", out)
-	requireExitCode(t, 0, err)
-
-	// The telemetry goroutine is async; wait up to 3s for the event to arrive.
-	select {
-	case event := <-events:
-		assert.Equal(t, "lstk_command", event["name"])
-
-		metadata, ok := event["metadata"].(map[string]any)
-		require.True(t, ok)
-		_, err := uuid.Parse(metadata["session_id"].(string))
-		assert.NoError(t, err, "session_id should be a valid UUID")
-		_, err = time.Parse("2006-01-02 15:04:05.000000", metadata["client_time"].(string))
-		assert.NoError(t, err, "client_time should match expected format")
-
-		payload, ok := event["payload"].(map[string]any)
-		require.True(t, ok)
-		assert.NotEmpty(t, payload["machine_id"], "machine_id should be present")
-		assert.Equal(t, os.Getenv("CI") != "", payload["is_ci"])
-
-		environment, ok := payload["environment"].(map[string]any)
-		require.True(t, ok)
-		assert.NotEmpty(t, environment["lstk_version"])
-		assert.Equal(t, runtime.GOOS, environment["os"])
-		assert.Equal(t, runtime.GOARCH, environment["arch"])
-
-		params, ok := payload["parameters"].(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, "start", params["command"])
-
-		result, ok := payload["result"].(map[string]any)
-		require.True(t, ok)
-		assert.InDelta(t, 0, result["exit_code"], 0)
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for telemetry event")
+	runCmd := func(t *testing.T, args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, binaryPath(), args...)
+		cmd.Env = env.With(env.AuthToken, "fake-token").
+			With(env.AnalyticsEndpoint, analyticsSrv.URL)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "lstk %v failed: %s", args, out)
 	}
+
+	t.Run("lstk start emits command=start", func(t *testing.T) {
+		runCmd(t, "start")
+
+		select {
+		case event := <-events:
+			assert.Equal(t, "lstk_command", event["name"])
+
+			metadata, ok := event["metadata"].(map[string]any)
+			require.True(t, ok)
+			_, err := uuid.Parse(metadata["session_id"].(string))
+			assert.NoError(t, err, "session_id should be a valid UUID")
+			_, err = time.Parse("2006-01-02 15:04:05.000000", metadata["client_time"].(string))
+			assert.NoError(t, err, "client_time should match expected format")
+
+			payload, ok := event["payload"].(map[string]any)
+			require.True(t, ok)
+			assert.NotEmpty(t, payload["machine_id"], "machine_id should be present")
+			assert.Equal(t, os.Getenv("CI") != "", payload["is_ci"])
+
+			environment, ok := payload["environment"].(map[string]any)
+			require.True(t, ok)
+			assert.NotEmpty(t, environment["lstk_version"])
+			assert.Equal(t, runtime.GOOS, environment["os"])
+			assert.Equal(t, runtime.GOARCH, environment["arch"])
+
+			params, ok := payload["parameters"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "start", params["command"])
+
+			result, ok := payload["result"].(map[string]any)
+			require.True(t, ok)
+			assert.InDelta(t, 0, result["exit_code"], 0)
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for telemetry event")
+		}
+	})
+
+	t.Run("lstk (no subcommand) emits command=lstk", func(t *testing.T) {
+		runCmd(t)
+		assertCommandTelemetry(t, events, "lstk", 0)
+	})
 }
 
 func TestStopCommandSendsTelemetryEvents(t *testing.T) {

--- a/test/integration/telemetry_test.go
+++ b/test/integration/telemetry_test.go
@@ -104,9 +104,9 @@ func TestStartCommandSendsTelemetryEvent(t *testing.T) {
 		}
 	})
 
-	t.Run("lstk (no subcommand) emits command=lstk", func(t *testing.T) {
+	t.Run("lstk (no subcommand) emits command=start", func(t *testing.T) {
 		runCmd(t)
-		assertCommandTelemetry(t, events, "lstk", 0)
+		assertCommandTelemetry(t, events, "start", 0)
 	})
 }
 


### PR DESCRIPTION
Refactoring addressing suggested improvement #2 from @thrau in this comment https://github.com/localstack/lstk/pull/127#pullrequestreview-3972108878


## Changes

- Replaces the `commandWithTelemetry` decorator and per-command manual telemetry with a single `instrumentCommands` function in `root.go` that walks the Cobra command tree and wraps every `RunE` automatically
- Command names are derived from `cmd.CommandPath()` (stripping the `lstk ` prefix) — no more hardcoded strings that can drift
- Removes `*telemetry.Client` from constructors that only needed it for the decorator (logout, status, logs, setup, config, volume, update, aws); kept where still needed for lifecycle events (start, stop, restart) or token updates (login)

## Deviation from the suggestion

> You can use Cobra's PersistentPreRun func to store data globally that you need (for example the startTime)

The PR instead captures `startTime` directly inside the `RunE` closure in `instrumentCommands`. This is simpler because local to the closure and there is no shared state needed.

> Instead, we could centralize this into root.go and remove the tel dependency out of the constructors completely.

`tel` must still be passed to constructors for commands that do more things with it: emitting lifecycle events, updating auth token. 

## Change in telemetry data

Before this change `lstk` (without subcommand) and `lstk start` both emitted `command="start"` and could not be differentiated in telemetry. Now `lstk` emits `"lstk"` instead.
