### PR TITLE
Make status command output easier to read

### DIFF
--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -153,24 +153,23 @@ func formatErrorEvent(e ErrorEvent) string {
 
 func formatInstanceInfo(e InstanceInfoEvent) string {
 	var sb strings.Builder
-	sb.WriteString(SuccessMarker() + " " + e.EmulatorName + " is running (" + e.Host + ")")
-	var meta []string
-	if e.Uptime > 0 {
-		meta = append(meta, "UPTIME: "+formatUptime(e.Uptime))
+	sb.WriteString(SuccessMarker() + " " + e.EmulatorName + " is running")
+	if e.Host != "" {
+		sb.WriteString("\n• Endpoint: " + e.Host)
 	}
 	if e.ContainerName != "" {
-		meta = append(meta, "CONTAINER: "+e.ContainerName)
+		sb.WriteString("\n• Container: " + e.ContainerName)
 	}
 	if e.Version != "" {
-		meta = append(meta, "VERSION: "+e.Version)
+		sb.WriteString("\n• Version: " + e.Version)
 	}
-	if len(meta) > 0 {
-		sb.WriteString("\n  " + strings.Join(meta, " · "))
+	if e.Uptime > 0 {
+		sb.WriteString("\n• Uptime: " + FormatUptime(e.Uptime))
 	}
 	return sb.String()
 }
 
-func formatUptime(d time.Duration) string {
+func FormatUptime(d time.Duration) string {
 	d = d.Round(time.Second)
 	h := int(d.Hours())
 	m := int(d.Minutes()) % 60

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -120,7 +120,7 @@ func TestFormatEventLine(t *testing.T) {
 				ContainerName: "localstack-aws",
 				Uptime:        4*time.Minute + 23*time.Second,
 			},
-			want:   SuccessMarker() + " LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1",
+			want:   SuccessMarker() + " LocalStack AWS Emulator is running\n• Endpoint: localhost.localstack.cloud:4566\n• Container: localstack-aws\n• Version: 4.14.1\n• Uptime: 4m 23s",
 			wantOK: true,
 		},
 		{
@@ -129,7 +129,7 @@ func TestFormatEventLine(t *testing.T) {
 				EmulatorName: "LocalStack AWS Emulator",
 				Host:         "127.0.0.1:4566",
 			},
-			want:   SuccessMarker() + " LocalStack AWS Emulator is running (127.0.0.1:4566)",
+			want:   SuccessMarker() + " LocalStack AWS Emulator is running\n• Endpoint: 127.0.0.1:4566",
 			wantOK: true,
 		},
 		{

--- a/internal/output/plain_sink_test.go
+++ b/internal/output/plain_sink_test.go
@@ -163,7 +163,7 @@ func TestPlainSink_EmitsInstanceInfoEvent(t *testing.T) {
 			Uptime:        4*time.Minute + 23*time.Second,
 		})
 
-		expected := SuccessMarker() + " LocalStack AWS Emulator is running (localhost.localstack.cloud:4566)\n  UPTIME: 4m 23s · CONTAINER: localstack-aws · VERSION: 4.14.1\n"
+		expected := SuccessMarker() + " LocalStack AWS Emulator is running\n• Endpoint: localhost.localstack.cloud:4566\n• Container: localstack-aws\n• Version: 4.14.1\n• Uptime: 4m 23s\n"
 		assert.Equal(t, expected, out.String())
 		assert.NoError(t, sink.Err())
 	})
@@ -177,7 +177,7 @@ func TestPlainSink_EmitsInstanceInfoEvent(t *testing.T) {
 			Host:         "127.0.0.1:4566",
 		})
 
-		expected := SuccessMarker() + " LocalStack AWS Emulator is running (127.0.0.1:4566)\n"
+		expected := SuccessMarker() + " LocalStack AWS Emulator is running\n• Endpoint: 127.0.0.1:4566\n"
 		assert.Equal(t, expected, out.String())
 		assert.NoError(t, sink.Err())
 	})

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -296,9 +296,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 	case output.InstanceInfoEvent:
 		if line, ok := output.FormatEventLine(msg); ok {
-			line = strings.Replace(line, output.SuccessMarker(), styles.Success.Render(output.SuccessMarker()), 1)
-			for _, part := range strings.Split(line, "\n") {
-				a.addLine(styledLine{text: part})
+			parts := strings.Split(line, "\n")
+			for i, part := range parts {
+				if i == 0 {
+					part = strings.Replace(part, output.SuccessMarker(), styles.Success.Render(output.SuccessMarker()), 1)
+					a.addLine(styledLine{text: part})
+				} else {
+					a.addLine(styledLine{text: part, secondary: true})
+				}
 			}
 		}
 		return a, nil

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -205,7 +205,7 @@ func TestStatusCommandForSnowflakeShowsVersion(t *testing.T) {
 	require.NoError(t, err, "lstk status failed: %s", stderr)
 	requireExitCode(t, 0, err)
 
-	assert.Contains(t, stdout, "VERSION: "+expectedVersion,
+	assert.Contains(t, stdout, "• Version: "+expectedVersion,
 		"snowflake status should display the version reported by /_localstack/health")
 }
 


### PR DESCRIPTION
| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="320" alt="Screenshot 2026-05-13 at 00 31 29" src="https://github.com/user-attachments/assets/1c4a49d7-7c30-4935-af90-d0acc2f7ce2a" /> | <img width="669" height="320" alt="Screenshot 2026-05-13 at 00 31 18" src="https://github.com/user-attachments/assets/e03e5d37-b188-4e26-85f0-c7603752a8e6" /> | 