### PR TITLE
Support cloud pods in snapshot save cmd

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -37,7 +37,9 @@ Pass [destination] as an absolute or relative path for the exported file:
   lstk snapshot save ./my-snapshot.zip  # saves to ./my-snapshot.zip
   lstk snapshot save /tmp/my-state      # saves to /tmp/my-state.zip
 
-Cloud destinations are not yet supported.`,
+To save to a remote pod on the LocalStack platform, use the pod: prefix:
+
+  lstk snapshot save pod:my-baseline    # saves as a named pod on the platform`,
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: initConfig(nil),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,12 +76,20 @@ Cloud destinations are not yet supported.`,
 				return err
 			}
 			host, _ := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
-			exporter := aws.NewClient()
+			client := aws.NewClient()
+			containers := []config.ContainerConfig{awsContainer}
 
 			if isInteractiveMode(cfg) {
-				return ui.RunSnapshotSave(cmd.Context(), rt, []config.ContainerConfig{awsContainer}, exporter, host, dest)
+				if dest.Kind == snapshot.KindPod {
+					return ui.RunSnapshotSavePod(cmd.Context(), rt, containers, client, host, dest.Value, cfg.AuthToken)
+				}
+				return ui.RunSnapshotSaveLocal(cmd.Context(), rt, containers, client, host, dest.Value)
 			}
-			return snapshot.Save(cmd.Context(), rt, []config.ContainerConfig{awsContainer}, exporter, host, dest, output.NewPlainSink(os.Stdout))
+			sink := output.NewPlainSink(os.Stdout)
+			if dest.Kind == snapshot.KindPod {
+				return snapshot.SavePod(cmd.Context(), rt, containers, client, host, dest.Value, cfg.AuthToken, sink)
+			}
+			return snapshot.SaveLocal(cmd.Context(), rt, containers, client, host, dest.Value, sink)
 		},
 	}
 }

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -79,17 +79,18 @@ To save to a remote pod on the LocalStack platform, use the pod: prefix:
 			client := aws.NewClient()
 			containers := []config.ContainerConfig{awsContainer}
 
-			if isInteractiveMode(cfg) {
-				if dest.Kind == snapshot.KindPod {
+			switch dest.Kind {
+			case snapshot.KindPod:
+				if isInteractiveMode(cfg) {
 					return ui.RunSnapshotSavePod(cmd.Context(), rt, containers, client, host, dest.Value, cfg.AuthToken)
 				}
-				return ui.RunSnapshotSaveLocal(cmd.Context(), rt, containers, client, host, dest.Value)
+				return snapshot.SavePod(cmd.Context(), rt, containers, client, host, dest.Value, cfg.AuthToken, output.NewPlainSink(os.Stdout))
+			default:
+				if isInteractiveMode(cfg) {
+					return ui.RunSnapshotSaveLocal(cmd.Context(), rt, containers, client, host, dest.Value)
+				}
+				return snapshot.SaveLocal(cmd.Context(), rt, containers, client, host, dest.Value, output.NewPlainSink(os.Stdout))
 			}
-			sink := output.NewPlainSink(os.Stdout)
-			if dest.Kind == snapshot.KindPod {
-				return snapshot.SavePod(cmd.Context(), rt, containers, client, host, dest.Value, cfg.AuthToken, sink)
-			}
-			return snapshot.SaveLocal(cmd.Context(), rt, containers, client, host, dest.Value, sink)
 		},
 	}
 }

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -79,17 +79,15 @@ To save to a remote pod on the LocalStack platform, use the pod: prefix:
 			client := aws.NewClient()
 			containers := []config.ContainerConfig{awsContainer}
 
+			if isInteractiveMode(cfg) {
+				return ui.RunSnapshotSave(cmd.Context(), rt, containers, client, host, dest, cfg.AuthToken)
+			}
+			sink := output.NewPlainSink(os.Stdout)
 			switch dest.Kind {
 			case snapshot.KindPod:
-				if isInteractiveMode(cfg) {
-					return ui.RunSnapshotSavePod(cmd.Context(), rt, containers, client, host, dest.Value, cfg.AuthToken)
-				}
-				return snapshot.SavePod(cmd.Context(), rt, containers, client, host, dest.Value, cfg.AuthToken, output.NewPlainSink(os.Stdout))
+				return snapshot.SavePod(cmd.Context(), rt, containers, client, host, dest.Value, cfg.AuthToken, sink)
 			default:
-				if isInteractiveMode(cfg) {
-					return ui.RunSnapshotSaveLocal(cmd.Context(), rt, containers, client, host, dest.Value)
-				}
-				return snapshot.SaveLocal(cmd.Context(), rt, containers, client, host, dest.Value, output.NewPlainSink(os.Stdout))
+				return snapshot.SaveLocal(cmd.Context(), rt, containers, client, host, dest.Value, sink)
 			}
 		},
 	}

--- a/internal/emulator/aws/client.go
+++ b/internal/emulator/aws/client.go
@@ -159,9 +159,6 @@ func (c *Client) ExportState(ctx context.Context, host string, dst io.Writer) er
 	return nil
 }
 
-// SavePodSnapshot triggers LocalStack to upload its state as a named pod to the
-// LocalStack platform. The authToken is forwarded as Basic auth so the container
-// can authenticate the upload to the platform on behalf of the CLI user.
 func (c *Client) SavePodSnapshot(ctx context.Context, host, podName, authToken string) (snapshot.PodSaveResult, error) {
 	url := fmt.Sprintf("http://%s/_localstack/pods/%s", host, podName)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader([]byte("{}")))
@@ -185,6 +182,8 @@ func (c *Client) SavePodSnapshot(ctx context.Context, host, podName, authToken s
 	// The response is a newline-delimited JSON stream. We scan until we find a
 	// completion event and surface any server-side error as a Go error.
 	scanner := bufio.NewScanner(resp.Body)
+	buf := make([]byte, 1024*1024)
+	scanner.Buffer(buf, 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {

--- a/internal/emulator/aws/client.go
+++ b/internal/emulator/aws/client.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/localstack/lstk/internal/snapshot"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/localstack/lstk/internal/emulator"
@@ -154,4 +157,65 @@ func (c *Client) ExportState(ctx context.Context, host string, dst io.Writer) er
 		return fmt.Errorf("stream state: %w", err)
 	}
 	return nil
+}
+
+// SavePodSnapshot triggers LocalStack to upload its state as a named pod to the
+// LocalStack platform. The authToken is forwarded as Basic auth so the container
+// can authenticate the upload to the platform on behalf of the CLI user.
+func (c *Client) SavePodSnapshot(ctx context.Context, host, podName, authToken string) (snapshot.PodSaveResult, error) {
+	url := fmt.Sprintf("http://%s/_localstack/pods/%s", host, podName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return snapshot.PodSaveResult{}, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(":"+authToken)))
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return snapshot.PodSaveResult{}, fmt.Errorf("connect to LocalStack: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return snapshot.PodSaveResult{}, fmt.Errorf("pod save failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	// The response is a newline-delimited JSON stream. We scan until we find a
+	// completion event and surface any server-side error as a Go error.
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var event struct {
+			Event   string `json:"event"`
+			Status  string `json:"status"`
+			Message string `json:"message"`
+			Info    struct {
+				Version  int      `json:"version"`
+				Services []string `json:"services"`
+				Size     int64    `json:"size"`
+			} `json:"info"`
+		}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+		if event.Event == "completion" {
+			if event.Status != "ok" {
+				return snapshot.PodSaveResult{}, fmt.Errorf("pod save failed: %s", event.Message)
+			}
+			return snapshot.PodSaveResult{
+				Version:  event.Info.Version,
+				Services: event.Info.Services,
+				Size:     event.Info.Size,
+			}, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return snapshot.PodSaveResult{}, fmt.Errorf("reading response: %w", err)
+	}
+	return snapshot.PodSaveResult{}, fmt.Errorf("pod save: server closed stream without a completion event")
 }

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -77,6 +77,13 @@ type ResourceSummaryEvent struct {
 	Services  int
 }
 
+type PodSnapshotSavedEvent struct {
+	PodName  string
+	Version  int
+	Services []string
+	Size     int64
+}
+
 type AuthCompleteEvent struct{}
 
 // Event is a sealed marker — only event types in this package implement it,
@@ -91,6 +98,7 @@ func (AuthCompleteEvent) sealedEvent()     {}
 func (InstanceInfoEvent) sealedEvent()     {}
 func (TableEvent) sealedEvent()            {}
 func (ResourceSummaryEvent) sealedEvent()  {}
+func (PodSnapshotSavedEvent) sealedEvent() {}
 func (ContainerStatusEvent) sealedEvent()  {}
 func (ProgressEvent) sealedEvent()         {}
 func (UserInputRequestEvent) sealedEvent() {}

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -6,6 +6,12 @@ import (
 	"time"
 )
 
+const (
+	byteKB int64 = 1024
+	byteMB       = 1024 * byteKB
+	byteGB       = 1024 * byteMB
+)
+
 // FormatEventLine converts an output event into a single display line.
 func FormatEventLine(event Event) (string, bool) {
 	switch e := event.(type) {
@@ -34,6 +40,8 @@ func FormatEventLine(event Event) (string, bool) {
 		return formatTable(e)
 	case ResourceSummaryEvent:
 		return formatResourceSummary(e), true
+	case PodSnapshotSavedEvent:
+		return formatPodSnapshotSaved(e), true
 	case AuthCompleteEvent:
 		return "", false
 	default:
@@ -188,6 +196,34 @@ func FormatUptime(d time.Duration) string {
 
 func formatResourceSummary(e ResourceSummaryEvent) string {
 	return fmt.Sprintf("~ %d resources · %d services", e.Resources, e.Services)
+}
+
+func formatPodSnapshotSaved(e PodSnapshotSavedEvent) string {
+	var sb strings.Builder
+	sb.WriteString(SuccessMarker() + fmt.Sprintf(" Snapshot saved to pod %q", e.PodName))
+	if e.Version > 0 {
+		sb.WriteString(fmt.Sprintf("\n• Version: %d", e.Version))
+	}
+	if len(e.Services) > 0 {
+		sb.WriteString("\n• Services: " + strings.Join(e.Services, ", "))
+	}
+	if e.Size > 0 {
+		sb.WriteString("\n• Size: " + formatBytes(e.Size))
+	}
+	return sb.String()
+}
+
+func formatBytes(b int64) string {
+	switch {
+	case b >= byteGB:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(byteGB))
+	case b >= byteMB:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(byteMB))
+	case b >= byteKB:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(byteKB))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
 }
 
 func formatTable(e TableEvent) (string, bool) {

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -200,7 +200,7 @@ func formatResourceSummary(e ResourceSummaryEvent) string {
 
 func formatPodSnapshotSaved(e PodSnapshotSavedEvent) string {
 	var sb strings.Builder
-	sb.WriteString(SuccessMarker() + fmt.Sprintf(" Snapshot saved to pod %q", e.PodName))
+	sb.WriteString(SuccessMarker() + fmt.Sprintf(" Snapshot saved to pod:%s", e.PodName))
 	if e.Version > 0 {
 		sb.WriteString(fmt.Sprintf("\n• Version: %d", e.Version))
 	}

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -188,7 +188,7 @@ func TestFormatEventLine(t *testing.T) {
 				Services: []string{"dynamodb", "s3", "sqs"},
 				Size:     2621440,
 			},
-			want:   SuccessMarker() + " Snapshot saved to pod \"my-baseline\"\n• Version: 3\n• Services: dynamodb, s3, sqs\n• Size: 2.5 MB",
+			want:   SuccessMarker() + " Snapshot saved to pod:my-baseline\n• Version: 3\n• Services: dynamodb, s3, sqs\n• Size: 2.5 MB",
 			wantOK: true,
 		},
 		{
@@ -199,7 +199,7 @@ func TestFormatEventLine(t *testing.T) {
 				Services: []string{"s3", "sqs", "sns", "dynamodb", "lambda", "apigateway", "iam", "sts", "ec2", "rds", "kinesis", "firehose", "cloudwatch", "cloudformation", "route53"},
 				Size:     10485760,
 			},
-			want:   SuccessMarker() + " Snapshot saved to pod \"big-pod\"\n• Version: 1\n• Services: s3, sqs, sns, dynamodb, lambda, apigateway, iam, sts, ec2, rds, kinesis, firehose, cloudwatch, cloudformation, route53\n• Size: 10.0 MB",
+			want:   SuccessMarker() + " Snapshot saved to pod:big-pod\n• Version: 1\n• Services: s3, sqs, sns, dynamodb, lambda, apigateway, iam, sts, ec2, rds, kinesis, firehose, cloudwatch, cloudformation, route53\n• Size: 10.0 MB",
 			wantOK: true,
 		},
 		{
@@ -207,7 +207,7 @@ func TestFormatEventLine(t *testing.T) {
 			event: PodSnapshotSavedEvent{
 				PodName: "minimal-pod",
 			},
-			want:   SuccessMarker() + " Snapshot saved to pod \"minimal-pod\"",
+			want:   SuccessMarker() + " Snapshot saved to pod:minimal-pod",
 			wantOK: true,
 		},
 	}

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -180,6 +180,36 @@ func TestFormatEventLine(t *testing.T) {
 			want:   "",
 			wantOK: false,
 		},
+		{
+			name: "pod snapshot saved full",
+			event: PodSnapshotSavedEvent{
+				PodName:  "my-baseline",
+				Version:  3,
+				Services: []string{"dynamodb", "s3", "sqs"},
+				Size:     2621440,
+			},
+			want:   SuccessMarker() + " Snapshot saved to pod \"my-baseline\"\n• Version: 3\n• Services: dynamodb, s3, sqs\n• Size: 2.5 MB",
+			wantOK: true,
+		},
+		{
+			name: "pod snapshot saved many services",
+			event: PodSnapshotSavedEvent{
+				PodName:  "big-pod",
+				Version:  1,
+				Services: []string{"s3", "sqs", "sns", "dynamodb", "lambda", "apigateway", "iam", "sts", "ec2", "rds", "kinesis", "firehose", "cloudwatch", "cloudformation", "route53"},
+				Size:     10485760,
+			},
+			want:   SuccessMarker() + " Snapshot saved to pod \"big-pod\"\n• Version: 1\n• Services: s3, sqs, sns, dynamodb, lambda, apigateway, iam, sts, ec2, rds, kinesis, firehose, cloudwatch, cloudformation, route53\n• Size: 10.0 MB",
+			wantOK: true,
+		},
+		{
+			name: "pod snapshot saved omits zero fields",
+			event: PodSnapshotSavedEvent{
+				PodName: "minimal-pod",
+			},
+			want:   SuccessMarker() + " Snapshot saved to pod \"minimal-pod\"",
+			wantOK: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -248,4 +278,31 @@ func TestFormatTableWidth(t *testing.T) {
 			t.Error("expected truncation at narrow width")
 		}
 	})
+}
+
+func TestFormatBytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{2621440, "2.5 MB"},
+		{1073741824, "1.0 GB"},
+		{2684354560, "2.5 GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			got := formatBytes(tt.input)
+			if got != tt.want {
+				t.Fatalf("formatBytes(%d) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/snapshot/destination.go
+++ b/internal/snapshot/destination.go
@@ -61,8 +61,11 @@ func ParseDestination(dest string, now time.Time) (Destination, error) {
 	} else {
 		lower := strings.ToLower(dest)
 		switch {
+		case strings.HasPrefix(lower, "pod://"):
+			podName := dest[len("pod://"):]
+			return Destination{}, fmt.Errorf("'%s' is not a valid reference. Aliases use a single colon. Did you mean:\npod:%s", dest, podName)
 		case strings.HasPrefix(lower, "pod:"):
-			podName := strings.TrimPrefix(dest[len("pod:"):], "//")
+			podName := dest[len("pod:"):]
 			if !validPodName.MatchString(podName) {
 				return Destination{}, fmt.Errorf("invalid pod name %q: use letters, digits, and hyphens only, starting with a letter or digit", podName)
 			}

--- a/internal/snapshot/destination.go
+++ b/internal/snapshot/destination.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	// ErrRemoteNotSupported is returned for known remote schemes (s3://, oras://, cloud:).
+	// ErrRemoteNotSupported is returned for known remote schemes (s3://, oras://, pod:).
 	ErrRemoteNotSupported = errors.New("remote destinations are not yet supported — coming soon")
 	// ErrUnknownScheme is returned for unrecognized URL schemes.
 	ErrUnknownScheme = errors.New("unrecognized destination scheme")
@@ -47,7 +47,7 @@ func ParseDestination(dest string, now time.Time) (string, error) {
 		switch {
 		case strings.HasPrefix(lower, "s3://"),
 			strings.HasPrefix(lower, "oras://"),
-			strings.HasPrefix(lower, "cloud:"):
+			strings.HasPrefix(lower, "pod:"):
 			return "", ErrRemoteNotSupported
 		case strings.Contains(lower, "://"):
 			scheme, _, _ := strings.Cut(dest, "://")

--- a/internal/snapshot/destination.go
+++ b/internal/snapshot/destination.go
@@ -6,16 +6,35 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
 
 var (
-	// ErrRemoteNotSupported is returned for known remote schemes (s3://, oras://, pod:).
+	// ErrRemoteNotSupported is returned for known remote schemes (s3://, oras://).
 	ErrRemoteNotSupported = errors.New("remote destinations are not yet supported — coming soon")
 	// ErrUnknownScheme is returned for unrecognized URL schemes.
 	ErrUnknownScheme = errors.New("unrecognized destination scheme")
+
+	validPodName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
 )
+
+// DestinationKind distinguishes local file paths from remote pod destinations.
+type DestinationKind int
+
+const (
+	KindLocal DestinationKind = iota
+	KindPod
+)
+
+// Destination is the parsed result of a user-supplied snapshot destination.
+// For KindLocal, Value is an absolute local file path with a .zip extension.
+// For KindPod, Value is the validated pod name (without the "pod:" prefix).
+type Destination struct {
+	Kind  DestinationKind
+	Value string
+}
 
 // displayPath shortens abs for human-readable output:
 // under cwd → ./rel, under home → ~/rel, otherwise unchanged.
@@ -33,11 +52,8 @@ func displayPath(abs, cwd, home string) string {
 	return abs
 }
 
-// ParseDestination resolves the user-supplied path to an absolute local path.
-// When dest is empty, a default name based on now (UTC) is used, e.g.
-// "snapshot-2026-05-11T21-04-32-a3f.zip", saved in the current working directory.
-// The returned path always has a .zip extension.
-func ParseDestination(dest string, now time.Time) (string, error) {
+// ParseDestination resolves a user-supplied destination to a local path (KindLocal) or validated pod name (KindPod).
+func ParseDestination(dest string, now time.Time) (Destination, error) {
 	if dest == "" {
 		b := make([]byte, 2)
 		_, _ = rand.Read(b)
@@ -45,48 +61,53 @@ func ParseDestination(dest string, now time.Time) (string, error) {
 	} else {
 		lower := strings.ToLower(dest)
 		switch {
+		case strings.HasPrefix(lower, "pod:"):
+			podName := strings.TrimPrefix(dest[len("pod:"):], "//")
+			if !validPodName.MatchString(podName) {
+				return Destination{}, fmt.Errorf("invalid pod name %q: use letters, digits, and hyphens only, starting with a letter or digit", podName)
+			}
+			return Destination{Kind: KindPod, Value: podName}, nil
 		case strings.HasPrefix(lower, "s3://"),
-			strings.HasPrefix(lower, "oras://"),
-			strings.HasPrefix(lower, "pod:"):
-			return "", ErrRemoteNotSupported
+			strings.HasPrefix(lower, "oras://"):
+			return Destination{}, ErrRemoteNotSupported
 		case strings.Contains(lower, "://"):
 			scheme, _, _ := strings.Cut(dest, "://")
-			return "", fmt.Errorf("%w: %q", ErrUnknownScheme, scheme+"://")
+			return Destination{}, fmt.Errorf("%w: %q", ErrUnknownScheme, scheme+"://")
 		}
 	}
 
 	if dest == "~" || strings.HasPrefix(dest, "~/") || strings.HasPrefix(dest, `~\`) {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("resolve home directory: %w", err)
+			return Destination{}, fmt.Errorf("resolve home directory: %w", err)
 		}
 		dest = filepath.Join(home, strings.TrimLeft(dest[1:], `/\`))
 	}
 
 	abs, err := filepath.Abs(dest)
 	if err != nil {
-		return "", fmt.Errorf("resolve path: %w", err)
+		return Destination{}, fmt.Errorf("resolve path: %w", err)
 	}
 
 	parent := filepath.Dir(abs)
 	parentInfo, err := os.Stat(parent)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", fmt.Errorf("parent directory %q does not exist — create it first", parent)
+			return Destination{}, fmt.Errorf("parent directory %q does not exist — create it first", parent)
 		}
-		return "", fmt.Errorf("check parent directory: %w", err)
+		return Destination{}, fmt.Errorf("check parent directory: %w", err)
 	}
 	if !parentInfo.IsDir() {
-		return "", fmt.Errorf("parent path %q is not a directory", parent)
+		return Destination{}, fmt.Errorf("parent path %q is not a directory", parent)
 	}
 
 	if info, err := os.Stat(abs); err == nil && info.IsDir() {
-		return "", fmt.Errorf("%q is a directory — specify a file path like ./my-snapshot", abs)
+		return Destination{}, fmt.Errorf("%q is a directory — specify a file path like ./my-snapshot", abs)
 	}
 
 	if !strings.EqualFold(filepath.Ext(abs), ".zip") {
 		abs += ".zip"
 	}
 
-	return abs, nil
+	return Destination{Kind: KindLocal, Value: abs}, nil
 }

--- a/internal/snapshot/destination_test.go
+++ b/internal/snapshot/destination_test.go
@@ -99,7 +99,9 @@ func TestParseDestination(t *testing.T) {
 	type testCase struct {
 		name           string // optional; uses input when empty
 		input          string
+		wantKind       snapshot.DestinationKind
 		wantPath       string
+		wantPodName    string
 		wantPathRegexp string // used instead of wantPath when the result contains a random component
 		wantErr        string
 		wantRemoteErr  bool
@@ -111,16 +113,19 @@ func TestParseDestination(t *testing.T) {
 		{
 			name:           "default",
 			input:          "",
+			wantKind:       snapshot.KindLocal,
 			wantPathRegexp: regexp.QuoteMeta(filepath.Join(wd, "snapshot-2026-05-11T21-04-32-")) + `[0-9a-f]{3}\.zip`,
 		},
 
 		// --- local paths ---
 		{
 			input:    "./my-state",
+			wantKind: snapshot.KindLocal,
 			wantPath: filepath.Join(wd, "my-state.zip"),
 		},
 		{
 			input:    filepath.Join(os.TempDir(), "state"),
+			wantKind: snapshot.KindLocal,
 			wantPath: filepath.Join(os.TempDir(), "state.zip"),
 		},
 		{
@@ -130,24 +135,29 @@ func TestParseDestination(t *testing.T) {
 		{
 			// parent (~/) always exists
 			input:    "~/my-state",
+			wantKind: snapshot.KindLocal,
 			wantPath: filepath.Join(home, "my-state.zip"),
 		},
 		{
 			name:     "relative path with existing subdir",
 			input:    filepath.Join(subDir, "state"),
+			wantKind: snapshot.KindLocal,
 			wantPath: filepath.Join(subDir, "state.zip"),
 		},
 		{
-			// bare name: treated as relative to CWD
+			// bare name: treated as relative to CWD, not a pod
 			input:    "my-pod",
+			wantKind: snapshot.KindLocal,
 			wantPath: filepath.Join(wd, "my-pod.zip"),
 		},
 		{
 			input:    "./checkpoint.zip",
+			wantKind: snapshot.KindLocal,
 			wantPath: filepath.Join(wd, "checkpoint.zip"),
 		},
 		{
 			input:    "./already.ZIP",
+			wantKind: snapshot.KindLocal,
 			wantPath: filepath.Join(wd, "already.ZIP"),
 		},
 
@@ -178,19 +188,50 @@ func TestParseDestination(t *testing.T) {
 			wantRemoteErr: true,
 		},
 
-		// --- remote: pod ---
+		// --- pod destinations ---
 		{
-			input:         "pod:my-pod",
-			wantRemoteErr: true,
+			input:       "pod:my-baseline",
+			wantKind:    snapshot.KindPod,
+			wantPodName: "my-baseline",
 		},
 		{
-			input:         "Pod:my-pod",
-			wantRemoteErr: true,
+			input:       "Pod:my-baseline",
+			wantKind:    snapshot.KindPod,
+			wantPodName: "my-baseline",
 		},
 		{
-			// pod: prefix also catches pod://
-			input:         "pod://my-pod",
-			wantRemoteErr: true,
+			// pod:// is also accepted
+			input:       "pod://my-baseline",
+			wantKind:    snapshot.KindPod,
+			wantPodName: "my-baseline",
+		},
+		{
+			input:       "pod:abc123",
+			wantKind:    snapshot.KindPod,
+			wantPodName: "abc123",
+		},
+		{
+			input:       "pod:my-long-pod-name-123",
+			wantKind:    snapshot.KindPod,
+			wantPodName: "my-long-pod-name-123",
+		},
+		{
+			// empty pod name
+			name:    "pod: empty name",
+			input:   "pod:",
+			wantErr: "invalid pod name",
+		},
+		{
+			// pod name starting with hyphen
+			name:    "pod: leading hyphen",
+			input:   "pod:-invalid",
+			wantErr: "invalid pod name",
+		},
+		{
+			// pod name with invalid characters
+			name:    "pod: underscore invalid",
+			input:   "pod:my_pod",
+			wantErr: "invalid pod name",
 		},
 
 		// --- unknown schemes ---
@@ -209,16 +250,19 @@ func TestParseDestination(t *testing.T) {
 		tests = append(tests,
 			testCase{
 				input:    `~\my-state`,
+				wantKind: snapshot.KindLocal,
 				wantPath: filepath.Join(home, "my-state.zip"),
 			},
 			testCase{
 				name:     "windows abs backslash",
 				input:    filepath.Join(tmpParent, "snap"),
+				wantKind: snapshot.KindLocal,
 				wantPath: filepath.Join(tmpParent, "snap.zip"),
 			},
 			testCase{
 				name:     "windows abs forward-slash",
 				input:    strings.ReplaceAll(filepath.Join(tmpParent, "snap"), `\`, `/`),
+				wantKind: snapshot.KindLocal,
 				wantPath: filepath.Join(tmpParent, "snap.zip"),
 			},
 		)
@@ -246,10 +290,13 @@ func TestParseDestination(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			if tc.wantPathRegexp != "" {
-				assert.Regexp(t, tc.wantPathRegexp, got)
+			assert.Equal(t, tc.wantKind, got.Kind)
+			if tc.wantPodName != "" {
+				assert.Equal(t, tc.wantPodName, got.Value)
+			} else if tc.wantPathRegexp != "" {
+				assert.Regexp(t, tc.wantPathRegexp, got.Value)
 			} else {
-				assert.Equal(t, tc.wantPath, got)
+				assert.Equal(t, tc.wantPath, got.Value)
 			}
 		})
 	}

--- a/internal/snapshot/destination_test.go
+++ b/internal/snapshot/destination_test.go
@@ -178,18 +178,18 @@ func TestParseDestination(t *testing.T) {
 			wantRemoteErr: true,
 		},
 
-		// --- remote: cloud ---
+		// --- remote: pod ---
 		{
-			input:         "cloud:my-pod",
+			input:         "pod:my-pod",
 			wantRemoteErr: true,
 		},
 		{
-			input:         "Cloud:my-pod",
+			input:         "Pod:my-pod",
 			wantRemoteErr: true,
 		},
 		{
-			// cloud: prefix also catches cloud://
-			input:         "cloud://my-pod",
+			// pod: prefix also catches pod://
+			input:         "pod://my-pod",
 			wantRemoteErr: true,
 		},
 

--- a/internal/snapshot/destination_test.go
+++ b/internal/snapshot/destination_test.go
@@ -200,10 +200,9 @@ func TestParseDestination(t *testing.T) {
 			wantPodName: "my-baseline",
 		},
 		{
-			// pod:// is also accepted
-			input:       "pod://my-baseline",
-			wantKind:    snapshot.KindPod,
-			wantPodName: "my-baseline",
+			name:    "pod:// rejected with did-you-mean hint",
+			input:   "pod://my-baseline",
+			wantErr: "not a valid reference. Aliases use a single colon. Did you mean:\npod:my-baseline",
 		},
 		{
 			input:       "pod:abc123",

--- a/internal/snapshot/mock_state_exporter_test.go
+++ b/internal/snapshot/mock_state_exporter_test.go
@@ -14,6 +14,7 @@ import (
 	io "io"
 	reflect "reflect"
 
+	snapshot "github.com/localstack/lstk/internal/snapshot"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -53,4 +54,43 @@ func (m *MockStateExporter) ExportState(ctx context.Context, host string, dst io
 func (mr *MockStateExporterMockRecorder) ExportState(ctx, host, dst any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportState", reflect.TypeOf((*MockStateExporter)(nil).ExportState), ctx, host, dst)
+}
+
+// MockPodSaver is a mock of PodSaver interface.
+type MockPodSaver struct {
+	ctrl     *gomock.Controller
+	recorder *MockPodSaverMockRecorder
+	isgomock struct{}
+}
+
+// MockPodSaverMockRecorder is the mock recorder for MockPodSaver.
+type MockPodSaverMockRecorder struct {
+	mock *MockPodSaver
+}
+
+// NewMockPodSaver creates a new mock instance.
+func NewMockPodSaver(ctrl *gomock.Controller) *MockPodSaver {
+	mock := &MockPodSaver{ctrl: ctrl}
+	mock.recorder = &MockPodSaverMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPodSaver) EXPECT() *MockPodSaverMockRecorder {
+	return m.recorder
+}
+
+// SavePodSnapshot mocks base method.
+func (m *MockPodSaver) SavePodSnapshot(ctx context.Context, host, podName, authToken string) (snapshot.PodSaveResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SavePodSnapshot", ctx, host, podName, authToken)
+	ret0, _ := ret[0].(snapshot.PodSaveResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SavePodSnapshot indicates an expected call of SavePodSnapshot.
+func (mr *MockPodSaverMockRecorder) SavePodSnapshot(ctx, host, podName, authToken any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavePodSnapshot", reflect.TypeOf((*MockPodSaver)(nil).SavePodSnapshot), ctx, host, podName, authToken)
 }

--- a/internal/snapshot/save.go
+++ b/internal/snapshot/save.go
@@ -19,7 +19,19 @@ type StateExporter interface {
 	ExportState(ctx context.Context, host string, dst io.Writer) error
 }
 
-func Save(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, exporter StateExporter, host, dest string, sink output.Sink) (retErr error) {
+// PodSaveResult holds the metadata returned by the platform after a successful pod save.
+type PodSaveResult struct {
+	Version  int
+	Services []string
+	Size     int64
+}
+
+// PodSaver triggers a remote pod snapshot save on the running LocalStack instance.
+type PodSaver interface {
+	SavePodSnapshot(ctx context.Context, host, podName, authToken string) (PodSaveResult, error)
+}
+
+func save(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, sink output.Sink, spinnerText string, onSuccess func(), do func() error) (retErr error) {
 	if err := rt.IsHealthy(ctx); err != nil {
 		rt.EmitUnhealthyError(sink, err)
 		return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
@@ -40,26 +52,59 @@ func Save(ctx context.Context, rt runtime.Runtime, containers []config.Container
 		return output.NewSilentError(fmt.Errorf("LocalStack is not running"))
 	}
 
-	sink.Emit(output.SpinnerStart("Saving snapshot..."))
+	sink.Emit(output.SpinnerStart(spinnerText))
 	defer func() {
 		sink.Emit(output.SpinnerStop())
 		if retErr == nil {
-			cwd, _ := os.Getwd()
-			home, _ := os.UserHomeDir()
-			sink.Emit(output.MessageEvent{Severity: output.SeveritySuccess, Text: fmt.Sprintf("Snapshot saved to %s", displayPath(dest, cwd, home))})
+			onSuccess()
 		}
 	}()
 
-	w, err := os.Create(dest)
-	if err != nil {
-		return fmt.Errorf("save to %s: %w", dest, err)
-	}
+	return do()
+}
 
-	if err := exporter.ExportState(ctx, host, w); err != nil {
-		_ = w.Close()
-		_ = os.Remove(dest)
-		return fmt.Errorf("export state from LocalStack: %w", err)
-	}
+func SaveLocal(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, exporter StateExporter, host, dest string, sink output.Sink) error {
+	cwd, _ := os.Getwd()
+	home, _ := os.UserHomeDir()
+	return save(ctx, rt, containers, sink,
+		"Saving snapshot...",
+		func() {
+			sink.Emit(output.MessageEvent{Severity: output.SeveritySuccess, Text: fmt.Sprintf("Snapshot saved to %s", displayPath(dest, cwd, home))})
+		},
+		func() error {
+			w, err := os.Create(dest)
+			if err != nil {
+				return fmt.Errorf("save to %s: %w", dest, err)
+			}
+			if err := exporter.ExportState(ctx, host, w); err != nil {
+				_ = w.Close()
+				_ = os.Remove(dest)
+				return fmt.Errorf("export state from LocalStack: %w", err)
+			}
+			return w.Close()
+		},
+	)
+}
 
-	return w.Close()
+func SavePod(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, saver PodSaver, host, podName, authToken string, sink output.Sink) error {
+	if authToken == "" {
+		return fmt.Errorf("pod snapshots require authentication — set LOCALSTACK_AUTH_TOKEN or run %q", "lstk login")
+	}
+	var result PodSaveResult
+	return save(ctx, rt, containers, sink,
+		fmt.Sprintf("Saving snapshot to pod %q...", podName),
+		func() {
+			sink.Emit(output.PodSnapshotSavedEvent{
+				PodName:  podName,
+				Version:  result.Version,
+				Services: result.Services,
+				Size:     result.Size,
+			})
+		},
+		func() error {
+			var err error
+			result, err = saver.SavePodSnapshot(ctx, host, podName, authToken)
+			return err
+		},
+	)
 }

--- a/internal/snapshot/save_test.go
+++ b/internal/snapshot/save_test.go
@@ -65,7 +65,7 @@ func TestSave_Success(t *testing.T) {
 	exporter := mockExporterReturning(t, []byte("ZIP_DATA"))
 	sink, getEvents := captureEvents(t)
 
-	err := snapshot.Save(context.Background(), healthyRunningMock(t), awsContainers, exporter, "", dest, sink)
+	err := snapshot.SaveLocal(context.Background(), healthyRunningMock(t), awsContainers, exporter, "", dest, sink)
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(dir, "snap"))
@@ -110,7 +110,7 @@ func TestSave_EmulatorNotRunning(t *testing.T) {
 	dest := filepath.Join(dir, "snap")
 	sink, getEvents := captureEvents(t)
 
-	err := snapshot.Save(context.Background(), mockRT, awsContainers, exporter, "", dest, sink)
+	err := snapshot.SaveLocal(context.Background(), mockRT, awsContainers, exporter, "", dest, sink)
 	require.Error(t, err)
 	assert.True(t, output.IsSilent(err))
 
@@ -141,7 +141,7 @@ func TestSave_UnhealthyRuntime(t *testing.T) {
 	dest := filepath.Join(dir, "snap")
 	sink := output.NewPlainSink(io.Discard)
 
-	err := snapshot.Save(context.Background(), mockRT, awsContainers, exporter, "", dest, sink)
+	err := snapshot.SaveLocal(context.Background(), mockRT, awsContainers, exporter, "", dest, sink)
 	require.Error(t, err)
 	assert.True(t, output.IsSilent(err))
 }
@@ -153,7 +153,7 @@ func TestSave_ExporterError(t *testing.T) {
 	exporter := mockExporterReturningError(t, fmt.Errorf("connection refused"))
 	sink := output.NewPlainSink(io.Discard)
 
-	err := snapshot.Save(context.Background(), healthyRunningMock(t), awsContainers, exporter, "", dest, sink)
+	err := snapshot.SaveLocal(context.Background(), healthyRunningMock(t), awsContainers, exporter, "", dest, sink)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection refused")
 
@@ -168,7 +168,7 @@ func TestSave_DestinationDirNotExist(t *testing.T) {
 	exporter := NewMockStateExporter(ctrl)
 	sink := output.NewPlainSink(io.Discard)
 
-	err := snapshot.Save(context.Background(), healthyRunningMock(t), awsContainers, exporter, "", dest, sink)
+	err := snapshot.SaveLocal(context.Background(), healthyRunningMock(t), awsContainers, exporter, "", dest, sink)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "save to")
 }
@@ -183,7 +183,7 @@ func TestSave_OverwritesExistingFile(t *testing.T) {
 	exporter := mockExporterReturning(t, []byte("NEW"))
 	sink := output.NewPlainSink(io.Discard)
 
-	err := snapshot.Save(context.Background(), healthyRunningMock(t), awsContainers, exporter, "", dest, sink)
+	err := snapshot.SaveLocal(context.Background(), healthyRunningMock(t), awsContainers, exporter, "", dest, sink)
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(path)
@@ -207,6 +207,107 @@ func TestSave_ContextCancelled(t *testing.T) {
 
 	sink := output.NewPlainSink(io.Discard)
 
-	err := snapshot.Save(ctx, mockRT, awsContainers, exporter, "", dest, sink)
+	err := snapshot.SaveLocal(ctx, mockRT, awsContainers, exporter, "", dest, sink)
 	require.Error(t, err)
 }
+
+func TestSavePod_Success(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	saver := NewMockPodSaver(ctrl)
+	saver.EXPECT().SavePodSnapshot(gomock.Any(), gomock.Any(), "my-baseline", "test-token").Return(
+		snapshot.PodSaveResult{Version: 2, Services: []string{"dynamodb", "s3"}, Size: 1048576},
+		nil,
+	)
+
+	sink, getEvents := captureEvents(t)
+	err := snapshot.SavePod(context.Background(), healthyRunningMock(t), awsContainers, saver, "", "my-baseline", "test-token", sink)
+	require.NoError(t, err)
+
+	events := getEvents()
+	var spinnerStarted, spinnerStopped bool
+	var saved *output.PodSnapshotSavedEvent
+	for _, e := range events {
+		switch ev := e.(type) {
+		case output.SpinnerEvent:
+			if ev.Active {
+				spinnerStarted = true
+			} else {
+				spinnerStopped = true
+			}
+		case output.PodSnapshotSavedEvent:
+			saved = &ev
+		}
+	}
+	assert.True(t, spinnerStarted, "spinner should have started")
+	assert.True(t, spinnerStopped, "spinner should have stopped")
+	require.NotNil(t, saved, "PodSnapshotSavedEvent should have been emitted")
+	assert.Equal(t, "my-baseline", saved.PodName)
+	assert.Equal(t, 2, saved.Version)
+	assert.Equal(t, []string{"dynamodb", "s3"}, saved.Services)
+	assert.Equal(t, int64(1048576), saved.Size)
+}
+
+func TestSavePod_NoAuthToken(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	saver := NewMockPodSaver(ctrl)
+
+	sink := output.NewPlainSink(io.Discard)
+	err := snapshot.SavePod(context.Background(), runtime.NewMockRuntime(ctrl), awsContainers, saver, "", "my-baseline", "", sink)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication")
+}
+
+func TestSavePod_EmulatorNotRunning(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsHealthy(gomock.Any()).Return(nil)
+	mockRT.EXPECT().IsRunning(gomock.Any(), "localstack-aws").Return(false, nil)
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	saver := NewMockPodSaver(ctrl)
+	sink, getEvents := captureEvents(t)
+
+	err := snapshot.SavePod(context.Background(), mockRT, awsContainers, saver, "", "my-baseline", "test-token", sink)
+	require.Error(t, err)
+	assert.True(t, output.IsSilent(err))
+
+	var gotErrorEvent bool
+	for _, e := range getEvents() {
+		if ev, ok := e.(output.ErrorEvent); ok {
+			gotErrorEvent = true
+			assert.Contains(t, ev.Title, "not running")
+		}
+	}
+	assert.True(t, gotErrorEvent, "ErrorEvent should have been emitted")
+}
+
+func TestSavePod_UnhealthyRuntime(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsHealthy(gomock.Any()).Return(fmt.Errorf("docker unavailable"))
+	mockRT.EXPECT().EmitUnhealthyError(gomock.Any(), gomock.Any())
+
+	saver := NewMockPodSaver(ctrl)
+	sink, _ := captureEvents(t)
+
+	err := snapshot.SavePod(context.Background(), mockRT, awsContainers, saver, "", "my-baseline", "test-token", sink)
+	require.Error(t, err)
+	assert.True(t, output.IsSilent(err))
+}
+
+func TestSavePod_SaverError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	saver := NewMockPodSaver(ctrl)
+	saver.EXPECT().SavePodSnapshot(gomock.Any(), gomock.Any(), "my-baseline", "test-token").Return(snapshot.PodSaveResult{}, fmt.Errorf("platform unreachable"))
+
+	sink, _ := captureEvents(t)
+	err := snapshot.SavePod(context.Background(), healthyRunningMock(t), awsContainers, saver, "", "my-baseline", "test-token", sink)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "platform unreachable")
+}
+

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -294,30 +294,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.addLine(styledLine{text: style.Render(text)})
 		a.addLine(blank)
 		return a, nil
-	case output.InstanceInfoEvent:
-		if line, ok := output.FormatEventLine(msg); ok {
-			parts := strings.Split(line, "\n")
-			for i, part := range parts {
-				if i == 0 {
-					part = strings.Replace(part, output.SuccessMarker(), styles.Success.Render(output.SuccessMarker()), 1)
-					a.addLine(styledLine{text: part})
-				} else {
-					a.addLine(styledLine{text: part, secondary: true})
-				}
-			}
-		}
-		return a, nil
-	case output.PodSnapshotSavedEvent:
-		if line, ok := output.FormatEventLine(msg); ok {
-			parts := strings.Split(line, "\n")
-			for i, part := range parts {
-				if i == 0 {
-					part = strings.Replace(part, output.SuccessMarker(), styles.Success.Render(output.SuccessMarker()), 1)
-					a.addLine(styledLine{text: part})
-				} else {
-					a.addLine(styledLine{text: part, secondary: true})
-				}
-			}
+	case output.InstanceInfoEvent, output.PodSnapshotSavedEvent:
+		if line, ok := output.FormatEventLine(msg.(output.Event)); ok {
+			a.addSuccessLines(line)
 		}
 		return a, nil
 	default:
@@ -359,6 +338,18 @@ func (a *App) addLine(line styledLine) {
 		a.bufferedLines = appendLine(a.bufferedLines, line)
 	} else {
 		a.lines = appendLine(a.lines, line)
+	}
+}
+
+func (a *App) addSuccessLines(line string) {
+	parts := strings.Split(line, "\n")
+	for i, part := range parts {
+		if i == 0 {
+			part = strings.Replace(part, output.SuccessMarker(), styles.Success.Render(output.SuccessMarker()), 1)
+			a.addLine(styledLine{text: part})
+		} else {
+			a.addLine(styledLine{text: part, secondary: true})
+		}
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -307,6 +307,19 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return a, nil
+	case output.PodSnapshotSavedEvent:
+		if line, ok := output.FormatEventLine(msg); ok {
+			parts := strings.Split(line, "\n")
+			for i, part := range parts {
+				if i == 0 {
+					part = strings.Replace(part, output.SuccessMarker(), styles.Success.Render(output.SuccessMarker()), 1)
+					a.addLine(styledLine{text: part})
+				} else {
+					a.addLine(styledLine{text: part, secondary: true})
+				}
+			}
+		}
+		return a, nil
 	default:
 		if e, ok := msg.(output.Event); ok {
 			if line, ok := output.FormatEventLine(e); ok {

--- a/internal/ui/run_snapshot_save.go
+++ b/internal/ui/run_snapshot_save.go
@@ -9,14 +9,20 @@ import (
 	"github.com/localstack/lstk/internal/snapshot"
 )
 
-func RunSnapshotSaveLocal(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, exporter snapshot.StateExporter, host, dest string) error {
-	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
-		return snapshot.SaveLocal(ctx, rt, containers, exporter, host, dest, sink)
-	})
+// SnapshotClient is satisfied by any type that can both export local state and
+// save a remote pod snapshot — aws.Client implements both today.
+type SnapshotClient interface {
+	snapshot.StateExporter
+	snapshot.PodSaver
 }
 
-func RunSnapshotSavePod(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, saver snapshot.PodSaver, host, podName, authToken string) error {
+func RunSnapshotSave(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, client SnapshotClient, host string, dest snapshot.Destination, authToken string) error {
 	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
-		return snapshot.SavePod(ctx, rt, containers, saver, host, podName, authToken, sink)
+		switch dest.Kind {
+		case snapshot.KindPod:
+			return snapshot.SavePod(ctx, rt, containers, client, host, dest.Value, authToken, sink)
+		default:
+			return snapshot.SaveLocal(ctx, rt, containers, client, host, dest.Value, sink)
+		}
 	})
 }

--- a/internal/ui/run_snapshot_save.go
+++ b/internal/ui/run_snapshot_save.go
@@ -9,8 +9,14 @@ import (
 	"github.com/localstack/lstk/internal/snapshot"
 )
 
-func RunSnapshotSave(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, exporter snapshot.StateExporter, host, dest string) error {
+func RunSnapshotSaveLocal(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, exporter snapshot.StateExporter, host, dest string) error {
 	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
-		return snapshot.Save(ctx, rt, containers, exporter, host, dest, sink)
+		return snapshot.SaveLocal(ctx, rt, containers, exporter, host, dest, sink)
+	})
+}
+
+func RunSnapshotSavePod(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, saver snapshot.PodSaver, host, podName, authToken string) error {
+	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
+		return snapshot.SavePod(ctx, rt, containers, saver, host, podName, authToken, sink)
 	})
 }

--- a/test/integration/snapshot_save_test.go
+++ b/test/integration/snapshot_save_test.go
@@ -237,22 +237,6 @@ func TestSnapshotSavePodNoAuthToken(t *testing.T) {
 	assert.Contains(t, stderr, "authentication")
 }
 
-func TestSnapshotSavePodLocalStackNotRunning(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
-
-	ctx := testContext(t)
-	// Intentionally no startTestContainer: the emulator is not running.
-
-	stdout, _, err := runLstk(t, ctx, t.TempDir(),
-		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.AuthToken, "test-token"),
-		"--non-interactive", "snapshot", "save", "pod:my-baseline",
-	)
-	requireExitCode(t, 1, err)
-	assert.Contains(t, stdout, "not running")
-}
-
 func TestSnapshotSavePodInvalidName(t *testing.T) {
 	t.Parallel()
 	for _, dest := range []string{
@@ -271,19 +255,40 @@ func TestSnapshotSavePodInvalidName(t *testing.T) {
 	}
 }
 
-func TestSnapshotSaveLocalStackNotRunning(t *testing.T) {
+func TestSnapshotSaveEmulatorNotRunning(t *testing.T) {
 	requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
 
-	ctx := testContext(t)
-	// Intentionally no startTestContainer: the emulator is not running.
+	tests := []struct {
+		name      string
+		args      []string
+		authToken string
+	}{
+		{
+			name: "local destination",
+			args: []string{"--non-interactive", "snapshot", "save"},
+		},
+		{
+			name:      "pod destination",
+			args:      []string{"--non-interactive", "snapshot", "save", "pod:my-baseline"},
+			authToken: "test-token",
+		},
+	}
 
-	stdout, _, err := runLstk(t, ctx, t.TempDir(), testEnvWithHome(t.TempDir(), ""),
-		"--non-interactive", "snapshot", "save",
-	)
-	requireExitCode(t, 1, err)
-	assert.Contains(t, stdout, "not running")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Intentionally no startTestContainer: the emulator is not running.
+			ctx := testContext(t)
+			e := env.Environ(testEnvWithHome(t.TempDir(), ""))
+			if tc.authToken != "" {
+				e = e.With(env.AuthToken, tc.authToken)
+			}
+			stdout, _, err := runLstk(t, ctx, t.TempDir(), e, tc.args...)
+			requireExitCode(t, 1, err)
+			assert.Contains(t, stdout, "not running")
+		})
+	}
 }
 
 func TestSnapshotSaveInvalidParentDir(t *testing.T) {

--- a/test/integration/snapshot_save_test.go
+++ b/test/integration/snapshot_save_test.go
@@ -150,7 +150,6 @@ func TestSnapshotSaveRemoteRejected(t *testing.T) {
 	for _, dest := range []string{
 		"s3://my-bucket/my-snap",
 		"oras://registry/my-snap",
-		"pod://my-pod",
 	} {
 		t.Run(dest, func(t *testing.T) {
 			t.Parallel()
@@ -159,6 +158,115 @@ func TestSnapshotSaveRemoteRejected(t *testing.T) {
 			_, stderr, err := runLstk(t, ctx, t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--non-interactive", "snapshot", "save", dest)
 			requireExitCode(t, 1, err)
 			assert.Contains(t, stderr, "not yet supported")
+		})
+	}
+}
+
+// mockPodSaveServer returns a test server that handles POST /_localstack/pods/{name}
+// and responds with a streaming completion event. respondOK controls whether the
+// completion event reports success or a server-side error.
+func mockPodSaveServer(t *testing.T, respondOK bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/_localstack/pods/") && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+			if respondOK {
+				_, _ = w.Write([]byte(`{"event":"completion","status":"ok","operation":"save","info":{"name":"my-baseline","version":1,"remote":"platform","services":["dynamodb","s3"],"size":1048576}}` + "\n"))
+			} else {
+				_, _ = w.Write([]byte(`{"event":"completion","status":"error","message":"platform error"}` + "\n"))
+			}
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestSnapshotSavePodSuccess(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+	srv := mockPodSaveServer(t, true)
+
+	stdout, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.LocalStackHost, lsHost(srv)).
+			With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "save", "pod:my-baseline",
+	)
+	require.NoError(t, err, "lstk snapshot save pod:my-baseline failed: %s", stderr)
+	assert.Contains(t, stdout, "Snapshot saved")
+	assert.Contains(t, stdout, "my-baseline")
+	assert.Contains(t, stdout, "Version: 1")
+	assert.Contains(t, stdout, "dynamodb, s3")
+}
+
+func TestSnapshotSavePodServerError(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+	srv := mockPodSaveServer(t, false)
+
+	_, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.LocalStackHost, lsHost(srv)).
+			With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "save", "pod:my-baseline",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "platform error")
+}
+
+func TestSnapshotSavePodNoAuthToken(t *testing.T) {
+	t.Parallel()
+	ctx := testContext(t)
+
+	_, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).Without(env.AuthToken),
+		"--non-interactive", "snapshot", "save", "pod:my-baseline",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "authentication")
+}
+
+func TestSnapshotSavePodLocalStackNotRunning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	// Intentionally no startTestContainer: the emulator is not running.
+
+	stdout, _, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "save", "pod:my-baseline",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stdout, "not running")
+}
+
+func TestSnapshotSavePodInvalidName(t *testing.T) {
+	t.Parallel()
+	for _, dest := range []string{
+		"pod:",
+		"pod:-invalid",
+		"pod:my_pod",
+	} {
+		t.Run(dest, func(t *testing.T) {
+			t.Parallel()
+			ctx := testContext(t)
+
+			_, stderr, err := runLstk(t, ctx, t.TempDir(), testEnvWithHome(t.TempDir(), ""), "--non-interactive", "snapshot", "save", dest)
+			requireExitCode(t, 1, err)
+			assert.Contains(t, stderr, "invalid pod name")
 		})
 	}
 }

--- a/test/integration/snapshot_save_test.go
+++ b/test/integration/snapshot_save_test.go
@@ -150,7 +150,7 @@ func TestSnapshotSaveRemoteRejected(t *testing.T) {
 	for _, dest := range []string{
 		"s3://my-bucket/my-snap",
 		"oras://registry/my-snap",
-		"cloud://my-pod",
+		"pod://my-pod",
 	} {
 		t.Run(dest, func(t *testing.T) {
 			t.Parallel()

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -150,9 +149,7 @@ func TestStatusCommandWorksWithExternalContainer(t *testing.T) {
 	}))
 	defer server.Close()
 
-	host := strings.TrimPrefix(server.URL, "http://")
-
-	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, host), "status")
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, lsHost(server)), "status")
 	require.NoError(t, err, "lstk status should work with external container: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "3.5.0")
@@ -230,9 +227,7 @@ func TestStatusCommandShowsNoResourcesWhenEmpty(t *testing.T) {
 	}))
 	defer server.Close()
 
-	host := strings.TrimPrefix(server.URL, "http://")
-
-	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, host), "status")
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, lsHost(server)), "status")
 	require.NoError(t, err, "lstk status failed: %s", stderr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdout, "No resources deployed")


### PR DESCRIPTION
Added support for cloud pods in existing `lstk snapshot save` command.

<img width="817" height="54" alt="image" src="https://github.com/user-attachments/assets/d85e8295-e8ce-4cc3-9d23-2704aa6d9acc" />

<img width="824" height="96" alt="image" src="https://github.com/user-attachments/assets/de7f4350-34cf-479d-9f23-2658d6fa3bf9" />