### PR TITLE
Integration tests parallelism - isolate HOME

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,8 @@ Environment variables:
 - Prefer integration tests to cover most cases. Use unit tests when integration tests are not practical.
 - **When fixing a bug, always add an integration test** that fails before the fix and passes after. This prevents regressions and documents the exact scenario that was broken.
 - Integration tests that run the CLI binary with Bubble Tea must use a PTY (`github.com/creack/pty`) since Bubble Tea requires a terminal. Use `pty.Start(cmd)` instead of `cmd.CombinedOutput()`, read output with `io.Copy()`, and send keystrokes by writing to the PTY (e.g., `ptmx.Write([]byte("\r"))` for Enter).
+- Mark every integration test with `t.Parallel()` unless it shares external state with other tests. Today the main blocker is the Docker daemon: tests that start LocalStack containers cannot run concurrently because lstk's container discovery matches by `(image, internal port)`, so two parallel runs would cross-contaminate. Tests that only touch the filesystem, mock servers, or the CLI binary itself should be parallel.
+- Never let an integration test inherit the developer's real `$HOME`. Pass an isolated env via `testEnvWithHome(t.TempDir(), "")` (or build on top of it with `env.With(...)`) instead of `nil` or `os.Environ()`. Inheriting HOME pollutes the user's `~/.config/lstk/`, `~/.aws/`, and `~/.cache/lstk/`, and makes parallel runs interfere through shared `lstk.log`, license cache, and file-keyring fallback.
 
 # Output Routing and Events
 

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -86,7 +86,7 @@ func TestConfigFlagOverridesConfigPath(t *testing.T) {
 	customConfig := filepath.Join(t.TempDir(), "custom.toml")
 	writeConfigFile(t, customConfig)
 
-	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", customConfig, "config", "path")
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", customConfig, "config", "path")
 	require.NoError(t, err, stderr)
 	requireExitCode(t, 0, err)
 
@@ -180,7 +180,7 @@ future_field = "should be ignored"
 	configFile := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
-	_, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", configFile, "config", "path")
+	_, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", configFile, "config", "path")
 	require.NoError(t, err, stderr)
 	requireExitCode(t, 0, err)
 }
@@ -195,7 +195,7 @@ tag = "latest"
 	configFile := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
-	_, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", configFile, "stop")
+	_, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", configFile, "stop")
 	require.Error(t, err)
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stderr, "port is required")
@@ -233,7 +233,7 @@ port = "4566"
 	configFile := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
-	_, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", configFile, "config", "path")
+	_, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", configFile, "config", "path")
 	require.NoError(t, err, stderr)
 	requireExitCode(t, 0, err)
 }

--- a/test/integration/docker_unhealthy_test.go
+++ b/test/integration/docker_unhealthy_test.go
@@ -16,6 +16,7 @@ func unhealthyDockerEnv() env.Environ {
 }
 
 func TestStartShowsDockerErrorWhenUnhealthy(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix socket test")
 	}
@@ -28,6 +29,7 @@ func TestStartShowsDockerErrorWhenUnhealthy(t *testing.T) {
 }
 
 func TestStopShowsDockerErrorWhenUnhealthy(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix socket test")
 	}
@@ -40,6 +42,7 @@ func TestStopShowsDockerErrorWhenUnhealthy(t *testing.T) {
 }
 
 func TestStatusShowsDockerErrorWhenUnhealthy(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix socket test")
 	}
@@ -52,6 +55,7 @@ func TestStatusShowsDockerErrorWhenUnhealthy(t *testing.T) {
 }
 
 func TestLogsShowsDockerErrorWhenUnhealthy(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix socket test")
 	}

