### PR TITLE
Use ANSI red for error styles to match terminal profile

### DIFF
--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -51,7 +51,7 @@ var (
 		Foreground(lipgloss.Color("214"))
 
 	LogError = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#C33820"))
+			Foreground(lipgloss.Color("1"))
 
 	// Secondary/muted style for prefixes
 	Secondary = lipgloss.NewStyle().
@@ -60,7 +60,7 @@ var (
 	// Error styles
 	ErrorTitle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#C33820"))
+			Foreground(lipgloss.Color("1"))
 
 	ErrorDetail = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("245"))


### PR DESCRIPTION
Switch `LogError` and `ErrorTitle` styles from hex `#C33820` to ANSI red (`"1"`) so each terminal renders error text using its own profile's red.

| BEFORE | AFTER |
|--------|--------|
| <img width="460" height="180" alt="Frame 852839925" src="https://github.com/user-attachments/assets/4825855f-504a-489e-bd8d-50d9822728bd" /> | <img width="460" height="180" alt="Frame 852839926" src="https://github.com/user-attachments/assets/9004a0a9-4301-4b32-b7fc-377dbdcdc3ad" /> |
| <img width="460" height="180" alt="Frame 852839928" src="https://github.com/user-attachments/assets/15ce3239-92a2-4eca-875b-7c788908af50" /> | <img width="460" height="180" alt="Frame 852839927" src="https://github.com/user-attachments/assets/b29ff264-d520-4a4a-9bd7-bea1a82b3a53" /> |
| <img width="460" height="180" alt="Frame 852839930" src="https://github.com/user-attachments/assets/3694e6ab-2ce8-4a93-b673-0c4040b9bd27" /> | <img width="460" height="180" alt="Frame 852839929" src="https://github.com/user-attachments/assets/6be2776e-1a93-426c-8c60-38b469829c54" /> | 