### PR TITLE
Detect externally-named containers in AWS proxy commmnds

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -8,6 +8,7 @@ import (
 	"github.com/localstack/lstk/internal/awscli"
 	"github.com/localstack/lstk/internal/awsconfig"
 	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/container"
 	"github.com/localstack/lstk/internal/endpoint"
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
@@ -60,11 +61,11 @@ Examples:
 				return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
 			}
 
-			running, err := rt.IsRunning(cmd.Context(), awsContainer.Name())
+			runningName, err := container.ResolveRunningContainerName(cmd.Context(), rt, awsContainer)
 			if err != nil {
 				return fmt.Errorf("checking emulator status: %w", err)
 			}
-			if !running {
+			if runningName == "" {
 				sink.Emit(output.ErrorEvent{
 					Title: fmt.Sprintf("%s is not running", awsContainer.DisplayName()),
 					Actions: []output.ErrorAction{

--- a/internal/container/running.go
+++ b/internal/container/running.go
@@ -23,7 +23,7 @@ func StillRunningMessage(running []config.ContainerConfig) string {
 func RunningEmulators(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig) ([]config.ContainerConfig, error) {
 	var running []config.ContainerConfig
 	for _, c := range containers {
-		name, err := resolveRunningContainerName(ctx, rt, c)
+		name, err := ResolveRunningContainerName(ctx, rt, c)
 		if err != nil {
 			return nil, err
 		}
@@ -34,7 +34,7 @@ func RunningEmulators(ctx context.Context, rt runtime.Runtime, containers []conf
 	return running, nil
 }
 
-func resolveRunningContainerName(ctx context.Context, rt runtime.Runtime, c config.ContainerConfig) (string, error) {
+func ResolveRunningContainerName(ctx context.Context, rt runtime.Runtime, c config.ContainerConfig) (string, error) {
 	running, err := rt.IsRunning(ctx, c.Name())
 	if err != nil {
 		return "", fmt.Errorf("checking %s running: %w", c.Name(), err)

--- a/internal/container/status.go
+++ b/internal/container/status.go
@@ -25,7 +25,7 @@ func Status(ctx context.Context, rt runtime.Runtime, containers []config.Contain
 	defer cancel()
 
 	for _, c := range containers {
-		name, err := resolveRunningContainerName(ctx, rt, c)
+		name, err := ResolveRunningContainerName(ctx, rt, c)
 		if err != nil {
 			return fmt.Errorf("checking %s running: %w", c.Name(), err)
 		}

--- a/internal/container/stop.go
+++ b/internal/container/stop.go
@@ -24,7 +24,7 @@ func Stop(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 
 	const stopTimeout = 30 * time.Second
 	for _, c := range containers {
-		name, err := resolveRunningContainerName(ctx, rt, c)
+		name, err := ResolveRunningContainerName(ctx, rt, c)
 		if err != nil {
 			return err
 		}

--- a/test/integration/aws_cmd_test.go
+++ b/test/integration/aws_cmd_test.go
@@ -1,12 +1,14 @@
 package integration_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/docker/docker/api/types/image"
 	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -273,6 +275,29 @@ func TestAWSCommandHintsSetupCommandWhenProfileMissing(t *testing.T) {
 	stdout, _, err := runLstk(t, ctx, t.TempDir(), e, "aws", "s3", "ls")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "lstk setup aws")
+}
+
+func TestAWSCommandWorksWithExternalContainer(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+
+	const fakeImage = "localstack/localstack-pro:test-fake"
+	require.NoError(t, dockerClient.ImageTag(ctx, testImage, fakeImage))
+	t.Cleanup(func() {
+		_, _ = dockerClient.ImageRemove(context.Background(), fakeImage, image.RemoveOptions{})
+	})
+
+	startExternalContainer(t, ctx, fakeImage, "localstack-main", "4566")
+
+	fakeDir := writeFakeAWS(t)
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+	stdout, stderr, err := runLstk(t, ctx, t.TempDir(), e, "aws", "s3", "ls")
+	require.NoError(t, err, "lstk aws should work with externally-named container: %s", stderr)
+	assert.Contains(t, stdout, "ENDPOINT:http://")
 }
 
 func TestAWSCommandSuppressesHintWhenProfileExists(t *testing.T) {


### PR DESCRIPTION
`lstk aws ...` reported `LocalStack AWS Emulator is not running` whenever LocalStack was started outside lstk under a non-default container name (e.g. via the `docker compose` template, where the container is named `localstack-main`). Other commands — `lstk` (start), `lstk status`, `lstk stop` — already detect the running container in this case, so the inconsistency was confusing.

Root cause: `cmd/aws.go` only checked Docker for the configured container name (`rt.IsRunning(awsContainer.Name())`) instead of falling back to image-based discovery the way the other commands do via `resolveRunningContainerName`.

Closes DES-220

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="335" alt="Screenshot 2026-05-07 at 14 03 04" src="https://github.com/user-attachments/assets/5f5e5e11-9d99-462c-a6ca-cf0aa8fd8ca6" /> | <img width="669" height="335" alt="Screenshot 2026-05-07 at 14 02 49" src="https://github.com/user-attachments/assets/ff0678a6-b9b1-40d6-87a2-a77763faa99a" /> | 