### PR TITLE
Set LOCALSTACK_HOST to fix custom port errors

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -100,6 +100,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			"LOCALSTACK_AUTH_TOKEN="+token,
 			"GATEWAY_LISTEN=:4566,:443",
 			"MAIN_CONTAINER_NAME="+containerName,
+			"LOCALSTACK_HOST="+endpoint.Hostname+":"+c.Port,
 		)
 
 		env = append(env, hostEnv...)

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -233,6 +233,12 @@ port = "4567"
 	ctx := testContext(t)
 	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
 	require.NoError(t, err, "lstk start failed: %s", stderr)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName)
+	require.NoError(t, err, "failed to inspect container")
+	envVars := containerEnvToMap(inspect.Config.Env)
+	assert.Equal(t, "localhost.localstack.cloud:4567", envVars["LOCALSTACK_HOST"],
+		"LOCALSTACK_HOST must reflect configured host port so LocalStack accepts requests on it")
 }
 
 func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
@@ -257,6 +263,7 @@ func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 		envVars := containerEnvToMap(inspect.Config.Env)
 		assert.Equal(t, ":4566,:443", envVars["GATEWAY_LISTEN"])
 		assert.Equal(t, containerName, envVars["MAIN_CONTAINER_NAME"])
+		assert.Equal(t, "localhost.localstack.cloud:4566", envVars["LOCALSTACK_HOST"])
 		assert.NotEmpty(t, envVars["LOCALSTACK_AUTH_TOKEN"])
 	})
 


### PR DESCRIPTION
## Motivation

When starting an emulator on a non-default port (e.g. `port = "4567"`), LocalStack rejects browser requests to `https://snowflake.localhost.localstack.cloud:4567/` with 403s and CORS-blocked errors. Root cause: lstk only set `GATEWAY_LISTEN=:4566,:443` and never told LocalStack about the external port, so the gateway's host validation and CORS allowlist treated the configured external port as unknown.

Towards DRG-805

## Changes

- Set `LOCALSTACK_HOST=localhost.localstack.cloud:<port>` in container env so LocalStack advertises the correct external host:port and accepts requests / origins on it. It worked for default port because the default value is `localhost.localstack.cloud:4566`

## Tests

- `TestStartCommandSucceedsWithNonDefaultPort` now asserts `LOCALSTACK_HOST=localhost.localstack.cloud:4567`. Fails before the fix, passes after.
- `TestStartCommandSetsUpContainerCorrectly` asserts the default-port equivalent for symmetry.
- Manually verified with custom port 4567 + snowflake `2026.3` (latest has an issue), loaded browser at https://snowflake.localhost.localstack.cloud:4567, it rendered without error:

<img width="943" height="735" alt="image" src="https://github.com/user-attachments/assets/aaacd677-78cc-418f-b847-54666e01e739" />