### PR TITLE
Hide header when already logged-in

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/auth"
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/log"
+	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/localstack/lstk/internal/version"
@@ -23,14 +25,25 @@ func newLoginCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 			if !isInteractiveMode(cfg) {
 				return fmt.Errorf("login requires an interactive terminal")
 			}
+			tokenStorage, err := auth.NewTokenStorage(cfg.ForceFileKeyring, logger)
+			if err != nil {
+				return fmt.Errorf("failed to initialize token storage: %w", err)
+			}
+			sink := output.NewPlainSink(os.Stdout)
+			if cfg.AuthToken != "" {
+				sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: "You're already logged in"})
+				return nil
+			}
+			if token, err := tokenStorage.GetAuthToken(); err == nil && token != "" {
+				sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: "You're already logged in"})
+				return nil
+			}
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
 			if err := ui.RunLogin(cmd.Context(), version.Version(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL, logger); err != nil {
 				return err
 			}
-			if tokenStorage, err := auth.NewTokenStorage(cfg.ForceFileKeyring, logger); err == nil {
-				if token, err := tokenStorage.GetAuthToken(); err == nil && token != "" {
-					tel.SetAuthToken(token)
-				}
+			if token, err := tokenStorage.GetAuthToken(); err == nil && token != "" {
+				tel.SetAuthToken(token)
 			}
 			return nil
 		},

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/auth"
@@ -29,14 +28,11 @@ func newLoginCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 			if err != nil {
 				return fmt.Errorf("failed to initialize token storage: %w", err)
 			}
-			sink := output.NewPlainSink(os.Stdout)
 			if cfg.AuthToken != "" {
-				sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: "You're already logged in"})
-				return nil
+				return ui.RunMessage(cmd.Context(), output.MessageEvent{Severity: output.SeverityNote, Text: "You're already logged in"})
 			}
 			if token, err := tokenStorage.GetAuthToken(); err == nil && token != "" {
-				sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: "You're already logged in"})
-				return nil
+				return ui.RunMessage(cmd.Context(), output.MessageEvent{Severity: output.SeverityNote, Text: "You're already logged in"})
 			}
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)
 			if err := ui.RunLogin(cmd.Context(), version.Version(), platformClient, cfg.AuthToken, cfg.ForceFileKeyring, cfg.WebAppURL, logger); err != nil {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -28,10 +28,8 @@ func newLoginCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 			if err != nil {
 				return fmt.Errorf("failed to initialize token storage: %w", err)
 			}
-			if cfg.AuthToken != "" {
-				return ui.RunMessage(cmd.Context(), output.MessageEvent{Severity: output.SeverityNote, Text: "You're already logged in"})
-			}
-			if token, err := tokenStorage.GetAuthToken(); err == nil && token != "" {
+			storedToken, _ := tokenStorage.GetAuthToken()
+			if cfg.AuthToken != "" || storedToken != "" {
 				return ui.RunMessage(cmd.Context(), output.MessageEvent{Severity: output.SeverityNote, Text: "You're already logged in"})
 			}
 			platformClient := api.NewPlatformClient(cfg.APIEndpoint, logger)

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/localstack/lstk/internal/ui/styles"
 )
 
 // FormatEventLine converts an output event into a single display line.
@@ -118,13 +120,13 @@ func formatAuthEvent(e AuthEvent) string {
 func formatMessageEvent(e MessageEvent) string {
 	switch e.Severity {
 	case SeveritySuccess:
-		return SuccessMarker() + " " + e.Text
+		return styles.Success.Render(SuccessMarker()) + " " + e.Text
 	case SeverityNote:
-		return "> Note: " + e.Text
+		return styles.Secondary.Render(">") + " " + styles.Note.Render("Note:") + " " + e.Text
 	case SeverityWarning:
-		return "> Warning: " + e.Text
+		return styles.Secondary.Render(">") + " " + styles.Warning.Render("Warning:") + " " + e.Text
 	case SeveritySecondary:
-		return e.Text
+		return styles.SecondaryMessage.Render(e.Text)
 	default:
 		return e.Text
 	}

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/localstack/lstk/internal/ui/styles"
 )
 
 // FormatEventLine converts an output event into a single display line.
@@ -120,13 +118,13 @@ func formatAuthEvent(e AuthEvent) string {
 func formatMessageEvent(e MessageEvent) string {
 	switch e.Severity {
 	case SeveritySuccess:
-		return styles.Success.Render(SuccessMarker()) + " " + e.Text
+		return SuccessMarker() + " " + e.Text
 	case SeverityNote:
-		return styles.Secondary.Render(">") + " " + styles.Note.Render("Note:") + " " + e.Text
+		return "> Note: " + e.Text
 	case SeverityWarning:
-		return styles.Secondary.Render(">") + " " + styles.Warning.Render("Warning:") + " " + e.Text
+		return "> Warning: " + e.Text
 	case SeveritySecondary:
-		return styles.SecondaryMessage.Render(e.Text)
+		return e.Text
 	default:
 		return e.Text
 	}

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -98,6 +98,13 @@ func Run(parentCtx context.Context, runOpts RunOptions) error {
 	return nil
 }
 
+func RunMessage(parentCtx context.Context, event output.MessageEvent) error {
+	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
+		sink.Emit(event)
+		return nil
+	})
+}
+
 func IsInteractive() bool {
 	return term.IsTerminal(int(os.Stdout.Fd())) && term.IsTerminal(int(os.Stdin.Fd()))
 }

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -45,7 +45,7 @@ var (
 		Foreground(lipgloss.Color(SuccessColor))
 
 	Note = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("33"))
+		Foreground(lipgloss.Color("69"))
 
 	Warning = lipgloss.NewStyle().
 		Foreground(lipgloss.Color("214"))

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -193,4 +195,41 @@ func TestDeviceFlowFailure_RequestNotConfirmed(t *testing.T) {
 	_, err = GetAuthTokenFromKeyring()
 	assert.Error(t, err, "no token should be stored when login fails")
 	assertCommandTelemetry(t, events, "login", 1)
+}
+
+func TestLoginShortCircuitsWhenEnvTokenSet(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+	t.Parallel()
+
+	environ := append(testEnvWithHome(t.TempDir(), ""), string(env.AuthToken)+"=fake-env-token")
+
+	out, err := runLstkInPTY(t, testContext(t), environ, "login")
+	require.NoError(t, err, "login should succeed when env token is set: %s", out)
+	requireExitCode(t, 0, err)
+	assert.Contains(t, out, "You're already logged in")
+	assert.NotContains(t, out, "Opening browser")
+	assert.NotContains(t, out, "Waiting for authorization")
+}
+
+func TestLoginShortCircuitsWhenStoredTokenExists(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+	t.Parallel()
+
+	tmpHome := t.TempDir()
+	tokenDir := filepath.Join(tmpHome, ".config", "lstk")
+	require.NoError(t, os.MkdirAll(tokenDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(tokenDir, "auth-token"), []byte("stored-token"), 0600))
+
+	environ := env.Environ(testEnvWithHome(tmpHome, "")).Without(env.AuthToken)
+
+	out, err := runLstkInPTY(t, testContext(t), environ, "login")
+	require.NoError(t, err, "login should succeed when stored token exists: %s", out)
+	requireExitCode(t, 0, err)
+	assert.Contains(t, out, "You're already logged in")
+	assert.NotContains(t, out, "Opening browser")
+	assert.NotContains(t, out, "Waiting for authorization")
 }


### PR DESCRIPTION
Hide header/banner when already logged in (env var or stored token), only emits a colored note and exits without showing the header.


| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="532" alt="Screenshot 2026-04-28 at 16 47 58" src="https://github.com/user-attachments/assets/55df88b6-10d4-4e0a-ae08-c722da6a880f" /> | <img width="669" height="532" alt="Screenshot 2026-04-28 at 16 44 14" src="https://github.com/user-attachments/assets/3e8c1fcf-c86f-43ef-b86d-ce435de43acd" /> | 