### PR TITLE
Report emulator type mismatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,10 @@ Environment variables:
 - Do not remove comments added by someone else than yourself.
 - Errors returned by functions should always be checked unless in test files.
 - Terminology: in user-facing CLI/help/docs, prefer `emulator` over `container`/`runtime`; use `container`/`runtime` only for internal implementation details.
+- Docker image naming convention (use these names consistently for variables/params/fields):
+  - **full image** (`image`, `imageName`): full reference with registry and tag, e.g. `"localstack/snowflake:latest"`. Used by Docker SDK calls (`PullImage`, `GetImageVersion`).
+  - **image repo** (`imageRepo`, `imageRepos`): registry/name without tag, e.g. `"localstack/snowflake"`. Used by `FindRunningByImage` and image-matching helpers.
+  - **product name** (`productName`, `ProductName`): name only, no registry, no tag, e.g. `"localstack-pro"` / `"snowflake"`. Used for license API `ProductInfo.Name` and to build full images via `dockerRegistry + "/" + ProductName`.
 - Avoid package-level global variables. Use constructor functions that return fresh instances and inject dependencies explicitly. This keeps packages testable in isolation and prevents shared mutable state between tests.
 - Never print directly to stdout/stderr (e.g., `fmt.Fprintf(os.Stderr, …)`). For user-facing output, emit events through `output.Sink`. For internal diagnostics, use `log.Logger`. If neither is available (e.g., during logger setup), return errors to the caller and let them decide.
 - Do not call `config.Get()` from domain/business-logic packages. Instead, extract the values you need at the command boundary (`cmd/`) and pass them as explicit function arguments. This keeps domain functions testable without requiring Viper/config initialization.

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -52,8 +52,8 @@ func newLogoutCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
 			}
 
 			if rt != nil {
-				if running, err := container.AnyRunning(cmd.Context(), rt, appConfig.Containers); err == nil && running {
-					sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: "LocalStack is still running in the background"})
+				if running, err := container.RunningEmulators(cmd.Context(), rt, appConfig.Containers); err == nil && len(running) > 0 {
+					sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: container.StillRunningMessage(running)})
 				}
 			}
 			return nil

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -25,14 +25,45 @@ var emulatorDisplayNames = map[EmulatorType]string{
 	EmulatorAzure:     "Azure",
 }
 
