### PR TITLE
Integration tests parallelism - part 1

### DIFF
--- a/test/integration/awsconfig_test.go
+++ b/test/integration/awsconfig_test.go
@@ -208,6 +208,7 @@ func TestStartEmitsNoteWhenAWSProfileIsPartial(t *testing.T) {
 }
 
 func TestConfigProfileCreatesAWSProfileWhenConfirmed(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
 	}
@@ -258,6 +259,7 @@ func TestConfigProfileCreatesAWSProfileWhenConfirmed(t *testing.T) {
 }
 
 func TestSetupAWSCreatesAWSProfileWhenConfirmed(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
 	}
@@ -308,6 +310,7 @@ func TestSetupAWSCreatesAWSProfileWhenConfirmed(t *testing.T) {
 }
 
 func TestConfigProfileDoesNotCreateAWSProfileWhenDeclined(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
 	}
@@ -349,6 +352,7 @@ func TestConfigProfileDoesNotCreateAWSProfileWhenDeclined(t *testing.T) {
 }
 
 func TestSetupAWSNonInteractiveReturnsError(t *testing.T) {
+	t.Parallel()
 	baseEnv, _ := awsConfigEnv(t)
 
 	_, stderr, err := runLstk(t, testContext(t), "",

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestConfigFileCreatedOnStartup(t *testing.T) {
+	t.Parallel()
 	t.Run("creates in home .config when present", func(t *testing.T) {
+		t.Parallel()
 		tmpHome := t.TempDir()
 		workDir := t.TempDir()
 		xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
@@ -30,6 +32,7 @@ func TestConfigFileCreatedOnStartup(t *testing.T) {
 	})
 
 	t.Run("falls back to os user config dir when home .config is missing", func(t *testing.T) {
+		t.Parallel()
 		tmpHome := t.TempDir()
 		workDir := t.TempDir()
 		xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
@@ -79,6 +82,7 @@ IAM_SOFT_MODE = "1"
 }
 
 func TestConfigFlagOverridesConfigPath(t *testing.T) {
+	t.Parallel()
 	customConfig := filepath.Join(t.TempDir(), "custom.toml")
 	writeConfigFile(t, customConfig)
 
@@ -90,6 +94,7 @@ func TestConfigFlagOverridesConfigPath(t *testing.T) {
 }
 
 func TestLocalConfigTakesPrecedence(t *testing.T) {
+	t.Parallel()
 	tmpHome := t.TempDir()
 	workDir := t.TempDir()
 	xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
@@ -110,6 +115,7 @@ func TestLocalConfigTakesPrecedence(t *testing.T) {
 }
 
 func TestXDGConfigTakesPrecedence(t *testing.T) {
+	t.Parallel()
 	tmpHome := t.TempDir()
 	workDir := t.TempDir()
 	xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
@@ -128,6 +134,7 @@ func TestXDGConfigTakesPrecedence(t *testing.T) {
 }
 
 func TestConfigPathCommand(t *testing.T) {
+	t.Parallel()
 	tmpHome := t.TempDir()
 	workDir := t.TempDir()
 	xdgConfigFile := filepath.Join(tmpHome, ".config", "lstk", "config.toml")
@@ -144,6 +151,7 @@ func TestConfigPathCommand(t *testing.T) {
 }
 
 func TestConfigPathCommandDoesNotCreateConfig(t *testing.T) {
+	t.Parallel()
 	tmpHome := t.TempDir()
 	workDir := t.TempDir()
 	xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
@@ -159,6 +167,7 @@ func TestConfigPathCommandDoesNotCreateConfig(t *testing.T) {
 }
 
 func TestConfigWithUnknownFieldsIsAccepted(t *testing.T) {
+	t.Parallel()
 	configContent := `
 unknown_top_level = "should be ignored"
 
@@ -177,6 +186,7 @@ future_field = "should be ignored"
 }
 
 func TestConfigWithMissingRequiredPortFails(t *testing.T) {
+	t.Parallel()
 	configContent := `
 [[containers]]
 type = "aws"
@@ -192,6 +202,7 @@ tag = "latest"
 }
 
 func TestLegacyYAMLConfigGivesHelpfulError(t *testing.T) {
+	t.Parallel()
 	tmpHome := t.TempDir()
 	workDir := t.TempDir()
 	xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
@@ -213,6 +224,7 @@ func TestLegacyYAMLConfigGivesHelpfulError(t *testing.T) {
 }
 
 func TestConfigWithMissingOptionalTagSucceeds(t *testing.T) {
+	t.Parallel()
 	configContent := `
 [[containers]]
 type = "aws"

--- a/test/integration/docs_test.go
+++ b/test/integration/docs_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestDocsCommandGeneratesManPages(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(t.TempDir(), "manpages")
 
 	_, stderr, err := runLstk(t, testContext(t), "", os.Environ(), "docs", "--format", "man", "--dir", dir)
@@ -22,6 +23,7 @@ func TestDocsCommandGeneratesManPages(t *testing.T) {
 }
 
 func TestDocsCommandGeneratesMarkdown(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(t.TempDir(), "markdown")
 
 	_, stderr, err := runLstk(t, testContext(t), "", os.Environ(), "docs", "--format", "markdown", "--dir", dir)
@@ -34,6 +36,7 @@ func TestDocsCommandGeneratesMarkdown(t *testing.T) {
 }
 
 func TestDocsCommandRejectsInvalidFormat(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	_, _, err := runLstk(t, testContext(t), "", os.Environ(), "docs", "--format", "invalid", "--dir", dir)
@@ -42,6 +45,7 @@ func TestDocsCommandRejectsInvalidFormat(t *testing.T) {
 }
 
 func TestDocsCommandIsHidden(t *testing.T) {
+	t.Parallel()
 	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--help")
 	require.NoError(t, err, stderr)
 

--- a/test/integration/license_test.go
+++ b/test/integration/license_test.go
@@ -104,7 +104,6 @@ func licenseFilePath(t *testing.T) string {
 
 func cleanupLicense() {
 	ctx := context.Background()
-	_ = dockerClient.ContainerStop(ctx, containerName, container.StopOptions{})
 	_ = dockerClient.ContainerRemove(ctx, containerName, container.RemoveOptions{Force: true})
 	if cacheDir, err := os.UserCacheDir(); err == nil {
 		_ = os.Remove(filepath.Join(cacheDir, "lstk", "license.json"))

--- a/test/integration/logging_test.go
+++ b/test/integration/logging_test.go
@@ -3,18 +3,35 @@ package integration_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLogging_NonTTY_WritesToLogFile(t *testing.T) {
-	logPath := filepath.Join(configDir(), "lstk.log")
-	_ = os.Remove(logPath)
+	t.Parallel()
+
+	tmpHome := t.TempDir()
+	var logPath string
+	var e env.Environ
+	if runtime.GOOS == "windows" {
+		appData := filepath.Join(tmpHome, "AppData", "Roaming")
+		e = env.Without("HOME", "XDG_CONFIG_HOME", "APPDATA", "USERPROFILE", "HOMEDRIVE", "HOMEPATH").
+			With(env.Home, tmpHome).
+			With("USERPROFILE", tmpHome).
+			With("APPDATA", appData)
+		logPath = filepath.Join(appData, "lstk", "lstk.log")
+	} else {
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, ".config"), 0755))
+		e = env.Without("HOME", "XDG_CONFIG_HOME").With(env.Home, tmpHome)
+		logPath = filepath.Join(tmpHome, ".config", "lstk", "lstk.log")
+	}
 
 	ctx := testContext(t)
-	_, _, err := runLstk(t, ctx, "", nil, "--version")
+	_, _, err := runLstk(t, ctx, "", e, "--version")
 	require.NoError(t, err)
 
 	logContents, err := os.ReadFile(logPath)
@@ -24,11 +41,18 @@ func TestLogging_NonTTY_WritesToLogFile(t *testing.T) {
 }
 
 func TestLogging_TTY_WritesToLogFile(t *testing.T) {
-	logPath := filepath.Join(configDir(), "lstk.log")
-	_ = os.Remove(logPath)
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	tmpHome := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, ".config"), 0755))
+	logPath := filepath.Join(tmpHome, ".config", "lstk", "lstk.log")
+	e := env.Without("HOME", "XDG_CONFIG_HOME").With(env.Home, tmpHome)
 
 	ctx := testContext(t)
-	_, err := runLstkInPTY(t, ctx, nil, "--version")
+	_, err := runLstkInPTY(t, ctx, e, "--version")
 	require.NoError(t, err)
 
 	logContents, err := os.ReadFile(logPath)

--- a/test/integration/logs_test.go
+++ b/test/integration/logs_test.go
@@ -2,7 +2,9 @@ package integration_test
 
 import (
 	"bufio"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// writeAwsConfig writes a minimal aws-only config so tests don't inherit the
+// developer's real ~/.config/lstk/config.toml (which may target a different
+// emulator / running container).
+func writeAwsConfig(t *testing.T) string {
+	t.Helper()
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+[[containers]]
+type = "aws"
+tag  = "latest"
+port = "4566"
+`), 0644))
+	return configFile
+}
+
 func TestLogsExitsByDefault(t *testing.T) {
 	requireDocker(t)
 	cleanup()
@@ -21,8 +38,9 @@ func TestLogsExitsByDefault(t *testing.T) {
 	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
+	configFile := writeAwsConfig(t)
 	analyticsSrv, events := mockAnalyticsServer(t)
-	_, _, err := runLstk(t, ctx, "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "logs")
+	_, _, err := runLstk(t, ctx, "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "--config", configFile, "logs")
 	require.NoError(t, err, "lstk logs should exit cleanly when container is running")
 	requireExitCode(t, 0, err)
 	assertCommandTelemetry(t, events, "logs", 0)
@@ -33,8 +51,9 @@ func TestLogsCommandFailsWhenNotRunning(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
+	configFile := writeAwsConfig(t)
 	analyticsSrv, events := mockAnalyticsServer(t)
-	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "logs", "--follow")
+	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "--config", configFile, "logs", "--follow")
 	require.Error(t, err, "expected lstk logs --follow to fail when container not running")
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stderr, "emulator is not running")
@@ -51,8 +70,9 @@ func TestLogsFollowStreamsOutput(t *testing.T) {
 
 	const marker = "lstk-logs-test-marker"
 
+	configFile := writeAwsConfig(t)
 	// Uses StdoutPipe for streaming — cannot use runLstk.
-	logsCmd := exec.CommandContext(ctx, binaryPath(), "logs", "--follow")
+	logsCmd := exec.CommandContext(ctx, binaryPath(), "--config", configFile, "logs", "--follow")
 	stdout, err := logsCmd.StdoutPipe()
 	require.NoError(t, err, "failed to get stdout pipe")
 

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -225,7 +225,6 @@ func startExternalContainer(t *testing.T, ctx context.Context, imgName, name, ho
 	err = dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
 	require.NoError(t, err, "failed to start external container")
 	t.Cleanup(func() {
-		_ = dockerClient.ContainerStop(context.Background(), name, container.StopOptions{})
 		_ = dockerClient.ContainerRemove(context.Background(), name, container.RemoveOptions{Force: true})
 	})
 }

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -439,14 +439,14 @@ func containerEnvToMap(envList []string) map[string]string {
 
 func cleanup() {
 	ctx := context.Background()
-	_ = dockerClient.ContainerStop(ctx, containerName, container.StopOptions{})
+	// ContainerRemove with Force already SIGKILLs the container; an explicit
+	// ContainerStop first would add the default 10s SIGTERM grace period.
 	_ = dockerClient.ContainerRemove(ctx, containerName, container.RemoveOptions{Force: true})
 	_ = DeleteAuthTokenFromKeyring()
 }
 
 func cleanupSnowflake() {
 	ctx := context.Background()
-	_ = dockerClient.ContainerStop(ctx, snowflakeContainerName, container.StopOptions{})
 	_ = dockerClient.ContainerRemove(ctx, snowflakeContainerName, container.RemoveOptions{Force: true})
 }
 

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestUpdateCheckCommand(t *testing.T) {
+	t.Parallel()
 	ctx := testContext(t)
 
 	analyticsSrv, events := mockAnalyticsServer(t)
@@ -32,6 +33,7 @@ func TestUpdateCheckCommand(t *testing.T) {
 }
 
 func TestUpdateCheckCommandNonInteractive(t *testing.T) {
+	t.Parallel()
 	ctx := testContext(t)
 
 	stdout, stderr, err := runLstk(t, ctx, "", nil, "update", "--check", "--non-interactive")
@@ -48,6 +50,7 @@ func requireNPM(t *testing.T) {
 }
 
 func TestUpdateNPMInstall(t *testing.T) {
+	t.Parallel()
 	requireNPM(t)
 
 	// Skip if lstk is already installed globally (e.g., via Homebrew).
@@ -114,6 +117,7 @@ func TestUpdateNPMInstall(t *testing.T) {
 }
 
 func TestUpdateBinaryInPlace(t *testing.T) {
+	t.Parallel()
 	ctx := testContext(t)
 
 	// Build a fake old version to a temp location
@@ -221,6 +225,7 @@ func TestUpdateHomebrew(t *testing.T) {
 }
 
 func TestUpdateNotification(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
 	}
@@ -243,9 +248,10 @@ func TestUpdateNotification(t *testing.T) {
 
 	// Mock API server so license validation fails fast after the notification
 	mockServer := createMockLicenseServer(false)
-	defer mockServer.Close()
+	t.Cleanup(mockServer.Close)
 
 	t.Run("skip", func(t *testing.T) {
+		t.Parallel()
 		configFile := filepath.Join(t.TempDir(), "config.toml")
 		originalConfig := `# User-maintained lstk config
 [[containers]]
@@ -295,6 +301,7 @@ port = "4566"    # Host port
 
 
 	t.Run("update", func(t *testing.T) {
+		t.Parallel()
 		// Copy binary since it will be replaced during the update
 		updateBinary := filepath.Join(t.TempDir(), "lstk")
 		data, err := os.ReadFile(tmpBinary)


### PR DESCRIPTION
## Summary

First pass at parallelizing the integration test suite, only addresses the low-hanging fruits. Docker-dependent tests are left serial for a follow-up since they share container name, ports and the host's Docker daemon.
Execution time goes from about 12min to 7min.

towards DRG-665

### Changes

- `t.Parallel()` added to tests that are safe to run concurrently
- Isolate some tests from the developer's real config, changed values of `HOME` / `XDG_CONFIG_HOME`
- Drop redundant `ContainerStop` calls before `ContainerRemove(Force: true)` in cleanup because Force-remove already SIGKILLs; an explicit stop first would add the default 10s SIGTERM grace period for nothing. 
