### PR TITLE
Reuse testEnvWithHome in logging integration tests

### DIFF
--- a/test/integration/logging_test.go
+++ b/test/integration/logging_test.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,19 +15,13 @@ func TestLogging_NonTTY_WritesToLogFile(t *testing.T) {
 
 	tmpHome := t.TempDir()
 	var logPath string
-	var e env.Environ
 	if runtime.GOOS == "windows" {
-		appData := filepath.Join(tmpHome, "AppData", "Roaming")
-		e = env.Without("HOME", "XDG_CONFIG_HOME", "APPDATA", "USERPROFILE", "HOMEDRIVE", "HOMEPATH").
-			With(env.Home, tmpHome).
-			With("USERPROFILE", tmpHome).
-			With("APPDATA", appData)
-		logPath = filepath.Join(appData, "lstk", "lstk.log")
+		logPath = filepath.Join(tmpHome, "AppData", "Roaming", "lstk", "lstk.log")
 	} else {
 		require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, ".config"), 0755))
-		e = env.Without("HOME", "XDG_CONFIG_HOME").With(env.Home, tmpHome)
 		logPath = filepath.Join(tmpHome, ".config", "lstk", "lstk.log")
 	}
+	e := testEnvWithHome(tmpHome, "")
 
 	ctx := testContext(t)
 	_, _, err := runLstk(t, ctx, "", e, "--version")
@@ -49,7 +42,7 @@ func TestLogging_TTY_WritesToLogFile(t *testing.T) {
 	tmpHome := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, ".config"), 0755))
 	logPath := filepath.Join(tmpHome, ".config", "lstk", "lstk.log")
-	e := env.Without("HOME", "XDG_CONFIG_HOME").With(env.Home, tmpHome)
+	e := testEnvWithHome(tmpHome, "")
 
 	ctx := testContext(t)
 	_, err := runLstkInPTY(t, ctx, e, "--version")


### PR DESCRIPTION
## Summary
- Address [PR #209 review comment](https://github.com/localstack/lstk/pull/209#discussion_r3161891959): reuse existing `testEnvWithHome` helper from `config_test.go` in `logging_test.go` instead of constructing the OS-specific env inline.

## Test plan
- [x] `go test -run TestLogging -count=1 ./test/integration/...` passes locally