### PR TITLE
Unit tests do not use real $HOME 

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -48,7 +48,8 @@ To save to a remote pod on the LocalStack platform, use the pod: prefix:
 				destArg = args[0]
 			}
 
-			dest, err := snapshot.ParseDestination(destArg, time.Now())
+			home, _ := os.UserHomeDir()
+			dest, err := snapshot.ParseDestination(destArg, home, time.Now())
 			if err != nil {
 				return err
 			}

--- a/internal/snapshot/destination.go
+++ b/internal/snapshot/destination.go
@@ -11,6 +11,9 @@ import (
 	"time"
 )
 
+// ErrHomeNotSet is returned when a destination needs "~" expansion but no home directory was provided.
+var ErrHomeNotSet = errors.New("home directory is not set")
+
 var (
 	// ErrRemoteNotSupported is returned for known remote schemes (s3://, oras://).
 	ErrRemoteNotSupported = errors.New("remote destinations are not yet supported — coming soon")
@@ -53,7 +56,8 @@ func displayPath(abs, cwd, home string) string {
 }
 
 // ParseDestination resolves a user-supplied destination to a local path (KindLocal) or validated pod name (KindPod).
-func ParseDestination(dest string, now time.Time) (Destination, error) {
+// home is used to expand a leading "~" or "~/"; pass "" to disable tilde expansion.
+func ParseDestination(dest, home string, now time.Time) (Destination, error) {
 	if dest == "" {
 		b := make([]byte, 2)
 		_, _ = rand.Read(b)
@@ -80,9 +84,8 @@ func ParseDestination(dest string, now time.Time) (Destination, error) {
 	}
 
 	if dest == "~" || strings.HasPrefix(dest, "~/") || strings.HasPrefix(dest, `~\`) {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return Destination{}, fmt.Errorf("resolve home directory: %w", err)
+		if home == "" {
+			return Destination{}, fmt.Errorf("cannot expand %q: %w", dest, ErrHomeNotSet)
 		}
 		dest = filepath.Join(home, strings.TrimLeft(dest[1:], `/\`))
 	}

--- a/internal/snapshot/destination_test.go
+++ b/internal/snapshot/destination_test.go
@@ -86,8 +86,9 @@ func TestParseDestination(t *testing.T) {
 	t.Parallel()
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
+	// Use a temp dir as home so the test doesn't depend on the real $HOME
+	// (e.g. under Nix's sandboxed build, $HOME is a non-existent placeholder).
+	home := t.TempDir()
 
 	now := time.Date(2026, 5, 11, 21, 4, 32, 0, time.UTC)
 
@@ -274,7 +275,7 @@ func TestParseDestination(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got, err := snapshot.ParseDestination(tc.input, now)
+			got, err := snapshot.ParseDestination(tc.input, home, now)
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
@@ -297,6 +298,27 @@ func TestParseDestination(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.wantPath, got.Value)
 			}
+		})
+	}
+}
+
+// TestParseDestinationTildeWithoutHome covers the Nix sandbox scenario where
+// the build runs without a usable home directory. Tilde expansion must fail
+// with a clear error instead of silently using a non-existent path.
+func TestParseDestinationTildeWithoutHome(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 11, 21, 4, 32, 0, time.UTC)
+
+	tests := []struct{ name, input string }{
+		{"bare tilde", "~"},
+		{"tilde slash", "~/snap"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := snapshot.ParseDestination(tc.input, "", now)
+			require.ErrorIs(t, err, snapshot.ErrHomeNotSet)
 		})
 	}
 }


### PR DESCRIPTION
## Motivation

Under Nix's sandboxed build, `$HOME` is set to `/homeless-shelter` (a deliberately non-existent placeholder), so `TestParseDestination` fails because it calls `os.UserHomeDir()` which does not exist.

## Changes

- Add a `home` parameter to `snapshot.ParseDestination` 
- Switch `TestParseDestination` to use `t.TempDir()` as home so it is hermetic
- Add `TestParseDestinationTildeWithoutHome` to test the Nix scenario

## Tests

- `make test` — all 520 unit tests pass.
- Verified the Nix-sandbox scenario locally: `HOME=/homeless-shelter go test ./internal/snapshot/...` passes (and failed before this change).

Closes FEED-67