### PR TITLE
Set dependabot gomod versioning strategy to increase-if-necessary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Etc/UTC"
+    versioning-strategy: increase-if-necessary
     open-pull-requests-limit: 10
     labels:
       - "semver: patch"


### PR DESCRIPTION
Dependabot's default behavior for Go modules skips major version bumps, so security fixes that land in a new major release (e.g. a CVE fixed in v29.x when we're on v28.x) never generate a PR.

Added `versioning-strategy: increase-if-necessary` to the `gomod` ecosystem in `.github/dependabot.yml`

ℹ️ Alternatively we can use `semver-major`

Closes DRG-826