### PR TITLE
Update config tag recommendation

### DIFF
--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -7,7 +7,7 @@
 
 [[containers]]
 type = "aws"     # Emulator type. Currently supported: "aws", "snowflake"
-tag  = "latest"  # Docker image tag, e.g. "latest", "2026.03"
+tag  = "latest"  # Docker image tag, e.g. "latest", "2026.4"
 port = "4566"    # Host port the emulator will be accessible on
 # volume = ""    # Host directory for persistent state (default: OS cache dir)
 # env = []       # Named environment profiles to apply (see [env.*] sections below)


### PR DESCRIPTION
Platform expects image tag without 0 for license checks because the Python version in the emulator is without 0. 

See [relevant discussion](https://localstack-cloud.slack.com/archives/C0A1857LGTU/p1779206277761589?thread_ts=1779201043.297249&cid=C0A1857LGTU) for more context. Cc @anisaoshafi 