### PR TITLE
Hide banner on first-run before auth

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -159,23 +159,6 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	interactive := isInteractiveMode(cfg)
-
-	// On first run with no token, run the auth flow before showing the start UI
-	// so the header isn't rendered with "(No license)" before authentication completes.
-	if interactive && cfg.AuthToken == "" {
-		platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
-		if err := ui.RunLogin(ctx, version.Version(), platformClient, "", cfg.ForceFileKeyring, cfg.WebAppURL, logger); err != nil {
-			return err
-		}
-		if tokenStorage, err := auth.NewTokenStorage(cfg.ForceFileKeyring, logger); err == nil {
-			if token, err := tokenStorage.GetAuthToken(); err == nil && token != "" {
-				cfg.AuthToken = token
-				tel.SetAuthToken(token)
-			}
-		}
-	}
-
 	opts := buildStartOptions(cfg, appConfig, logger, tel, persist)
 
 	notifyOpts := update.NotifyOptions{
@@ -190,7 +173,7 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 		logger.Info("could not resolve friendly config path: %v", err)
 	}
 
-	if interactive {
+	if isInteractiveMode(cfg) {
 		labelCh := make(chan string, 1)
 		go func() {
 			label, ok := container.ResolveEmulatorLabel(ctx, opts.PlatformClient, appConfig.Containers, cfg.AuthToken, logger)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -159,6 +159,23 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
+	interactive := isInteractiveMode(cfg)
+
+	// On first run with no token, run the auth flow before showing the start UI
+	// so the header isn't rendered with "(No license)" before authentication completes.
+	if interactive && cfg.AuthToken == "" {
+		platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
+		if err := ui.RunLogin(ctx, version.Version(), platformClient, "", cfg.ForceFileKeyring, cfg.WebAppURL, logger); err != nil {
+			return err
+		}
+		if tokenStorage, err := auth.NewTokenStorage(cfg.ForceFileKeyring, logger); err == nil {
+			if token, err := tokenStorage.GetAuthToken(); err == nil && token != "" {
+				cfg.AuthToken = token
+				tel.SetAuthToken(token)
+			}
+		}
+	}
+
 	opts := buildStartOptions(cfg, appConfig, logger, tel, persist)
 
 	notifyOpts := update.NotifyOptions{
@@ -173,7 +190,7 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 		logger.Info("could not resolve friendly config path: %v", err)
 	}
 
-	if isInteractiveMode(cfg) {
+	if interactive {
 		labelCh := make(chan string, 1)
 		go func() {
 			label, ok := container.ResolveEmulatorLabel(ctx, opts.PlatformClient, appConfig.Containers, cfg.AuthToken, logger)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -59,8 +59,8 @@ func (a *Auth) GetToken(ctx context.Context) (string, error) {
 		a.sink.Emit(output.MessageEvent{Severity: output.SeverityWarning, Text: fmt.Sprintf("could not store token in keyring: %v", err)})
 	}
 
-	a.sink.Emit(output.MessageEvent{Severity: output.SeveritySuccess, Text: "Login successful."})
 	a.sink.Emit(output.AuthCompleteEvent{})
+	a.sink.Emit(output.MessageEvent{Severity: output.SeveritySuccess, Text: "Login successful."})
 	return token, nil
 }
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -60,6 +60,7 @@ func (a *Auth) GetToken(ctx context.Context) (string, error) {
 	}
 
 	a.sink.Emit(output.MessageEvent{Severity: output.SeveritySuccess, Text: "Login successful."})
+	a.sink.Emit(output.AuthCompleteEvent{})
 	return token, nil
 }
 

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -21,10 +21,10 @@ type MessageSeverity int
 
 const (
 	SeverityInfo      MessageSeverity = iota
-	SeveritySuccess                          // positive outcome
-	SeverityNote                             // informational
-	SeverityWarning                          // cautionary
-	SeveritySecondary                        // subdued/decorative text
+	SeveritySuccess                   // positive outcome
+	SeverityNote                      // informational
+	SeverityWarning                   // cautionary
+	SeveritySecondary                 // subdued/decorative text
 )
 
 type MessageEvent struct {
@@ -76,6 +76,8 @@ type ResourceSummaryEvent struct {
 	Services  int
 }
 
+type AuthCompleteEvent struct{}
+
 // Event is a sealed marker — only event types in this package implement it,
 // so Sink.Emit rejects unknown types at compile time.
 type Event interface{ sealedEvent() }
@@ -84,6 +86,7 @@ func (MessageEvent) sealedEvent()          {}
 func (SpinnerEvent) sealedEvent()          {}
 func (ErrorEvent) sealedEvent()            {}
 func (AuthEvent) sealedEvent()             {}
+func (AuthCompleteEvent) sealedEvent()     {}
 func (InstanceInfoEvent) sealedEvent()     {}
 func (TableEvent) sealedEvent()            {}
 func (ResourceSummaryEvent) sealedEvent()  {}

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -34,6 +34,8 @@ func FormatEventLine(event Event) (string, bool) {
 		return formatTable(e)
 	case ResourceSummaryEvent:
 		return formatResourceSummary(e), true
+	case AuthCompleteEvent:
+		return "", false
 	default:
 		return "", false
 	}

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -162,6 +162,12 @@ func TestFormatEventLine(t *testing.T) {
 			want:   "Docker not available",
 			wantOK: true,
 		},
+		{
+			name:   "auth complete event",
+			event:  AuthCompleteEvent{},
+			want:   "",
+			wantOK: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/output/tui_sink_test.go
+++ b/internal/output/tui_sink_test.go
@@ -23,12 +23,14 @@ func TestTUISinkForwardsEvents(t *testing.T) {
 	sink.Emit(MessageEvent{Severity: SeverityWarning, Text: "careful"})
 	sink.Emit(ContainerStatusEvent{Phase: "starting", Container: "localstack"})
 	sink.Emit(ProgressEvent{LayerID: "abc", Status: "Downloading", Current: 1, Total: 2})
+	sink.Emit(AuthCompleteEvent{})
 
 	want := []any{
 		MessageEvent{Severity: SeverityInfo, Text: "hello"},
 		MessageEvent{Severity: SeverityWarning, Text: "careful"},
 		ContainerStatusEvent{Phase: "starting", Container: "localstack"},
 		ProgressEvent{LayerID: "abc", Status: "Downloading", Current: 1, Total: 2},
+		AuthCompleteEvent{},
 	}
 	if !reflect.DeepEqual(sender.msgs, want) {
 		t.Fatalf("unexpected msgs: got=%#v want=%#v", sender.msgs, want)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -44,21 +44,22 @@ type styledLine struct {
 }
 
 type App struct {
-	header        components.Header
-	inputPrompt   components.InputPrompt
-	spinner       components.Spinner
-	pullProgress  components.PullProgress
-	errorDisplay  components.ErrorDisplay
-	lines         []styledLine
-	bufferedLines []styledLine // lines waiting for spinner to finish
-	width         int
-	cancel        func()
-	pendingInput  *output.UserInputRequestEvent
-	err           error
-	quitting      bool
-	hideHeader    bool
-	headerLoading bool
-	headerFrame   int
+	header           components.Header
+	inputPrompt      components.InputPrompt
+	spinner          components.Spinner
+	pullProgress     components.PullProgress
+	errorDisplay     components.ErrorDisplay
+	lines            []styledLine
+	bufferedLines    []styledLine // lines waiting for spinner to finish
+	width            int
+	cancel           func()
+	pendingInput     *output.UserInputRequestEvent
+	err              error
+	quitting         bool
+	hideHeader       bool
+	showHeaderOnAuth bool
+	headerLoading    bool
+	headerFrame      int
 }
 
 type AppOption func(*App)
@@ -69,6 +70,14 @@ func withoutHeader() AppOption {
 
 func withHeaderLoading() AppOption {
 	return func(a *App) { a.headerLoading = true }
+}
+
+func withHeaderAfterAuth() AppOption {
+	return func(a *App) {
+		a.hideHeader = true
+		a.showHeaderOnAuth = true
+		a.headerLoading = true
+	}
 }
 
 func NewApp(version, emulatorName, configPath string, cancel func(), opts ...AppOption) App {
@@ -145,6 +154,12 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.header = a.header.SetEmulatorName(msg.label)
 		if a.quitting {
 			return a, tea.Quit
+		}
+		return a, nil
+	case output.AuthCompleteEvent:
+		if a.showHeaderOnAuth {
+			a.hideHeader = false
+			a.showHeaderOnAuth = false
 		}
 		return a, nil
 	case output.UserInputRequestEvent:

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -72,6 +72,10 @@ func withHeaderLoading() AppOption {
 	return func(a *App) { a.headerLoading = true }
 }
 
+// withHeaderAfterAuth hides the header during the in-line login flow.
+// When AuthCompleteEvent arrives the TUI clears its scroll buffer and reveals
+// the header — so the start UI begins fresh under the header instead of the
+// header popping in above existing auth output (layout shift).
 func withHeaderAfterAuth() AppOption {
 	return func(a *App) {
 		a.hideHeader = true
@@ -160,6 +164,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.showHeaderOnAuth {
 			a.hideHeader = false
 			a.showHeaderOnAuth = false
+			// Drop auth-flow lines so the header doesn't pop in above existing
+			// content (layout shift). Post-auth feedback like "Login successful"
+			// is emitted after AuthCompleteEvent and lands under the header.
+			a.lines = a.lines[:0]
+			a.bufferedLines = a.bufferedLines[:0]
 		}
 		return a, nil
 	case output.UserInputRequestEvent:

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -41,7 +41,9 @@ func Run(parentCtx context.Context, runOpts RunOptions) error {
 	defer cancel()
 
 	var appOpts []AppOption
-	if runOpts.EmulatorLabel == "" {
+	if runOpts.StartOptions.AuthToken == "" {
+		appOpts = append(appOpts, withHeaderAfterAuth())
+	} else if runOpts.EmulatorLabel == "" {
 		appOpts = append(appOpts, withHeaderLoading())
 	}
 	app := NewApp(runOpts.Version, runOpts.EmulatorLabel, runOpts.ConfigPath, cancel, appOpts...)

--- a/internal/ui/run_login.go
+++ b/internal/ui/run_login.go
@@ -16,7 +16,7 @@ func RunLogin(parentCtx context.Context, version string, platformClient api.Plat
 	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
 
-	app := NewApp(version, "", "", cancel)
+	app := NewApp(version, "", "", cancel, withoutHeader())
 	p := tea.NewProgram(app, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
 	runErrCh := make(chan error, 1)
 

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -498,15 +498,17 @@ func TestStartHidesHeaderUntilAuthComplete(t *testing.T) {
 		return bytes.Contains(output.Bytes(), []byte("Press any key when complete"))
 	}, 10*time.Second, 100*time.Millisecond, "auth prompt should appear")
 
-	assert.NotContains(t, output.String(), "lstk (", "header must be hidden while auth is pending")
+	assert.NotContains(t, output.String(), "lstk ", "header must be hidden while auth is pending")
 
 	// Complete auth by pressing ENTER.
 	_, err = ptmx.Write([]byte("\r"))
 	require.NoError(t, err)
 
-	// After auth completes, the header must appear.
+	// After auth completes, the header must appear. Look for the header's
+	// "lstk " prefix — the version that follows is wrapped in ANSI styling
+	// so a contiguous "lstk (" match would fail under terminal rendering.
 	require.Eventually(t, func() bool {
-		return bytes.Contains(output.Bytes(), []byte("lstk ("))
+		return bytes.Contains(output.Bytes(), []byte("lstk "))
 	}, 10*time.Second, 100*time.Millisecond, "header should appear after auth completes")
 
 	cancel()

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -1,18 +1,24 @@
 package integration_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/creack/pty"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/go-connections/nat"
@@ -458,6 +464,53 @@ func containerEnvToMap(envList []string) map[string]string {
 		m[k] = v
 	}
 	return m
+}
+
+func TestStartHidesHeaderUntilAuthComplete(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+	requireDocker(t)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockAPIServer(t, "test-license-token", true)
+	defer mockServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd.Env = env.Without(env.AuthToken).With(env.APIEndpoint, mockServer.URL)
+
+	ptmx, err := pty.Start(cmd)
+	require.NoError(t, err, "failed to start command in PTY")
+	defer func() { _ = ptmx.Close() }()
+
+	output := &syncBuffer{}
+	go func() {
+		_, _ = io.Copy(output, ptmx)
+	}()
+
+	// Wait for the login prompt — header must not be visible yet.
+	require.Eventually(t, func() bool {
+		return bytes.Contains(output.Bytes(), []byte("Press any key when complete"))
+	}, 10*time.Second, 100*time.Millisecond, "auth prompt should appear")
+
+	assert.NotContains(t, output.String(), "lstk (", "header must be hidden while auth is pending")
+
+	// Complete auth by pressing ENTER.
+	_, err = ptmx.Write([]byte("\r"))
+	require.NoError(t, err)
+
+	// After auth completes, the header must appear.
+	require.Eventually(t, func() bool {
+		return bytes.Contains(output.Bytes(), []byte("lstk ("))
+	}, 10*time.Second, 100*time.Millisecond, "header should appear after auth completes")
+
+	cancel()
+	_ = cmd.Wait()
 }
 
 func cleanup() {


### PR DESCRIPTION
On first interactive run with no auth token, run the device-flow login before launching the start UI so the header doesn't render with (No license) while authentication is still pending. This will hide the banner during the login flow and render the header after login succeeds and the start UI takes over with a resolved license label.

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="723" alt="Screenshot 2026-04-28 at 11 57 10" src="https://github.com/user-attachments/assets/e3d9b24e-b9b4-4d51-b8d7-83a0e8c15c32" /> | <img width="1271" height="240" alt="image" src="https://github.com/user-attachments/assets/b112fc24-6465-4fa9-ac2e-5e67b5bbd90e" /><img width="1281" height="303" alt="image" src="https://github.com/user-attachments/assets/d960b6c3-eaad-4273-b574-b0c5c11f3bc0" /> | 