### PR TITLE
Create Linear release on tag push

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,23 @@
+name: Linear Release
+
+on:
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: read
+
+jobs:
+  linear-release:
+    name: Create Linear release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}


### PR DESCRIPTION
This will add a GitHub Actions workflow that creates a Linear release whenever a `v*.*.*` tag is pushed. 

Each Thursday auto-release and any manual tag from `create-release-tag.yml` will now produce a corresponding release in the Linear `CLI` continuous pipeline, with referenced issues attached automatically.

⚠️ Reminder to add `LINEAR_ACCESS_KEY` in the repository secrets. 🎗️ 