-var emulatorImages = map[EmulatorType]string{
-	EmulatorAWS:       "localstack-pro",
-	EmulatorSnowflake: "snowflake",
-}
-
 var emulatorHealthPaths = map[EmulatorType]string{
 	EmulatorAWS:       "/_localstack/health",
 	EmulatorSnowflake: "/_localstack/health",
+}
+
+var knownImages = []struct {
+	Type        EmulatorType
+	ProductName string
+	Default     bool
+}{
+	{EmulatorAWS, "localstack", false},
+	{EmulatorAWS, "localstack-pro", true},
+	{EmulatorSnowflake, "snowflake", true},
+}
+
+func EmulatorTypeForImage(image string) EmulatorType {
+	repo, _, _ := strings.Cut(image, ":")
+	for _, e := range knownImages {
+		if dockerRegistry+"/"+e.ProductName == repo {
+			return e.Type
+		}
+	}
+	return ""
+}
+
+func KnownImageRepos() []string {
+	repos := make([]string, len(knownImages))
+	for i, e := range knownImages {
+		repos[i] = dockerRegistry + "/" + e.ProductName
+	}
+	return repos
+}
+
+func DisplayNameForType(t EmulatorType) string {
+	name, ok := emulatorDisplayNames[t]
+	if !ok {
+		return fmt.Sprintf("LocalStack %s Emulator", t)
+	}
+	return fmt.Sprintf("LocalStack %s Emulator", name)
 }
 
 type ContainerConfig struct {
@@ -127,18 +158,14 @@ func (c *ContainerConfig) ContainerPort() (string, error) {
 }
 
 func (c *ContainerConfig) DisplayName() string {
-	name, ok := emulatorDisplayNames[c.Type]
-	if !ok {
-		return fmt.Sprintf("LocalStack %s Emulator", c.Type)
-	}
-	return fmt.Sprintf("LocalStack %s Emulator", name)
+	return DisplayNameForType(c.Type)
 }
 
 func (c *ContainerConfig) ProductName() (string, error) {
-	productName, ok := emulatorImages[c.Type]
-	if !ok {
-		return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
+	for _, e := range knownImages {
+		if e.Default && e.Type == c.Type {
+			return e.ProductName, nil
+		}
 	}
-	return productName, nil
+	return "", fmt.Errorf("%s emulator not supported yet by lstk", c.Type)
 }
-

--- a/internal/config/containers.go
+++ b/internal/config/containers.go
@@ -35,8 +35,8 @@ var knownImages = []struct {
 	ProductName string
 	Default     bool
 }{
-	{EmulatorAWS, "localstack", false},
 	{EmulatorAWS, "localstack-pro", true},
+	{EmulatorAWS, "localstack", false},
 	{EmulatorSnowflake, "snowflake", true},
 }
 
@@ -54,6 +54,16 @@ func KnownImageRepos() []string {
 	repos := make([]string, len(knownImages))
 	for i, e := range knownImages {
 		repos[i] = dockerRegistry + "/" + e.ProductName
+	}
+	return repos
+}
+
+func KnownImageReposForType(t EmulatorType) []string {
+	var repos []string
+	for _, e := range knownImages {
+		if e.Type == t {
+			repos = append(repos, dockerRegistry+"/"+e.ProductName)
+		}
 	}
 	return repos
 }

--- a/internal/container/running.go
+++ b/internal/container/running.go
@@ -9,18 +9,29 @@ import (
 	"github.com/localstack/lstk/internal/runtime"
 )
 
-func AnyRunning(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig) (bool, error) {
+func StillRunningMessage(running []config.ContainerConfig) string {
+	names := make([]string, len(running))
+	for i, c := range running {
+		names[i] = c.DisplayName()
+	}
+	if len(names) == 1 {
+		return fmt.Sprintf("%s is still running in the background", names[0])
+	}
+	return fmt.Sprintf("%s are still running in the background", strings.Join(names, ", "))
+}
+
+func RunningEmulators(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig) ([]config.ContainerConfig, error) {
+	var running []config.ContainerConfig
 	for _, c := range containers {
 		name, err := resolveRunningContainerName(ctx, rt, c)
 		if err != nil {
-			return false, err
+			return nil, err
 		}
 		if name != "" {
-			return true, nil
+			running = append(running, c)
 		}
 	}
-
-	return false, nil
+	return running, nil
 }
 
 func resolveRunningContainerName(ctx context.Context, rt runtime.Runtime, c config.ContainerConfig) (string, error) {

--- a/internal/container/running.go
+++ b/internal/container/running.go
@@ -43,18 +43,12 @@ func resolveRunningContainerName(ctx context.Context, rt runtime.Runtime, c conf
 		return c.Name(), nil
 	}
 
-	image, err := c.Image()
-	if err != nil {
-		return "", err
-	}
-	imageRepo, _, _ := strings.Cut(image, ":")
-
 	containerPort, err := c.ContainerPort()
 	if err != nil {
 		return "", err
 	}
 
-	found, err := rt.FindRunningByImage(ctx, []string{imageRepo, "localstack/localstack"}, containerPort)
+	found, err := rt.FindRunningByImage(ctx, config.KnownImageReposForType(c.Type), containerPort)
 	if err != nil {
 		return "", fmt.Errorf("failed to scan for running containers: %w", err)
 	}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -396,7 +396,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			foundType := config.EmulatorTypeForImage(found.Image)
 			if foundType != "" && foundType != c.EmulatorType {
 				sink.Emit(output.ErrorEvent{
-					Title:   fmt.Sprintf("%s is already running on port %s", config.DisplayNameForType(foundType), found.BoundPort),
+					Title:   fmt.Sprintf("%s is running on port %s", config.DisplayNameForType(foundType), found.BoundPort),
 					Summary: fmt.Sprintf("Your config specifies the %s. Only one emulator can run on a port at a time.", config.DisplayNameForType(c.EmulatorType)),
 					Actions: []output.ErrorAction{
 						{Label: "Stop the running emulator:", Value: fmt.Sprintf("docker stop %s", found.Name)},

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -217,7 +217,7 @@ func runPostStartSetups(ctx context.Context, sink output.Sink, containers []conf
 }
 
 func emitAlreadyRunning(sink output.Sink, c runtime.ContainerConfig, localStackHost, webAppURL string) {
-	sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: "LocalStack is already running"})
+	sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: fmt.Sprintf("%s is already running", config.DisplayNameForType(config.EmulatorType(c.EmulatorType)))})
 	resolvedHost, dnsOK := endpoint.ResolveHost(c.Port, localStackHost)
 	if !dnsOK {
 		sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: endpoint.DNSRebindNote})
@@ -388,15 +388,32 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			continue
 		}
 
-		imageRepo, _, _ := strings.Cut(c.Image, ":")
-		found, err := rt.FindRunningByImage(ctx, []string{imageRepo, "localstack/localstack"}, c.ContainerPort)
+		found, err := rt.FindRunningByImage(ctx, config.KnownImageRepos(), c.ContainerPort)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan for running containers: %w", err)
 		}
 		if found != nil {
+			foundType := config.EmulatorTypeForImage(found.Image)
+			if foundType != "" && string(foundType) != c.EmulatorType {
+				sink.Emit(output.ErrorEvent{
+					Title:   fmt.Sprintf("%s is already running on port %s", config.DisplayNameForType(foundType), found.BoundPort),
+					Summary: fmt.Sprintf("Your config specifies the %s. Only one emulator can run on a port at a time.", config.DisplayNameForType(config.EmulatorType(c.EmulatorType))),
+					Actions: []output.ErrorAction{
+						{Label: "Stop the running emulator:", Value: fmt.Sprintf("docker stop %s", found.Name)},
+					},
+				})
+				tel.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
+					EventType: telemetry.LifecycleStartError,
+					Emulator:  c.EmulatorType,
+					Image:     c.Image,
+					ErrorCode: telemetry.ErrCodeEmulatorMismatch,
+					ErrorMsg:  fmt.Sprintf("running %s on port %s, configured %s", foundType, found.BoundPort, c.EmulatorType),
+				})
+				return nil, output.NewSilentError(fmt.Errorf("%s is already running on port %s", config.DisplayNameForType(foundType), found.BoundPort))
+			}
 			if found.BoundPort != c.Port {
 				sink.Emit(output.ErrorEvent{
-					Title:   fmt.Sprintf("LocalStack is already running on port %s", found.BoundPort),
+					Title:   fmt.Sprintf("%s is already running on port %s", config.DisplayNameForType(config.EmulatorType(c.EmulatorType)), found.BoundPort),
 					Summary: fmt.Sprintf("Config expects port %s. Only one instance can run at a time.", c.Port),
 					Actions: []output.ErrorAction{
 						{Label: "Stop existing emulator:", Value: "lstk stop"},

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -126,7 +126,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		containers[i] = runtime.ContainerConfig{
 			Image:         image,
 			Name:          containerName,
-			EmulatorType:  string(c.Type),
+			EmulatorType:  c.Type,
 			Port:          c.Port,
 			ContainerPort: containerPort,
 			HealthPath:    healthPath,
@@ -217,12 +217,12 @@ func runPostStartSetups(ctx context.Context, sink output.Sink, containers []conf
 }
 
 func emitAlreadyRunning(sink output.Sink, c runtime.ContainerConfig, localStackHost, webAppURL string) {
-	sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: fmt.Sprintf("%s is already running", config.DisplayNameForType(config.EmulatorType(c.EmulatorType)))})
+	sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: fmt.Sprintf("%s is already running", config.DisplayNameForType(c.EmulatorType))})
 	resolvedHost, dnsOK := endpoint.ResolveHost(c.Port, localStackHost)
 	if !dnsOK {
 		sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: endpoint.DNSRebindNote})
 	}
-	emitPostStartPointers(sink, resolvedHost, webAppURL, c.EmulatorType == string(config.EmulatorAWS))
+	emitPostStartPointers(sink, resolvedHost, webAppURL, c.EmulatorType == config.EmulatorAWS)
 }
 
 func emitPostStartPointers(sink output.Sink, resolvedHost, webAppURL string, showTip bool) {
@@ -283,7 +283,7 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *
 func tryPrePullLicenseValidation(ctx context.Context, sink output.Sink, opts StartOptions, containers []runtime.ContainerConfig, token, licenseFilePath string) ([]runtime.ContainerConfig, error) {
 	var needsPostPull []runtime.ContainerConfig
 	for _, c := range containers {
-		if c.EmulatorType == string(config.EmulatorSnowflake) {
+		if c.EmulatorType == config.EmulatorSnowflake {
 			continue
 		}
 
@@ -295,7 +295,7 @@ func tryPrePullLicenseValidation(ctx context.Context, sink output.Sink, opts Sta
 		}
 
 		apiCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-		v, err := opts.PlatformClient.GetLatestCatalogVersion(apiCtx, c.EmulatorType)
+		v, err := opts.PlatformClient.GetLatestCatalogVersion(apiCtx, string(c.EmulatorType))
 		cancel()
 
 		if err != nil {
@@ -315,7 +315,7 @@ func tryPrePullLicenseValidation(ctx context.Context, sink output.Sink, opts Sta
 // Fallback path: inspects each pulled image for its version, then validates the license.
 func validateLicensesFromImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, containers []runtime.ContainerConfig, token, licenseFilePath string) error {
 	for _, c := range containers {
-		if c.EmulatorType == string(config.EmulatorSnowflake) {
+		if c.EmulatorType == config.EmulatorSnowflake {
 			continue
 		}
 
@@ -394,10 +394,10 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 		}
 		if found != nil {
 			foundType := config.EmulatorTypeForImage(found.Image)
-			if foundType != "" && string(foundType) != c.EmulatorType {
+			if foundType != "" && foundType != c.EmulatorType {
 				sink.Emit(output.ErrorEvent{
 					Title:   fmt.Sprintf("%s is already running on port %s", config.DisplayNameForType(foundType), found.BoundPort),
-					Summary: fmt.Sprintf("Your config specifies the %s. Only one emulator can run on a port at a time.", config.DisplayNameForType(config.EmulatorType(c.EmulatorType))),
+					Summary: fmt.Sprintf("Your config specifies the %s. Only one emulator can run on a port at a time.", config.DisplayNameForType(c.EmulatorType)),
 					Actions: []output.ErrorAction{
 						{Label: "Stop the running emulator:", Value: fmt.Sprintf("docker stop %s", found.Name)},
 					},
@@ -413,7 +413,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			}
 			if found.BoundPort != c.Port {
 				sink.Emit(output.ErrorEvent{
-					Title:   fmt.Sprintf("%s is already running on port %s", config.DisplayNameForType(config.EmulatorType(c.EmulatorType)), found.BoundPort),
+					Title:   fmt.Sprintf("%s is already running on port %s", config.DisplayNameForType(c.EmulatorType), found.BoundPort),
 					Summary: fmt.Sprintf("Config expects port %s. Only one instance can run at a time.", c.Port),
 					Actions: []output.ErrorAction{
 						{Label: "Stop existing emulator:", Value: "lstk stop"},

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -170,7 +170,7 @@ func TestSelectContainersToStart_ErrorsOnEmulatorTypeMismatch(t *testing.T) {
 	assert.True(t, output.IsSilent(err), "error should be silent since it was already emitted")
 	assert.Empty(t, result)
 	got := out.String()
-	assert.Contains(t, got, "LocalStack AWS Emulator is already running on port 4566")
+	assert.Contains(t, got, "LocalStack AWS Emulator is running on port 4566")
 	assert.Contains(t, got, "Your config specifies the LocalStack Snowflake Emulator")
 	assert.Contains(t, got, "docker stop localstack-aws")
 }

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/localstack/lstk/internal/log"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -62,13 +63,14 @@ func TestSelectContainersToStart_AttachesWhenExternalContainerOnConfiguredPort(t
 	c := runtime.ContainerConfig{
 		Image:         "localstack/localstack-pro:3.5.0",
 		Name:          "localstack-aws-3.5.0",
+		EmulatorType:  "aws",
 		Tag:           "3.5.0",
 		Port:          "4566",
 		ContainerPort: "4566/tcp",
 	}
 
 	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name).Return(false, nil)
-	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack-pro", "localstack/localstack"}, "4566/tcp").
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack", "localstack/localstack-pro", "localstack/snowflake"}, "4566/tcp").
 		Return(&runtime.RunningContainer{Name: "external-container", Image: "localstack/localstack-pro:3.5.0", BoundPort: "4566"}, nil)
 
 	var out bytes.Buffer
@@ -89,13 +91,14 @@ func TestSelectContainersToStart_AttachesWhenExternalContainerVersionDiffers(t *
 	c := runtime.ContainerConfig{
 		Image:         "localstack/localstack-pro:3.4.0",
 		Name:          "localstack-aws-3.4.0",
+		EmulatorType:  "aws",
 		Tag:           "3.4.0",
 		Port:          "4566",
 		ContainerPort: "4566/tcp",
 	}
 
 	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name).Return(false, nil)
-	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack-pro", "localstack/localstack"}, "4566/tcp").
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack", "localstack/localstack-pro", "localstack/snowflake"}, "4566/tcp").
 		Return(&runtime.RunningContainer{Name: "external-container", Image: "localstack/localstack-pro:3.5.0", BoundPort: "4566"}, nil)
 
 	var out bytes.Buffer
@@ -121,13 +124,14 @@ func TestSelectContainersToStart_QueuesContainerWhenNoneRunningOnPort(t *testing
 	c := runtime.ContainerConfig{
 		Image:         "localstack/localstack-pro:3.5.0",
 		Name:          "localstack-aws-3.5.0",
+		EmulatorType:  "aws",
 		Tag:           "3.5.0",
 		Port:          strconv.Itoa(freePort),
 		ContainerPort: "4566/tcp",
 	}
 
 	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name).Return(false, nil)
-	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack-pro", "localstack/localstack"}, "4566/tcp").
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack", "localstack/localstack-pro", "localstack/snowflake"}, "4566/tcp").
 		Return(nil, nil)
 
 	sink := output.NewPlainSink(io.Discard)
@@ -136,6 +140,38 @@ func TestSelectContainersToStart_QueuesContainerWhenNoneRunningOnPort(t *testing
 
 	require.NoError(t, err)
 	assert.Equal(t, []runtime.ContainerConfig{c}, result, "container should be queued for start")
+}
+
+func TestSelectContainersToStart_ErrorsOnEmulatorTypeMismatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockTel := telemetry.New("", true)
+
+	c := runtime.ContainerConfig{
+		Image:         "localstack/snowflake:latest",
+		Name:          "localstack-snowflake",
+		EmulatorType:  "snowflake",
+		Tag:           "latest",
+		Port:          "4566",
+		ContainerPort: "4566/tcp",
+	}
+
+	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name).Return(false, nil)
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack", "localstack/localstack-pro", "localstack/snowflake"}, "4566/tcp").
+		Return(&runtime.RunningContainer{Name: "localstack-aws", Image: "localstack/localstack-pro:latest", BoundPort: "4566"}, nil)
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	result, err := selectContainersToStart(context.Background(), mockRT, sink, mockTel, []runtime.ContainerConfig{c}, "", "")
+
+	require.Error(t, err)
+	assert.True(t, output.IsSilent(err), "error should be silent since it was already emitted")
+	assert.Empty(t, result)
+	got := out.String()
+	assert.Contains(t, got, "LocalStack AWS Emulator is already running on port 4566")
+	assert.Contains(t, got, "Your config specifies the LocalStack Snowflake Emulator")
+	assert.Contains(t, got, "docker stop localstack-aws")
 }
 
 func TestEmitPostStartPointers_NoTip(t *testing.T) {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/log"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
@@ -63,14 +64,14 @@ func TestSelectContainersToStart_AttachesWhenExternalContainerOnConfiguredPort(t
 	c := runtime.ContainerConfig{
 		Image:         "localstack/localstack-pro:3.5.0",
 		Name:          "localstack-aws-3.5.0",
-		EmulatorType:  "aws",
+		EmulatorType:  config.EmulatorAWS,
 		Tag:           "3.5.0",
 		Port:          "4566",
 		ContainerPort: "4566/tcp",
 	}
 
 	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name).Return(false, nil)
-	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack", "localstack/localstack-pro", "localstack/snowflake"}, "4566/tcp").
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack-pro", "localstack/localstack", "localstack/snowflake"}, "4566/tcp").
 		Return(&runtime.RunningContainer{Name: "external-container", Image: "localstack/localstack-pro:3.5.0", BoundPort: "4566"}, nil)
 
 	var out bytes.Buffer
@@ -91,14 +92,14 @@ func TestSelectContainersToStart_AttachesWhenExternalContainerVersionDiffers(t *
 	c := runtime.ContainerConfig{
 		Image:         "localstack/localstack-pro:3.4.0",
 		Name:          "localstack-aws-3.4.0",
-		EmulatorType:  "aws",
+		EmulatorType:  config.EmulatorAWS,
 		Tag:           "3.4.0",
 		Port:          "4566",
 		ContainerPort: "4566/tcp",
 	}
 
 	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name).Return(false, nil)
-	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack", "localstack/localstack-pro", "localstack/snowflake"}, "4566/tcp").
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack-pro", "localstack/localstack", "localstack/snowflake"}, "4566/tcp").
 		Return(&runtime.RunningContainer{Name: "external-container", Image: "localstack/localstack-pro:3.5.0", BoundPort: "4566"}, nil)
 
 	var out bytes.Buffer
@@ -124,14 +125,14 @@ func TestSelectContainersToStart_QueuesContainerWhenNoneRunningOnPort(t *testing
 	c := runtime.ContainerConfig{
 		Image:         "localstack/localstack-pro:3.5.0",
 		Name:          "localstack-aws-3.5.0",
-		EmulatorType:  "aws",
+		EmulatorType:  config.EmulatorAWS,
 		Tag:           "3.5.0",
 		Port:          strconv.Itoa(freePort),
 		ContainerPort: "4566/tcp",
 	}
 
 	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name).Return(false, nil)
-	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack", "localstack/localstack-pro", "localstack/snowflake"}, "4566/tcp").
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack-pro", "localstack/localstack", "localstack/snowflake"}, "4566/tcp").
 		Return(nil, nil)
 
 	sink := output.NewPlainSink(io.Discard)
@@ -150,14 +151,14 @@ func TestSelectContainersToStart_ErrorsOnEmulatorTypeMismatch(t *testing.T) {
 	c := runtime.ContainerConfig{
 		Image:         "localstack/snowflake:latest",
 		Name:          "localstack-snowflake",
-		EmulatorType:  "snowflake",
+		EmulatorType:  config.EmulatorSnowflake,
 		Tag:           "latest",
 		Port:          "4566",
 		ContainerPort: "4566/tcp",
 	}
 
 	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name).Return(false, nil)
-	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack", "localstack/localstack-pro", "localstack/snowflake"}, "4566/tcp").
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), []string{"localstack/localstack-pro", "localstack/localstack", "localstack/snowflake"}, "4566/tcp").
 		Return(&runtime.RunningContainer{Name: "localstack-aws", Image: "localstack/localstack-pro:latest", BoundPort: "4566"}, nil)
 
 	var out bytes.Buffer

--- a/internal/container/stop.go
+++ b/internal/container/stop.go
@@ -29,7 +29,10 @@ func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 			return err
 		}
 		if name == "" {
-			return fmt.Errorf("LocalStack is not running")
+			sink.Emit(output.ErrorEvent{
+				Title: fmt.Sprintf("%s is not running", c.DisplayName()),
+			})
+			return output.NewSilentError(fmt.Errorf("%s is not running", c.Name()))
 		}
 
 		// Fetch localstack info before stopping so it can be included in telemetry.
@@ -46,7 +49,7 @@ func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 		}
 		stopCancel()
 		sink.Emit(output.SpinnerStop())
-		sink.Emit(output.MessageEvent{Severity: output.SeveritySuccess, Text: "LocalStack stopped"})
+		sink.Emit(output.MessageEvent{Severity: output.SeveritySuccess, Text: fmt.Sprintf("%s stopped", c.DisplayName())})
 
 		opts.Telemetry.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
 			EventType:      telemetry.LifecycleStop,

--- a/internal/container/stop.go
+++ b/internal/container/stop.go
@@ -53,7 +53,7 @@ func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 
 		opts.Telemetry.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
 			EventType:      telemetry.LifecycleStop,
-			Emulator:       string(c.Type),
+			Emulator:       c.Type,
 			DurationMS:     time.Since(stopStart).Milliseconds(),
 			LocalStackInfo: lsInfo,
 		})

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -26,9 +26,9 @@ type PortMapping struct {
 type ContainerConfig struct {
 	Image         string
 	Name          string
-	EmulatorType  config.EmulatorType // e.g., "aws", "snowflake" — used for telemetry
+	EmulatorType  config.EmulatorType
 	Port          string
-	ContainerPort string   // internal port the emulator listens on inside the container (e.g. "4566/tcp")
+	ContainerPort string // internal port the emulator listens on inside the container (e.g. "4566/tcp")
 	HealthPath    string
 	Env           []string // e.g., ["KEY=value", "FOO=bar"]
 	Tag           string

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/output"
 )
 
@@ -25,7 +26,7 @@ type PortMapping struct {
 type ContainerConfig struct {
 	Image         string
 	Name          string
-	EmulatorType  string   // e.g., "aws", "snowflake" — used for telemetry
+	EmulatorType  config.EmulatorType // e.g., "aws", "snowflake" — used for telemetry
 	Port          string
 	ContainerPort string   // internal port the emulator listens on inside the container (e.g. "4566/tcp")
 	HealthPath    string

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -73,10 +73,11 @@ const (
 
 // Error codes for start_error lifecycle events.
 const (
-	ErrCodePortConflict    = "port_conflict"
-	ErrCodeImagePullFailed = "image_pull_failed"
-	ErrCodeLicenseInvalid  = "license_invalid"
-	ErrCodeStartFailed     = "start_failed"
+	ErrCodePortConflict      = "port_conflict"
+	ErrCodeImagePullFailed   = "image_pull_failed"
+	ErrCodeLicenseInvalid    = "license_invalid"
+	ErrCodeStartFailed       = "start_failed"
+	ErrCodeEmulatorMismatch  = "emulator_mismatch"
 )
 
 // ToMap converts a telemetry event struct to a map[string]any for use with Emit.

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"runtime"
 
+	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/version"
 )
 
@@ -54,7 +55,7 @@ type CommandResult struct {
 type LifecycleEvent struct {
 	EventType      string          `json:"event_type"`
 	Environment    Environment     `json:"environment"`
-	Emulator       string          `json:"emulator"`
+	Emulator       config.EmulatorType `json:"emulator"`
 	Image          string          `json:"image,omitempty"`
 	ContainerID    string          `json:"container_id,omitempty"`
 	DurationMS     int64           `json:"duration_ms,omitempty"`

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -33,9 +33,9 @@ type LocalStackInfo struct {
 
 // CommandEvent is the payload for an lstk_command telemetry event.
 type CommandEvent struct {
-	Environment Environment      `json:"environment"`
+	Environment Environment       `json:"environment"`
 	Parameters  CommandParameters `json:"parameters"`
-	Result      CommandResult    `json:"result"`
+	Result      CommandResult     `json:"result"`
 }
 
 // CommandParameters holds the command name and set flags.
@@ -53,16 +53,16 @@ type CommandResult struct {
 
 // LifecycleEvent is the payload for an lstk_lifecycle telemetry event.
 type LifecycleEvent struct {
-	EventType      string          `json:"event_type"`
-	Environment    Environment     `json:"environment"`
+	EventType      string              `json:"event_type"`
+	Environment    Environment         `json:"environment"`
 	Emulator       config.EmulatorType `json:"emulator"`
-	Image          string          `json:"image,omitempty"`
-	ContainerID    string          `json:"container_id,omitempty"`
-	DurationMS     int64           `json:"duration_ms,omitempty"`
-	Pulled         bool            `json:"pulled,omitempty"`
-	LocalStackInfo *LocalStackInfo `json:"localstack_info,omitempty"`
-	ErrorCode      string          `json:"error_code,omitempty"`
-	ErrorMsg       string          `json:"error_msg,omitempty"`
+	Image          string              `json:"image,omitempty"`
+	ContainerID    string              `json:"container_id,omitempty"`
+	DurationMS     int64               `json:"duration_ms,omitempty"`
+	Pulled         bool                `json:"pulled,omitempty"`
+	LocalStackInfo *LocalStackInfo     `json:"localstack_info,omitempty"`
+	ErrorCode      string              `json:"error_code,omitempty"`
+	ErrorMsg       string              `json:"error_msg,omitempty"`
 }
 
 // Lifecycle event type constants.
@@ -74,11 +74,11 @@ const (
 
 // Error codes for start_error lifecycle events.
 const (
-	ErrCodePortConflict      = "port_conflict"
-	ErrCodeImagePullFailed   = "image_pull_failed"
-	ErrCodeLicenseInvalid    = "license_invalid"
-	ErrCodeStartFailed       = "start_failed"
-	ErrCodeEmulatorMismatch  = "emulator_mismatch"
+	ErrCodePortConflict     = "port_conflict"
+	ErrCodeImagePullFailed  = "image_pull_failed"
+	ErrCodeLicenseInvalid   = "license_invalid"
+	ErrCodeStartFailed      = "start_failed"
+	ErrCodeEmulatorMismatch = "emulator_mismatch"
 )
 
 // ToMap converts a telemetry event struct to a map[string]any for use with Emit.

--- a/internal/ui/run_logout.go
+++ b/internal/ui/run_logout.go
@@ -37,8 +37,8 @@ func RunLogout(parentCtx context.Context, rt runtime.Runtime, platformClient api
 		a := auth.New(sink, platformClient, tokenStorage, authToken, "", false, licenseFilePath)
 		err = a.Logout()
 		if err == nil && rt != nil {
-			if running, runningErr := container.AnyRunning(ctx, rt, containers); runningErr == nil && running {
-				sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: "LocalStack is still running in the background"})
+			if running, runningErr := container.RunningEmulators(ctx, rt, containers); runningErr == nil && len(running) > 0 {
+				sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: container.StillRunningMessage(running)})
 			}
 		}
 

--- a/test/integration/logout_test.go
+++ b/test/integration/logout_test.go
@@ -65,5 +65,5 @@ func TestLogoutCommandNotesWhenEmulatorStillRunning(t *testing.T) {
 	stdout, stderr, err := runLstk(t, ctx, "", testEnvWithHome(t.TempDir(), ""), "logout")
 	require.NoError(t, err, "lstk logout failed: %s", stderr)
 	requireExitCode(t, 0, err)
-	assert.Contains(t, stdout, "LocalStack is still running in the background")
+	assert.Contains(t, stdout, "LocalStack AWS Emulator is still running in the background")
 }

--- a/test/integration/logout_test.go
+++ b/test/integration/logout_test.go
@@ -1,8 +1,12 @@
 package integration_test
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/docker/docker/api/types/image"
 	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,4 +70,79 @@ func TestLogoutCommandNotesWhenEmulatorStillRunning(t *testing.T) {
 	require.NoError(t, err, "lstk logout failed: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "LocalStack AWS Emulator is still running in the background")
+}
+
+func TestLogoutCommandReportsBothEmulatorsWhenMultipleRunning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	cleanupSnowflake()
+	t.Cleanup(cleanup)
+	t.Cleanup(cleanupSnowflake)
+	t.Cleanup(func() {
+		_ = DeleteAuthTokenFromKeyring()
+	})
+
+	ctx := testContext(t)
+
+	const fakeAWSImage = "localstack/localstack-pro:test-fake"
+	const fakeSnowflakeImage = "localstack/snowflake:test-fake"
+	require.NoError(t, dockerClient.ImageTag(ctx, testImage, fakeAWSImage))
+	require.NoError(t, dockerClient.ImageTag(ctx, testImage, fakeSnowflakeImage))
+	t.Cleanup(func() {
+		_, _ = dockerClient.ImageRemove(context.Background(), fakeAWSImage, image.RemoveOptions{})
+		_, _ = dockerClient.ImageRemove(context.Background(), fakeSnowflakeImage, image.RemoveOptions{})
+	})
+	startExternalContainer(t, ctx, fakeAWSImage, "localstack-external-aws", "4566")
+	startExternalContainer(t, ctx, fakeSnowflakeImage, "localstack-external-snowflake", "4567")
+
+	require.NoError(t, SetAuthTokenInKeyring("test-token"), "failed to store token in keyring")
+
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+[[containers]]
+type = "aws"
+tag  = "test-fake"
+port = "4566"
+
+[[containers]]
+type = "snowflake"
+tag  = "test-fake"
+port = "4567"
+`), 0644))
+
+	stdout, stderr, err := runLstk(t, ctx, "", testEnvWithHome(t.TempDir(), ""), "--config", configFile, "logout")
+	require.NoError(t, err, "lstk logout failed: %s", stderr)
+	requireExitCode(t, 0, err)
+	assert.Contains(t, stdout, "LocalStack AWS Emulator, LocalStack Snowflake Emulator are still running in the background")
+}
+
+func TestLogoutCommandDoesNotReportForeignEmulatorAsRunning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	cleanupSnowflake()
+	t.Cleanup(cleanup)
+	t.Cleanup(cleanupSnowflake)
+	t.Cleanup(func() {
+		_ = DeleteAuthTokenFromKeyring()
+	})
+
+	ctx := testContext(t)
+
+	// AWS image running on 4566 while config targets snowflake.
+	const fakeImage = "localstack/localstack-pro:test-fake"
+	require.NoError(t, dockerClient.ImageTag(ctx, testImage, fakeImage))
+	t.Cleanup(func() {
+		_, _ = dockerClient.ImageRemove(context.Background(), fakeImage, image.RemoveOptions{})
+	})
+	startExternalContainer(t, ctx, fakeImage, "localstack-external-aws", "4566")
+
+	require.NoError(t, SetAuthTokenInKeyring("test-token"), "failed to store token in keyring")
+
+	configFile := writeSnowflakeConfig(t, "4566")
+
+	stdout, stderr, err := runLstk(t, ctx, "", testEnvWithHome(t.TempDir(), ""), "--config", configFile, "logout")
+	require.NoError(t, err, "lstk logout failed: %s", stderr)
+	requireExitCode(t, 0, err)
+	assert.NotContains(t, stdout, "still running",
+		"snowflake-targeted logout should not detect the AWS container as the configured emulator")
 }

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -77,9 +77,9 @@ func TestRestartCommandFailsWhenNotRunning(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	analyticsSrv, events := mockAnalyticsServer(t)
-	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "restart")
+	stdout, _, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "restart")
 	require.Error(t, err, "expected lstk restart to fail when emulator is not running")
 	requireExitCode(t, 1, err)
-	assert.Contains(t, stderr, "is not running")
+	assert.Contains(t, stdout, "LocalStack AWS Emulator is not running")
 	assertCommandTelemetry(t, events, "restart", 1)
 }

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -230,7 +230,7 @@ func TestStartCommandFailsOnEmulatorTypeMismatch(t *testing.T) {
 	stdout, _, err := runLstk(t, ctx, "", env.With(env.AuthToken, "fake-token").With(env.AnalyticsEndpoint, analyticsSrv.URL), "--config", configFile, "start")
 	require.Error(t, err, "lstk start should fail on emulator type mismatch")
 	requireExitCode(t, 1, err)
-	assert.Contains(t, stdout, "LocalStack AWS Emulator is already running on port 4566")
+	assert.Contains(t, stdout, "LocalStack AWS Emulator is running on port 4566")
 	assert.Contains(t, stdout, "Your config specifies the LocalStack Snowflake Emulator")
 	assert.Contains(t, stdout, "docker stop localstack-external-aws")
 

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -233,7 +233,21 @@ func TestStartCommandFailsOnEmulatorTypeMismatch(t *testing.T) {
 	assert.Contains(t, stdout, "LocalStack AWS Emulator is already running on port 4566")
 	assert.Contains(t, stdout, "Your config specifies the LocalStack Snowflake Emulator")
 	assert.Contains(t, stdout, "docker stop localstack-external-aws")
-	assertCommandTelemetry(t, events, "start", 1)
+
+	byName := collectTelemetryByName(t, events, 2)
+	cmdPayload, _ := byName["lstk_command"]["payload"].(map[string]any)
+	cmdParams, _ := cmdPayload["parameters"].(map[string]any)
+	cmdResult, _ := cmdPayload["result"].(map[string]any)
+	assert.Equal(t, "start", cmdParams["command"])
+	assert.InDelta(t, 1, cmdResult["exit_code"], 0)
+
+	lifecycle, ok := byName["lstk_lifecycle"]
+	require.True(t, ok, "expected lstk_lifecycle telemetry event")
+	lifePayload, _ := lifecycle["payload"].(map[string]any)
+	assert.Equal(t, "start_error", lifePayload["event_type"])
+	assert.Equal(t, "emulator_mismatch", lifePayload["error_code"])
+	assert.Equal(t, "snowflake", lifePayload["emulator"])
+	assert.Contains(t, lifePayload["error_msg"], "running aws on port 4566, configured snowflake")
 }
 
 func TestStartCommandSucceedsWithNonDefaultPort(t *testing.T) {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -205,6 +205,37 @@ port = "4567"
 	assertCommandTelemetry(t, events, "start", 1)
 }
 
+func TestStartCommandFailsOnEmulatorTypeMismatch(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	cleanupSnowflake()
+	t.Cleanup(cleanup)
+	t.Cleanup(cleanupSnowflake)
+
+	ctx := testContext(t)
+
+	// Tag the test image as a LocalStack pro image to simulate AWS LocalStack running.
+	const fakeImage = "localstack/localstack-pro:test-fake"
+	require.NoError(t, dockerClient.ImageTag(ctx, testImage, fakeImage))
+	t.Cleanup(func() {
+		_, _ = dockerClient.ImageRemove(context.Background(), fakeImage, image.RemoveOptions{})
+	})
+
+	startExternalContainer(t, ctx, fakeImage, "localstack-external-aws", "4566")
+
+	// Start lstk with a Snowflake config on the same port — expect a clear mismatch error.
+	configFile := writeSnowflakeConfig(t, "4566")
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, _, err := runLstk(t, ctx, "", env.With(env.AuthToken, "fake-token").With(env.AnalyticsEndpoint, analyticsSrv.URL), "--config", configFile, "start")
+	require.Error(t, err, "lstk start should fail on emulator type mismatch")
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stdout, "LocalStack AWS Emulator is already running on port 4566")
+	assert.Contains(t, stdout, "Your config specifies the LocalStack Snowflake Emulator")
+	assert.Contains(t, stdout, "docker stop localstack-external-aws")
+	assertCommandTelemetry(t, events, "start", 1)
+}
+
 func TestStartCommandSucceedsWithNonDefaultPort(t *testing.T) {
 	requireDocker(t)
 	_ = env.Require(t, env.AuthToken)

--- a/test/integration/stop_test.go
+++ b/test/integration/stop_test.go
@@ -40,11 +40,26 @@ func TestStopCommandFailsWhenNotRunning(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	analyticsSrv, events := mockAnalyticsServer(t)
-	_, stderr, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "stop")
+	stdout, _, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "stop")
 	require.Error(t, err, "expected lstk stop to fail when container not running")
 	requireExitCode(t, 1, err)
-	assert.Contains(t, stderr, "is not running")
+	// Match status: e.g. "LocalStack AWS Emulator is not running".
+	assert.Contains(t, stdout, "LocalStack AWS Emulator is not running")
 	assertCommandTelemetry(t, events, "stop", 1)
+}
+
+func TestStopCommandFailsWhenSnowflakeNotRunning(t *testing.T) {
+	requireDocker(t)
+	cleanupSnowflake()
+	t.Cleanup(cleanupSnowflake)
+
+	configFile := writeSnowflakeConfig(t, "4566")
+
+	stdout, _, err := runLstk(t, testContext(t), "", testEnvWithHome(t.TempDir(), ""), "--config", configFile, "stop")
+	require.Error(t, err, "expected lstk stop to fail when snowflake container not running")
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stdout, "LocalStack Snowflake Emulator is not running",
+		"stop should match status's emulator-specific message")
 }
 
 func TestStopCommandStopsExternalContainer(t *testing.T) {

--- a/test/integration/stop_test.go
+++ b/test/integration/stop_test.go
@@ -54,11 +54,43 @@ func TestStopCommandReportsEmulatorSpecificNotRunningMessage(t *testing.T) {
 
 	configFile := writeSnowflakeConfig(t, "4566")
 
-	stdout, _, err := runLstk(t, testContext(t), "", testEnvWithHome(t.TempDir(), ""), "--config", configFile, "stop")
+	analyticsSrv, events := mockAnalyticsServer(t)
+	e := env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.AnalyticsEndpoint, analyticsSrv.URL)
+	stdout, _, err := runLstk(t, testContext(t), "", e, "--config", configFile, "stop")
 	require.Error(t, err, "expected lstk stop to fail when snowflake container not running")
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stdout, "LocalStack Snowflake Emulator is not running",
 		"stop should match status's emulator-specific message")
+	assertCommandTelemetry(t, events, "stop", 1)
+}
+
+func TestStopCommandIgnoresForeignEmulatorOnPort(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	cleanupSnowflake()
+	t.Cleanup(cleanup)
+	t.Cleanup(cleanupSnowflake)
+
+	ctx := testContext(t)
+
+	// AWS image running on 4566 while config targets snowflake.
+	const fakeImage = "localstack/localstack-pro:test-fake"
+	require.NoError(t, dockerClient.ImageTag(ctx, testImage, fakeImage))
+	t.Cleanup(func() {
+		_, _ = dockerClient.ImageRemove(context.Background(), fakeImage, image.RemoveOptions{})
+	})
+	startExternalContainer(t, ctx, fakeImage, "localstack-external-aws", "4566")
+
+	configFile := writeSnowflakeConfig(t, "4566")
+
+	stdout, _, err := runLstk(t, testContext(t), "", testEnvWithHome(t.TempDir(), ""), "--config", configFile, "stop")
+	require.Error(t, err, "lstk stop should not match foreign emulator on configured port")
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stdout, "LocalStack Snowflake Emulator is not running")
+	assert.NotContains(t, stdout, "stopped", "should not have stopped the AWS container")
+
+	_, inspectErr := dockerClient.ContainerInspect(ctx, "localstack-external-aws")
+	assert.NoError(t, inspectErr, "AWS container should still exist after snowflake-targeted stop")
 }
 
 func TestStopCommandStopsExternalContainer(t *testing.T) {

--- a/test/integration/stop_test.go
+++ b/test/integration/stop_test.go
@@ -43,12 +43,11 @@ func TestStopCommandFailsWhenNotRunning(t *testing.T) {
 	stdout, _, err := runLstk(t, testContext(t), "", env.With(env.AnalyticsEndpoint, analyticsSrv.URL), "stop")
 	require.Error(t, err, "expected lstk stop to fail when container not running")
 	requireExitCode(t, 1, err)
-	// Match status: e.g. "LocalStack AWS Emulator is not running".
 	assert.Contains(t, stdout, "LocalStack AWS Emulator is not running")
 	assertCommandTelemetry(t, events, "stop", 1)
 }
 
-func TestStopCommandFailsWhenSnowflakeNotRunning(t *testing.T) {
+func TestStopCommandReportsEmulatorSpecificNotRunningMessage(t *testing.T) {
 	requireDocker(t)
 	cleanupSnowflake()
 	t.Cleanup(cleanupSnowflake)


### PR DESCRIPTION
## Motivation

`lstk` would emit a confusing version-mismatch warning when a config targeted a different emulator type than the one already running on the port (e.g. snowflake config, AWS instance running). User-facing messages also varied between commands: `lstk status` showed `LocalStack Snowflake Emulator is not running` while `lstk stop` only said `LocalStack is not running`.

## Changes

- Detect emulator type mismatch in `selectContainersToStart` by widening the running-container scan to all known LocalStack image repos and comparing emulator types.
- Replace generic `LocalStack ...` strings in start/stop/logout flows with `DisplayName()` so messages match `lstk status` (`LocalStack AWS Emulator is not running`).
- Replace `AnyRunning` with `RunningEmulators` returning the running configs; add `StillRunningMessage` helper that handles singular/plural grammar.
- Narrow `resolveRunningContainerName` scan to repos matching the configured emulator type via new `config.KnownImageReposForType(t)` so `stop`/`logout` don't falsely report a different emulator as the configured one.
- Document the Docker image naming convention (full image / image repo / product name) in `CLAUDE.md`.

Closes DRG-806


## Example with aws running, snowflake in the config:

<img width="1277" height="616" alt="image" src="https://github.com/user-attachments/assets/55df4134-07bf-4940-98b0-d7ac947fc748" />

