### PR TITLE
Tag weekly go upgrade PRs with patch label

### DIFF
--- a/.github/workflows/weekly-go-upgrade.yml
+++ b/.github/workflows/weekly-go-upgrade.yml
@@ -44,5 +44,7 @@ jobs:
 
             - Updates the `toolchain` directive to the latest released Go version.
             - Runs `go mod tidy` to keep module files consistent.
-          labels: dependencies
+          labels: |
+            dependencies
+            semver: patch
           token: ${{ secrets.PRO_ACCESS_TOKEN }}


### PR DESCRIPTION
Tag weekly go upgrade PRs with patch label, so we don't have to manually tag the PRs: e.g: https://github.com/localstack/lstk/pull/254
If we don't tag PRs: `Require release label`  check fails.
