### PR TITLE
Skip stale Docker sockets when probing for the daemon

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -77,11 +78,20 @@ func findDockerSocket() string {
 	return probeSocket(vmSocketPaths(home)...)
 }
 
+// Dial as well as stat: a socket file may linger after its daemon is gone (e.g. a
+// stale ~/.docker/run/docker.sock from an uninstalled Docker Desktop) and would
+// otherwise shadow a live socket later in the list.
 func probeSocket(candidates ...string) string {
 	for _, sock := range candidates {
-		if _, err := os.Stat(sock); err == nil {
-			return sock
+		if _, err := os.Stat(sock); err != nil {
+			continue
 		}
+		conn, err := net.DialTimeout("unix", sock, 200*time.Millisecond)
+		if err != nil {
+			continue
+		}
+		_ = conn.Close()
+		return sock
 	}
 	return ""
 }

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,29 +12,67 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProbeSocket_ReturnsFirstExisting(t *testing.T) {
-	dir := t.TempDir()
+// macOS caps Unix socket paths at ~104 chars; t.TempDir() under /var/folders/...
+// can exceed that, so tests that bind sockets must use /tmp.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "lstk-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func listenUnixSocket(t *testing.T, path string) {
+	t.Helper()
+	l, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+}
+
+func TestProbeSocket_ReturnsFirstLive(t *testing.T) {
+	dir := shortTempDir(t)
 	sock1 := filepath.Join(dir, "first.sock")
 	sock2 := filepath.Join(dir, "second.sock")
 
-	require.NoError(t, os.WriteFile(sock1, nil, 0o600))
-	require.NoError(t, os.WriteFile(sock2, nil, 0o600))
+	listenUnixSocket(t, sock1)
+	listenUnixSocket(t, sock2)
 
 	assert.Equal(t, sock1, probeSocket(sock1, sock2))
 }
 
-func TestProbeSocket_SkipsMissingAndReturnsExisting(t *testing.T) {
-	dir := t.TempDir()
+func TestProbeSocket_SkipsMissingAndReturnsLive(t *testing.T) {
+	dir := shortTempDir(t)
 	missing := filepath.Join(dir, "missing.sock")
-	existing := filepath.Join(dir, "existing.sock")
+	live := filepath.Join(dir, "live.sock")
 
-	require.NoError(t, os.WriteFile(existing, nil, 0o600))
+	listenUnixSocket(t, live)
 
-	assert.Equal(t, existing, probeSocket(missing, existing))
+	assert.Equal(t, live, probeSocket(missing, live))
+}
+
+func TestProbeSocket_SkipsStaleSocketForLiveOne(t *testing.T) {
+	dir := shortTempDir(t)
+	stale := filepath.Join(dir, "stale.sock")
+	live := filepath.Join(dir, "live.sock")
+
+	require.NoError(t, os.WriteFile(stale, nil, 0o600))
+	listenUnixSocket(t, live)
+
+	assert.Equal(t, live, probeSocket(stale, live))
 }
 
 func TestProbeSocket_ReturnsEmptyWhenNoneExist(t *testing.T) {
 	assert.Equal(t, "", probeSocket("/no/such/path.sock", "/also/missing.sock"))
+}
+
+func TestProbeSocket_ReturnsEmptyWhenAllStale(t *testing.T) {
+	dir := shortTempDir(t)
+	stale1 := filepath.Join(dir, "stale1.sock")
+	stale2 := filepath.Join(dir, "stale2.sock")
+	require.NoError(t, os.WriteFile(stale1, nil, 0o600))
+	require.NoError(t, os.WriteFile(stale2, nil, 0o600))
+
+	assert.Equal(t, "", probeSocket(stale1, stale2))
 }
 
 func TestProbeSocket_ReturnsEmptyForNoCandidates(t *testing.T) {
@@ -166,11 +205,11 @@ func TestFindDockerSocket_ProbesVMSockets(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir := t.TempDir()
-			sock := filepath.Join(tmpDir, filepath.FromSlash(tc.relPath))
+			home := shortTempDir(t)
+			sock := filepath.Join(home, filepath.FromSlash(tc.relPath))
 			require.NoError(t, os.MkdirAll(filepath.Dir(sock), 0o700))
-			require.NoError(t, os.WriteFile(sock, nil, 0o600))
-			t.Setenv("HOME", tmpDir)
+			listenUnixSocket(t, sock)
+			t.Setenv("HOME", home)
 
 			assert.Equal(t, sock, findDockerSocket())
 		})


### PR DESCRIPTION
## Problem
When Docker Desktop is installed alongside another Docker runtime (e.g., Colima or OrbStack), Docker Desktop can leave behind a stale Unix socket at `~/.docker/run/docker.sock` even when it is not running. This causes lstk to incorrectly probe the stale socket and fail to connect, even though a working Docker daemon is available through the other runtime.

This was reported by a user who had both Docker Desktop and Colima installed. Docker Desktop had been used previously but was only \"stopped\" (not fully exited), leaving its socket file in place. Colima was running and functional, but lstk failed because it tried the stale Docker Desktop socket first.

## Solution
When probing candidate Docker sockets, attempt a \"hello\" ping to each socket and skip any that return `connection refused` or `no such file` errors. The first responsive socket is used. This ensures that stale or orphaned sockets are ignored and a live daemon is found.

## Changes
- Update socket probing loop to test connectivity before selecting a socket
- Add test coverage for stale socket fallback behavior

See DES-212 and [relevant discussion](https://localstack-cloud.slack.com/archives/C0A1857LGTU/p1777550172961019?thread_ts=1773771243.122349&cid=C0A1857LGTU) for more context.