### PR TITLE
Hide catalog-resolved license version from start output

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -149,17 +149,17 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		binds = append(binds, runtime.BindMount{HostPath: volumeDir, ContainerPath: "/var/lib/localstack"})
 
 		containers[i] = runtime.ContainerConfig{
-			Image:              image,
-			Name:               containerName,
-			EmulatorType:       string(c.Type),
-			Port:               c.Port,
-			ContainerPort:      containerPort,
-			HealthPath:         healthPath,
-			Env:                env,
-			Tag:                c.Tag,
-			ProductName: productName,
-			Binds:       binds,
-			ExtraPorts:         servicePortRange(),
+			Image:         image,
+			Name:          containerName,
+			EmulatorType:  string(c.Type),
+			Port:          c.Port,
+			ContainerPort: containerPort,
+			HealthPath:    healthPath,
+			Env:           env,
+			Tag:           c.Tag,
+			ProductName:   productName,
+			Binds:         binds,
+			ExtraPorts:    servicePortRange(),
 		}
 	}
 
@@ -240,7 +240,6 @@ func runPostStartSetups(ctx context.Context, sink output.Sink, containers []conf
 	}
 	return nil
 }
-
 
 func emitPostStartPointers(sink output.Sink, resolvedHost, webAppURL string, showTip bool) {
 	sink.Emit(output.MessageEvent{Severity: output.SeveritySecondary, Text: fmt.Sprintf("• Endpoint: %s", resolvedHost)})
@@ -465,7 +464,7 @@ func emitPortInUseError(sink output.Sink, port string) {
 
 func validateLicense(ctx context.Context, sink output.Sink, opts StartOptions, tel *telemetry.Client, containerConfig runtime.ContainerConfig, token, licenseFilePath string) error {
 	version := containerConfig.Tag
-	sink.Emit(output.ContainerStatusEvent{Phase: "validating license", Container: containerConfig.Name, Detail: version})
+	sink.Emit(output.ContainerStatusEvent{Phase: "validating license", Container: containerConfig.Name})
 
 	hostname, _ := os.Hostname()
 	licenseReq := &api.LicenseRequest{

--- a/test/integration/version_resolution_test.go
+++ b/test/integration/version_resolution_test.go
@@ -73,6 +73,8 @@ func TestVersionResolvedViaCatalog(t *testing.T) {
 		"license request should carry the version returned by the catalog API")
 	assert.NotEqual(t, "latest", *capturedVersion,
 		"license request should not use the unresolved 'latest' tag")
+	assert.Contains(t, stdout, "LocalStack: validating license")
+	assert.NotContains(t, stdout, "validating license (4.14.0)")
 }
 
 // Verifies that when the catalog endpoint is unavailable, the version is resolved


### PR DESCRIPTION
| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="340" alt="Screenshot 2026-04-29 at 14 54 26" src="https://github.com/user-attachments/assets/71e9e623-b8b3-4b77-ba6d-c694d5af44cd" /> | <img width="669" height="340" alt="Screenshot 2026-04-29 at 14 50 38" src="https://github.com/user-attachments/assets/60cbf001-5367-4e43-bc92-bb14ab0132b3" /> | 