### PR TITLE
Add gitleaks secret scanning via pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 lstk is LocalStack's new CLI (v2) - a Go-based command-line interface for starting and managing LocalStack instances via Docker (and more runtimes in the future).
 
+# Developer Setup
+
+After cloning, install the pre-commit hooks:
+
+```bash
+pre-commit install
+```
+
+This installs a [gitleaks](https://github.com/gitleaks/gitleaks) hook that scans staged files for secrets before each commit. Requires [pre-commit](https://pre-commit.com/#install).
+
 # Build and Test Commands
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,17 @@ Thanks for contributing to lstk! This document covers contribution guidelines fo
 - Go 1.21+ (or latest stable)
 - Docker (for integration tests)
 - Make
+- [pre-commit](https://pre-commit.com/#install) (for secret scanning hooks)
+
+### First-time setup
+
+After cloning, install the pre-commit hooks:
+
+```bash
+pre-commit install
+```
+
+This sets up a local git hook that runs [gitleaks](https://github.com/gitleaks/gitleaks) before each commit to prevent accidentally committing secrets or credentials.
 
 ### Building
 


### PR DESCRIPTION
For best security practices, we want to avoid accidentally leaking any secrets:
- Added .pre-commit-config.yaml with gitleaks v8.30.1 hook
- Document pre-commit install step in CONTRIBUTING.md and CLAUDE.md

Towards DEVX-857