### PR TITLE
 Integration tests parallelism - CI sharding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Ubuntu integration tests are sharded across 4 runners — they dominate
-        # wall time (~7min unsharded). macOS and Windows stay single-runner;
-        # they're already fast and Homebrew/PTY-style tests benefit less from
-        # sharding.
         include:
           - os: ubuntu-latest
             shard: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,21 @@ jobs:
           path: test-integration-results.xml
           reporter: java-junit
 
+  # Aggregator job under a stable name so branch ruleset can require a single
+  # status check regardless of how many shards the integration matrix uses.
+  test-integration-summary:
+    name: Integration Tests (ubuntu-latest)
+    runs-on: ubuntu-latest
+    needs: test-integration
+    if: always()
+    steps:
+      - name: Verify integration matrix succeeded
+        run: |
+          if [ "${{ needs.test-integration.result }}" != "success" ]; then
+            echo "test-integration matrix result: ${{ needs.test-integration.result }}"
+            exit 1
+          fi
+
   release:
     name: Build and Publish Release
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,30 @@ jobs:
           reporter: java-junit
 
   test-integration:
-    name: Integration Tests (${{ matrix.os }})
+    name: Integration Tests (${{ matrix.os }}${{ matrix.shard && format(' shard {0}/{1}', matrix.shard, matrix.shard_total) || '' }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Ubuntu integration tests are sharded across 4 runners — they dominate
+        # wall time (~7min unsharded). macOS and Windows stay single-runner;
+        # they're already fast and Homebrew/PTY-style tests benefit less from
+        # sharding.
+        include:
+          - os: ubuntu-latest
+            shard: 0
+            shard_total: 4
+          - os: ubuntu-latest
+            shard: 1
+            shard_total: 4
+          - os: ubuntu-latest
+            shard: 2
+            shard_total: 4
+          - os: ubuntu-latest
+            shard: 3
+            shard_total: 4
+          - os: macos-latest
+          - os: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -112,19 +130,21 @@ jobs:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           LSTK_TEST_HOMEBREW: ${{ matrix.os == 'macos-latest' && '1' || '0' }}
           LSTK_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHARD_INDEX: ${{ matrix.shard }}
+          SHARD_TOTAL: ${{ matrix.shard_total }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: integration-test-results-${{ matrix.os }}
+          name: integration-test-results-${{ matrix.os }}${{ matrix.shard && format('-{0}', matrix.shard) || '' }}
           path: test-integration-results.xml
 
       - name: Test report
         uses: dorny/test-reporter@v3
         if: always()
         with:
-          name: Integration Test Results (${{ matrix.os }})
+          name: Integration Test Results (${{ matrix.os }}${{ matrix.shard && format(' shard {0}/{1}', matrix.shard, matrix.shard_total) || '' }})
           path: test-integration-results.xml
           reporter: java-junit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,6 @@ jobs:
         # sharding.
         include:
           - os: ubuntu-latest
-            shard: 0
-            shard_total: 4
-          - os: ubuntu-latest
             shard: 1
             shard_total: 4
           - os: ubuntu-latest
@@ -102,6 +99,9 @@ jobs:
             shard_total: 4
           - os: ubuntu-latest
             shard: 3
+            shard_total: 4
+          - os: ubuntu-latest
+            shard: 4
             shard_total: 4
           - os: macos-latest
           - os: windows-latest

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,7 @@ test:
 	go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- ./cmd/... ./internal/...
 
 test-integration: $(BUILD_DIR)/$(BINARY_NAME)
-	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile ../../test-integration-results.xml"; \
-	if [ "$$(uname)" = "Darwin" ]; then \
-		cd test/integration && LSTK_KEYRING=file go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 -timeout 15m $(if $(RUN),-run $(RUN)) ./...; \
-	else \
-		cd test/integration && go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- -count=1 -timeout 15m $(if $(RUN),-run $(RUN)) ./...; \
-	fi
+	@RUN="$(RUN)" ./scripts/test-integration.sh
 
 otel:
 	docker compose -f docker-compose.tracing.yaml up -d

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -3,7 +3,7 @@
 #
 # Honors:
 #   CREATE_JUNIT_REPORT  Emit JUnit XML when set.
-#   SHARD_INDEX          0-based shard index (used with SHARD_TOTAL).
+#   SHARD_INDEX          1-based shard index (used with SHARD_TOTAL).
 #   SHARD_TOTAL          Total number of shards. When set, this run executes
 #                        only the tests assigned to SHARD_INDEX (round-robin
 #                        partition by sorted test name).
@@ -27,12 +27,13 @@ fi
 
 RUN_FLAG=()
 if [ -n "${SHARD_TOTAL:-}" ]; then
-  IDX="${SHARD_INDEX:-0}"
+  IDX="${SHARD_INDEX:-1}"
   # `go test -list` enumerates top-level tests in each package; we filter to
   # lines matching /^Test/ to drop the trailing "ok pkg" summary lines, sort
-  # for stable partitioning, and pick every N-th entry.
+  # for stable partitioning, and pick every N-th entry. SHARD_INDEX is
+  # 1-based for human-friendly CI labels (shard 1/4, 2/4, ...).
   TESTS=$(go test -list '.*' ./... 2>/dev/null | awk '/^Test/' | sort \
-    | awk -v idx="$IDX" -v total="$SHARD_TOTAL" '(NR-1) % total == idx')
+    | awk -v idx="$IDX" -v total="$SHARD_TOTAL" '((NR-1) % total) + 1 == idx')
   if [ -z "$TESTS" ]; then
     echo "no tests for shard $IDX/$SHARD_TOTAL — skipping"
     exit 0

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -28,11 +28,16 @@ fi
 RUN_FLAG=()
 if [ -n "${SHARD_TOTAL:-}" ]; then
   IDX="${SHARD_INDEX:-1}"
-  # `go test -list` enumerates top-level tests in each package; we filter to
-  # lines matching /^Test/ to drop the trailing "ok pkg" summary lines, sort
-  # for stable partitioning, and pick every N-th entry. SHARD_INDEX is
-  # 1-based for human-friendly CI labels (shard 1/4, 2/4, ...).
-  TESTS=$(go test -list '.*' ./... 2>/dev/null | awk '/^Test/' | sort \
+  # `go test -list` enumerates top-level tests in each package. Run it as a
+  # standalone step (no stderr suppression) so compile errors surface loudly
+  # under `set -e` instead of being swallowed into an empty test list. The
+  # subsequent `go test -run` reuses the compiled test binary from Go's build
+  # cache, so this isn't a duplicate compile.
+  LIST_OUTPUT=$(go test -list '.*' ./...)
+  # Filter to lines matching /^Test/ to drop the trailing "ok pkg" summary
+  # lines, sort for stable partitioning, and pick every N-th entry.
+  # SHARD_INDEX is 1-based for human-friendly CI labels (shard 1/4, 2/4, ...).
+  TESTS=$(echo "$LIST_OUTPUT" | awk '/^Test/' | sort \
     | awk -v idx="$IDX" -v total="$SHARD_TOTAL" '((NR-1) % total) + 1 == idx')
   if [ -z "$TESTS" ]; then
     echo "no tests for shard $IDX/$SHARD_TOTAL — skipping"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -44,5 +44,11 @@ elif [ -n "${RUN:-}" ]; then
   RUN_FLAG=(-run "$RUN")
 fi
 
-exec go run gotest.tools/gotestsum@latest --format testname "${JUNIT_FLAG[@]}" \
-  -- -count=1 -timeout 15m "${RUN_FLAG[@]}" ./...
+# Bash 3 (macOS default) treats `${arr[@]}` on an empty array as unbound under
+# `set -u`. The `${arr[@]+"${arr[@]}"}` idiom expands to nothing when the
+# array is empty and to the array's contents otherwise.
+exec go run gotest.tools/gotestsum@latest --format testname \
+  ${JUNIT_FLAG[@]+"${JUNIT_FLAG[@]}"} \
+  -- -count=1 -timeout 15m \
+  ${RUN_FLAG[@]+"${RUN_FLAG[@]}"} \
+  ./...

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Run integration tests, optionally sharded across CI runners.
+#
+# Honors:
+#   CREATE_JUNIT_REPORT  Emit JUnit XML when set.
+#   SHARD_INDEX          0-based shard index (used with SHARD_TOTAL).
+#   SHARD_TOTAL          Total number of shards. When set, this run executes
+#                        only the tests assigned to SHARD_INDEX (round-robin
+#                        partition by sorted test name).
+#   RUN                  Override: pass directly to `go test -run`.
+#
+# Sharding is disabled when SHARD_TOTAL is unset or empty, so the script also
+# acts as a drop-in replacement for the unsharded `go test ./...` invocation.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../test/integration"
+
+JUNIT_FLAG=()
+if [ -n "${CREATE_JUNIT_REPORT:-}" ]; then
+  JUNIT_FLAG=(--junitfile ../../test-integration-results.xml)
+fi
+
+if [ "$(uname)" = "Darwin" ]; then
+  export LSTK_KEYRING=file
+fi
+
+RUN_FLAG=()
+if [ -n "${SHARD_TOTAL:-}" ]; then
+  IDX="${SHARD_INDEX:-0}"
+  # `go test -list` enumerates top-level tests in each package; we filter to
+  # lines matching /^Test/ to drop the trailing "ok pkg" summary lines, sort
+  # for stable partitioning, and pick every N-th entry.
+  TESTS=$(go test -list '.*' ./... 2>/dev/null | awk '/^Test/' | sort \
+    | awk -v idx="$IDX" -v total="$SHARD_TOTAL" '(NR-1) % total == idx')
+  if [ -z "$TESTS" ]; then
+    echo "no tests for shard $IDX/$SHARD_TOTAL — skipping"
+    exit 0
+  fi
+  REGEX="^($(echo "$TESTS" | paste -sd '|' -))\$"
+  RUN_FLAG=(-run "$REGEX")
+elif [ -n "${RUN:-}" ]; then
+  RUN_FLAG=(-run "$RUN")
+fi
+
+exec go run gotest.tools/gotestsum@latest --format testname "${JUNIT_FLAG[@]}" \
+  -- -count=1 -timeout 15m "${RUN_FLAG[@]}" ./...


### PR DESCRIPTION
## Summary

Shards Ubuntu integration tests across 4 GitHub Actions runners. macOS and Windows stay single-runner.
Slowest CI job overall before: 6m40s, after (ubuntu shard 4/4): 3m07s.


## Changes

- **`.github/workflows/ci.yml`** — replace flat `os` matrix with `include:` entries adding `shard` / `shard_total` for Ubuntu only.
- **`Makefile`** — `test-integration` now delegates to `scripts/test-integration.sh`.
- **`scripts/test-integration.sh`** (new) — when `SHARD_TOTAL` is set, runs `go test -list` once, partitions top-level test names round-robin by sorted name, and passes the resulting `-run` regex to gotestsum. When unset, behaves exactly like the previous Makefile invocation. `RUN=` still works for `make test-integration RUN=...` locally. 