### PR TITLE
Update docker compose using Jaeger v2

### DIFF
--- a/docker-compose.tracing.yaml
+++ b/docker-compose.tracing.yaml
@@ -1,17 +1,37 @@
-# Starts Jaeger for local trace collection and visualization.
+# Starts Jaeger v2 (all-in-one) for local trace collection and visualization.
 # UI:        http://localhost:16686
-# OTLP HTTP: http://localhost:4318   (used by lstk)
 # OTLP gRPC: localhost:4317
+# OTLP HTTP: http://localhost:4318
+# GitHub: https://github.com/jaegertracing/jaeger
 #
 # Usage:
-#   docker compose -f docker-compose.tracing.yaml up -d
+#   docker compose -f otel/jaeger/docker-compose.yaml up -d
+#
+# Traces are persisted in the jaeger-data Docker volume via Badger embedded storage.
+# The volume is mounted at /tmp so UID 10001 (the Jaeger process user) can write to it.
+# Badger data is stored at /tmp/badger inside the volume.
+
+name: jaeger-standalone
 
 services:
   jaeger:
-    image: jaegertracing/all-in-one:latest
-    environment:
-      COLLECTOR_OTLP_ENABLED: "true"
+    image: jaegertracing/jaeger:latest
+    container_name: jaeger
+    restart: unless-stopped
+    command:
+      - --set=extensions.jaeger_storage.backends.badger_store.badger.ephemeral=false
+      - --set=extensions.jaeger_storage.backends.badger_store.badger.directories.keys=/tmp/badger
+      - --set=extensions.jaeger_storage.backends.badger_store.badger.directories.values=/tmp/badger
+      - --set=extensions.jaeger_storage.backends.badger_store.badger.ttl.spans=168h
+      - --set=extensions.jaeger_query.storage.traces=badger_store
+      - --set=exporters.jaeger_storage_exporter.trace_storage=badger_store
     ports:
       - "4317:4317"    # OTLP gRPC
       - "4318:4318"    # OTLP HTTP
       - "16686:16686"  # UI
+    volumes:
+      - jaeger-data:/tmp
+
+volumes:
+  jaeger-data:
+    name: jaeger-data

--- a/docker-compose.tracing.yaml
+++ b/docker-compose.tracing.yaml
@@ -1,7 +1,7 @@
 # Starts Jaeger v2 (all-in-one) for local trace collection and visualization.
 # UI:        http://localhost:16686
 # OTLP gRPC: localhost:4317
-# OTLP HTTP: http://localhost:4318
+# OTLP HTTP: http://localhost:4318   (used by lstk)
 # GitHub: https://github.com/jaegertracing/jaeger
 #
 # Usage:

--- a/docker-compose.tracing.yaml
+++ b/docker-compose.tracing.yaml
@@ -5,7 +5,7 @@
 # GitHub: https://github.com/jaegertracing/jaeger
 #
 # Usage:
-#   docker compose -f otel/jaeger/docker-compose.yaml up -d
+#   docker compose -f docker-compose.tracing.yaml up -d
 #
 # Traces are persisted in the jaeger-data Docker volume via Badger embedded storage.
 # The volume is mounted at /tmp so UID 10001 (the Jaeger process user) can write to it.


### PR DESCRIPTION
## Motivation

The previously used `jaegertracing/all-in-one:latest` image (Jaeger v1) is deprecated and now fails to start, so `make otel` is broken.
<img width="628" height="547" alt="Screenshot 2026-05-08 at 11 57 43" src="https://github.com/user-attachments/assets/641a003a-f776-4e8c-9af6-e9b74a4c7c7b" />

## Changes

Upgrades `docker-compose.tracing.yaml` to Jaeger v2 (`jaegertracing/jaeger:latest`).

<img width="2302" height="1163" alt="Screenshot 2026-05-08 at 12 10 25" src="https://github.com/user-attachments/assets/3e667c0a-1885-43ef-bc01-f04987c67512" />

- Switches to the Jaeger v2 image with Badger embedded storage (7-day span TTL)
- Adds a named Docker volume (`jaeger-data`) so traces persist across container restarts
- Adds `restart: unless-stopped` and an explicit `container_name`