### PR TITLE
Hide header on start when Docker is not detected

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -204,6 +204,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 	case output.ErrorEvent:
+		if a.headerLoading {
+			a.hideHeader = true
+			a.headerLoading = false
+		}
 		a.errorDisplay = a.errorDisplay.Show(msg)
 		a.spinner, _ = a.spinner.Stop()
 		return a, nil

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -265,6 +265,45 @@ func TestAppErrorEventStopsSpinner(t *testing.T) {
 	}
 }
 
+func TestAppErrorEventHidesLoadingHeader(t *testing.T) {
+	t.Parallel()
+
+	// When Docker is unavailable, the unhealthy ErrorEvent arrives before the
+	// label resolves, freezing the header dots mid-animation. Hiding the header
+	// in that window keeps the error the only thing on screen.
+	app := NewApp("dev", "", "", nil, withHeaderLoading())
+	if app.hideHeader {
+		t.Fatal("expected header to be visible while loading")
+	}
+
+	model, _ := app.Update(output.ErrorEvent{Title: "Docker is not available"})
+	app = model.(App)
+
+	if !app.hideHeader {
+		t.Fatal("expected header to be hidden after early ErrorEvent")
+	}
+	if app.headerLoading {
+		t.Fatal("expected headerLoading to be cleared after early ErrorEvent")
+	}
+}
+
+func TestAppErrorEventKeepsHeaderAfterLabelResolved(t *testing.T) {
+	t.Parallel()
+
+	// Once the label has resolved, the header is meaningful (e.g. "LocalStack
+	// Ultimate") and should stay visible even if a later error occurs.
+	app := NewApp("dev", "", "", nil, withHeaderLoading())
+	model, _ := app.Update(headerLabelMsg{label: "LocalStack Ultimate"})
+	app = model.(App)
+
+	model, _ = app.Update(output.ErrorEvent{Title: "Something went wrong"})
+	app = model.(App)
+
+	if app.hideHeader {
+		t.Fatal("expected header to remain visible after label resolved")
+	}
+}
+
 func TestAppSilentErrorDoesNotOverwriteErrorDisplay(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Running lstk start without a Docker daemon shows the header with the "LocalStack" loading-dots animation frozen at one or two dots, then the unavailable-Docker error:
```
     ▟████▖   lstk (0.7.1)
    ▟██▙█▙█▟  LocalStack ..
      ▀▛▀▛▀   ~/.config/lstk/config.toml
```

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="335" alt="Screenshot 2026-05-08 at 15 06 42" src="https://github.com/user-attachments/assets/88197ccb-f7cc-48a7-a2aa-0fb7cd1aef2d" /> |  <img width="669" height="335" alt="Screenshot 2026-05-08 at 15 06 30" src="https://github.com/user-attachments/assets/e9d805ff-a3c2-42da-9164-5fdcdd8e859b" />| 

Fix DES-223