--- a/test/integration/docker_windows_test.go
+++ b/test/integration/docker_windows_test.go
@@ -18,6 +18,7 @@ func windowsDockerErrorEnv() env.Environ {
 
 // Verifies that when docker is in PATH, lstk suggests "docker desktop start".
 func TestWindowsDockerErrorShowsDockerCLICommand(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows-only test")
 	}
@@ -30,6 +31,7 @@ func TestWindowsDockerErrorShowsDockerCLICommand(t *testing.T) {
 
 // Verifies that the verbose Docker error message is suppressed on Windows.
 func TestWindowsDockerErrorOmitsVerboseSummary(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows-only test")
 	}

--- a/test/integration/docs_test.go
+++ b/test/integration/docs_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,7 +12,7 @@ func TestDocsCommandGeneratesManPages(t *testing.T) {
 	t.Parallel()
 	dir := filepath.Join(t.TempDir(), "manpages")
 
-	_, stderr, err := runLstk(t, testContext(t), "", os.Environ(), "docs", "--format", "man", "--dir", dir)
+	_, stderr, err := runLstk(t, testContext(t), "", testEnvWithHome(t.TempDir(), ""), "docs", "--format", "man", "--dir", dir)
 	require.NoError(t, err, stderr)
 	requireExitCode(t, 0, err)
 
@@ -26,7 +25,7 @@ func TestDocsCommandGeneratesMarkdown(t *testing.T) {
 	t.Parallel()
 	dir := filepath.Join(t.TempDir(), "markdown")
 
-	_, stderr, err := runLstk(t, testContext(t), "", os.Environ(), "docs", "--format", "markdown", "--dir", dir)
+	_, stderr, err := runLstk(t, testContext(t), "", testEnvWithHome(t.TempDir(), ""), "docs", "--format", "markdown", "--dir", dir)
 	require.NoError(t, err, stderr)
 	requireExitCode(t, 0, err)
 
@@ -39,14 +38,14 @@ func TestDocsCommandRejectsInvalidFormat(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	_, _, err := runLstk(t, testContext(t), "", os.Environ(), "docs", "--format", "invalid", "--dir", dir)
+	_, _, err := runLstk(t, testContext(t), "", testEnvWithHome(t.TempDir(), ""), "docs", "--format", "invalid", "--dir", dir)
 	require.Error(t, err)
 	requireExitCode(t, 1, err)
 }
 
 func TestDocsCommandIsHidden(t *testing.T) {
 	t.Parallel()
-	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--help")
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--help")
 	require.NoError(t, err, stderr)
 
 	assert.NotContains(t, stdout, "docs")

--- a/test/integration/logout_test.go
+++ b/test/integration/logout_test.go
@@ -62,7 +62,7 @@ func TestLogoutCommandNotesWhenEmulatorStillRunning(t *testing.T) {
 	err := SetAuthTokenInKeyring("test-token")
 	require.NoError(t, err, "failed to store token in keyring")
 
-	stdout, stderr, err := runLstk(t, ctx, "", nil, "logout")
+	stdout, stderr, err := runLstk(t, ctx, "", testEnvWithHome(t.TempDir(), ""), "logout")
 	require.NoError(t, err, "lstk logout failed: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "LocalStack is still running in the background")

--- a/test/integration/non_interactive_test.go
+++ b/test/integration/non_interactive_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestNonInteractiveFlagBlocksLogin(t *testing.T) {
-	out, err := runLstkInPTY(t, testContext(t), nil, "login", "--non-interactive")
+	t.Parallel()
+	out, err := runLstkInPTY(t, testContext(t), testEnvWithHome(t.TempDir(), ""), "login", "--non-interactive")
 	require.Error(t, err, "expected login --non-interactive to fail")
 	requireExitCode(t, 1, err)
 	assert.Contains(t, out, "login requires an interactive terminal")

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -114,7 +114,7 @@ func TestStatusCommandWorksWithNonDefaultPort(t *testing.T) {
 	configFile := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
-	stdout, stderr, err := runLstk(t, ctx, "", nil, "--config", configFile, "status")
+	stdout, stderr, err := runLstk(t, ctx, "", testEnvWithHome(t.TempDir(), ""), "--config", configFile, "status")
 	require.NoError(t, err, "lstk status failed: %s", stderr)
 	assert.Contains(t, stdout, "4.14.1")
 }
@@ -163,7 +163,7 @@ func TestStatusCommandForSnowflakeShowsNoResources(t *testing.T) {
 	ctx := testContext(t)
 	startTestSnowflakeContainer(t, ctx)
 
-	stdout, stderr, err := runLstk(t, ctx, "", nil, "--config", writeSnowflakeConfig(t, "4566"), "status")
+	stdout, stderr, err := runLstk(t, ctx, "", testEnvWithHome(t.TempDir(), ""), "--config", writeSnowflakeConfig(t, "4566"), "status")
 	require.NoError(t, err, "lstk status failed for snowflake: %s", stderr)
 	requireExitCode(t, 0, err)
 

--- a/test/integration/stop_test.go
+++ b/test/integration/stop_test.go
@@ -62,7 +62,7 @@ func TestStopCommandStopsExternalContainer(t *testing.T) {
 
 	startExternalContainer(t, ctx, fakeImage, "localstack-external", "4566")
 
-	stdout, stderr, err := runLstk(t, ctx, "", nil, "stop")
+	stdout, stderr, err := runLstk(t, ctx, "", testEnvWithHome(t.TempDir(), ""), "stop")
 	require.NoError(t, err, "lstk stop should stop external container: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "stopped")
@@ -79,14 +79,15 @@ func TestStopCommandIsIdempotent(t *testing.T) {
 	ctx := testContext(t)
 	startTestContainer(t, ctx)
 
-	_, stderr, err := runLstk(t, ctx, "", nil, "stop")
+	e := testEnvWithHome(t.TempDir(), "")
+	_, stderr, err := runLstk(t, ctx, "", e, "stop")
 	require.NoError(t, err, "first lstk stop failed: %s", stderr)
 	requireExitCode(t, 0, err)
 
 	_, err = dockerClient.ContainerInspect(ctx, containerName)
 	require.Error(t, err, "container should not exist after first stop")
 
-	_, _, err = runLstk(t, ctx, "", nil, "stop")
+	_, _, err = runLstk(t, ctx, "", e, "stop")
 	assert.Error(t, err, "second lstk stop should fail since container already removed")
 	requireExitCode(t, 1, err)
 }

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -36,7 +36,7 @@ func TestUpdateCheckCommandNonInteractive(t *testing.T) {
 	t.Parallel()
 	ctx := testContext(t)
 
-	stdout, stderr, err := runLstk(t, ctx, "", nil, "update", "--check", "--non-interactive")
+	stdout, stderr, err := runLstk(t, ctx, "", testEnvWithHome(t.TempDir(), ""), "update", "--check", "--non-interactive")
 	require.NoError(t, err, "lstk update --check --non-interactive failed: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "Note:", "should show a note in non-interactive mode")

--- a/test/integration/volume_test.go
+++ b/test/integration/volume_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestVolumePathCommand(t *testing.T) {
+	t.Parallel()
 	t.Run("prints default volume path", func(t *testing.T) {
+		t.Parallel()
 		tmpHome := t.TempDir()
 		xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
 		configFile := filepath.Join(tmpHome, ".config", "lstk", "config.toml")
@@ -33,6 +35,7 @@ func TestVolumePathCommand(t *testing.T) {
 	})
 
 	t.Run("prints custom volume path from config", func(t *testing.T) {
+		t.Parallel()
 		customVolume := filepath.Join(t.TempDir(), "my-volume")
 		configContent := `
 [[containers]]
@@ -52,6 +55,7 @@ volume = "` + escapeTomlPath(customVolume) + `"
 	})
 
 	t.Run("emits telemetry", func(t *testing.T) {
+		t.Parallel()
 		tmpHome := t.TempDir()
 		xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
 		configFile := filepath.Join(tmpHome, ".config", "lstk", "config.toml")
@@ -68,7 +72,9 @@ volume = "` + escapeTomlPath(customVolume) + `"
 }
 
 func TestVolumeClearCommand(t *testing.T) {
+	t.Parallel()
 	t.Run("clears volume with force flag", func(t *testing.T) {
+		t.Parallel()
 		volumeDir := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(volumeDir, "cache", "certs"), 0755))
 		require.NoError(t, os.WriteFile(filepath.Join(volumeDir, "cache", "certs", "cert.pem"), []byte("fake cert"), 0644))
@@ -101,6 +107,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 	})
 
 	t.Run("fails without force in non-interactive mode", func(t *testing.T) {
+		t.Parallel()
 		tmpHome := t.TempDir()
 		xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
 		configFile := filepath.Join(tmpHome, ".config", "lstk", "config.toml")
@@ -115,6 +122,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 	})
 
 	t.Run("handles nonexistent volume directory", func(t *testing.T) {
+		t.Parallel()
 		volumeDir := filepath.Join(t.TempDir(), "does-not-exist")
 
 		configContent := `
@@ -135,6 +143,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 	})
 
 	t.Run("filters by emulator type", func(t *testing.T) {
+		t.Parallel()
 		volumeDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(volumeDir, "data.json"), []byte("{}"), 0644))
 
@@ -165,6 +174,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 	})
 
 	t.Run("emits telemetry", func(t *testing.T) {
+		t.Parallel()
 		tmpHome := t.TempDir()
 		xdgOverride := filepath.Join(tmpHome, "xdg-config-home")
 		configFile := filepath.Join(tmpHome, ".config", "lstk", "config.toml")
@@ -180,6 +190,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 	})
 
 	t.Run("suggests sudo when volume contains root-owned files", func(t *testing.T) {
+		t.Parallel()
 		if runtime.GOOS != "linux" {
 			t.Skip("root-owned bind-mount files only occur on Linux")
 		}
@@ -223,6 +234,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 }
 
 func TestVolumeClearInteractive(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
 	}
@@ -263,6 +275,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 	}
 
 	t.Run("clears volume when user confirms with y", func(t *testing.T) {
+		t.Parallel()
 		volumeDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(volumeDir, "data.json"), []byte("{}"), 0644))
 
@@ -279,6 +292,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 	})
 
 	t.Run("cancels when user presses n", func(t *testing.T) {
+		t.Parallel()
 		volumeDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(volumeDir, "data.json"), []byte("{}"), 0644))
 

--- a/test/integration/volume_test.go
+++ b/test/integration/volume_test.go
@@ -47,7 +47,7 @@ volume = "` + escapeTomlPath(customVolume) + `"
 		configFile := filepath.Join(t.TempDir(), "config.toml")
 		require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
-		stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", configFile, "volume", "path")
+		stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", configFile, "volume", "path")
 		require.NoError(t, err, stderr)
 		requireExitCode(t, 0, err)
 
@@ -90,7 +90,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 		configFile := filepath.Join(t.TempDir(), "config.toml")
 		require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
-		stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", configFile, "--non-interactive", "volume", "clear", "--force")
+		stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", configFile, "--non-interactive", "volume", "clear", "--force")
 		require.NoError(t, err, "lstk volume clear failed: %s\nstdout: %s", stderr, stdout)
 		requireExitCode(t, 0, err)
 
@@ -135,7 +135,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 		configFile := filepath.Join(t.TempDir(), "config.toml")
 		require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
-		stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", configFile, "--non-interactive", "volume", "clear", "--force")
+		stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", configFile, "--non-interactive", "volume", "clear", "--force")
 		require.NoError(t, err, "lstk volume clear failed: %s\nstdout: %s", stderr, stdout)
 		requireExitCode(t, 0, err)
 
@@ -158,13 +158,13 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 		require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
 		// Wrong type should fail
-		_, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", configFile, "--non-interactive", "volume", "clear", "--force", "--type", "snowflake")
+		_, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", configFile, "--non-interactive", "volume", "clear", "--force", "--type", "snowflake")
 		require.Error(t, err)
 		requireExitCode(t, 1, err)
 		assert.Contains(t, stderr, "not found")
 
 		// Correct type should succeed
-		stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", configFile, "--non-interactive", "volume", "clear", "--force", "--type", "aws")
+		stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", configFile, "--non-interactive", "volume", "clear", "--force", "--type", "aws")
 		require.NoError(t, err, "lstk volume clear failed: %s\nstdout: %s", stderr, stdout)
 		requireExitCode(t, 0, err)
 
@@ -223,7 +223,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 		configFile := filepath.Join(t.TempDir(), "config.toml")
 		require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
-		_, stderr, err := runLstk(t, testContext(t), t.TempDir(), os.Environ(), "--config", configFile, "--non-interactive", "volume", "clear", "--force")
+		_, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--config", configFile, "--non-interactive", "volume", "clear", "--force")
 		if err == nil {
 			t.Skip("Docker is configured with user namespace remapping; root-owned files cleared without issue")
 		}
@@ -258,7 +258,7 @@ volume = "` + escapeTomlPath(volumeDir) + `"
 	startVolumeClear := func(t *testing.T, configFile string) (*os.File, *syncBuffer, chan struct{}, *exec.Cmd) {
 		t.Helper()
 		cmd := exec.CommandContext(testContext(t), binaryPath(), "--config", configFile, "volume", "clear")
-		cmd.Env = os.Environ()
+		cmd.Env = testEnvWithHome(t.TempDir(), "")
 		ptmx, err := pty.Start(cmd)
 		require.NoError(t, err, "failed to start command in PTY")
 		t.Cleanup(func() { _ = ptmx.Close() })


### PR DESCRIPTION
## Motivation

Continue widening integration-test parallelism on top of the CI sharding landed in #213. Two safe levers picked up here: cover the remaining non-Docker tests with `t.Parallel()`, and stop tests from inheriting the developer's real `$HOME` (which leaks state across parallel runs and pollutes the local config dir).

## Impact

This PR is mostly hygiene + future-proofing, not performance improvement

It also fixes local `make test-integration` runs, which were failing on many tests because they inherited the developer's `$HOME`/config and clashed with state from real lstk usage. 

towards DRG-665