### PR TITLE
Flush telemetry in a detached subprocess

### DIFF
--- a/cmd/flush_telemetry.go
+++ b/cmd/flush_telemetry.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/localstack/lstk/internal/env"
+	"github.com/localstack/lstk/internal/log"
+	"github.com/localstack/lstk/internal/telemetry"
+	"github.com/localstack/lstk/internal/tracing"
+)
+
+// runFlushTelemetry handles the flusher subprocess. It bypasses the normal
+// Execute() boot path — no logger, keyring, telemetry client, or cobra tree —
+// so it writes nothing to disk and cannot spawn another flusher.
+func runFlushTelemetry(ctx context.Context, args []string) error {
+	cfg := env.Init()
+	if cfg.TracesEnabled {
+		shutdown := tracing.Init(ctx, log.Nop())
+		defer func() {
+			// Fresh context: ctx may be cancelled and Shutdown would skip the flush.
+			shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = shutdown(shutCtx)
+		}()
+	}
+
+	endpoint := ""
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--endpoint" && i+1 < len(args) {
+			endpoint = args[i+1]
+			i++
+		}
+	}
+	if endpoint == "" {
+		return fmt.Errorf("missing --endpoint")
+	}
+
+	ctx = tracing.ContextWithRemoteParent(ctx, os.Getenv)
+	return telemetry.RunFlush(ctx, endpoint, os.Stdin)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,10 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 }
 
 func Execute(ctx context.Context) error {
+	if len(os.Args) > 1 && os.Args[1] == telemetry.FlushCommandName {
+		return runFlushTelemetry(ctx, os.Args[2:])
+	}
+
 	cfg := env.Init()
 
 	logger, cleanup, err := newLogger()

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,9 @@ require (
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/mock v0.6.0
+	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
 	gopkg.in/ini.v1 v1.67.2
 	gotest.tools/v3 v3.5.2
@@ -82,11 +84,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/internal/container/telemetry_test.go
+++ b/internal/container/telemetry_test.go
@@ -33,7 +33,7 @@ func newCapturingTelClient(t *testing.T) (*telemetry.Client, <-chan map[string]a
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
-	return telemetry.New(srv.URL, false), ch
+	return telemetry.NewWithInProcessFlush(srv.URL), ch
 }
 
 func TestStop_EmitsLifecycleStopEvent(t *testing.T) {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,25 +1,17 @@
 package telemetry
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"os"
 	"runtime"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-
-	"github.com/localstack/lstk/internal/version"
 )
 
-func userAgent() string {
-	return fmt.Sprintf("localstack lstk/%s (%s; %s)", version.Version(), runtime.GOOS, runtime.GOARCH)
-}
+// pendingCap bounds in-memory events; on overflow the oldest is dropped.
+const pendingCap = 64
 
 type Client struct {
 	enabled   bool
@@ -27,11 +19,12 @@ type Client struct {
 	machineID string
 	authToken string
 
-	httpClient *http.Client
-	endpoint   string
+	endpoint string
+	flushFn  func(ctx context.Context, endpoint string, events []eventBody)
 
-	events        chan eventBody
-	done          chan struct{}
+	mu            sync.Mutex
+	pending       []eventBody
+	traceCtx      context.Context // last Emit ctx; carries the command span for trace propagation
 	closeOnce     sync.Once
 	machineIDOnce sync.Once
 }
@@ -46,26 +39,13 @@ func New(endpoint string, disabled bool) *Client {
 	if disabled {
 		return &Client{enabled: false}
 	}
-	c := &Client{
+	return &Client{
 		enabled:   true,
 		sessionID: uuid.NewString(),
-		// http.Client has no default timeout (zero means none). Without one, a
-		// slow or unreachable endpoint would block the worker goroutine.
-		httpClient: &http.Client{
-			Timeout: 3 * time.Second,
-			Transport: otelhttp.NewTransport(
-				http.DefaultTransport,
-				otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
-					return "telemetry " + r.Method + " " + r.URL.Path
-				}),
-			),
-		},
-		endpoint: endpoint,
-		events:   make(chan eventBody, 64),
-		done:     make(chan struct{}),
+		endpoint:  endpoint,
+		flushFn:   spawnDetachedFlusher,
+		pending:   make([]eventBody, 0, pendingCap),
 	}
-	go c.worker()
-	return c
 }
 
 type requestBody struct {
@@ -73,10 +53,9 @@ type requestBody struct {
 }
 
 type eventBody struct {
-	ctx      context.Context // not serialized; carries context to the worker
-	Name     string          `json:"name"`
-	Metadata eventMetadata   `json:"metadata"`
-	Payload  any             `json:"payload"`
+	Name     string        `json:"name"`
+	Metadata eventMetadata `json:"metadata"`
+	Payload  any           `json:"payload"`
 }
 
 type eventMetadata struct {
@@ -101,7 +80,6 @@ func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) 
 	}
 
 	body := eventBody{
-		ctx:  context.WithoutCancel(ctx),
 		Name: name,
 		Metadata: eventMetadata{
 			ClientTime: time.Now().UTC().Format("2006-01-02 15:04:05.000000"),
@@ -109,48 +87,34 @@ func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) 
 		},
 		Payload: enriched,
 	}
-	select {
-	case c.events <- body:
-	default:
+
+	c.mu.Lock()
+	if len(c.pending) >= pendingCap {
+		c.pending = c.pending[1:]
 	}
+	c.pending = append(c.pending, body)
+	c.traceCtx = context.WithoutCancel(ctx)
+	c.mu.Unlock()
 }
 
-func (c *Client) worker() {
-	defer close(c.done)
-	for body := range c.events {
-		c.send(body)
-	}
-}
-
-func (c *Client) send(body eventBody) {
-	data, err := json.Marshal(requestBody{Events: []eventBody{body}})
-	if err != nil {
-		return
-	}
-
-	req, err := http.NewRequestWithContext(body.ctx, http.MethodPost, c.endpoint, bytes.NewReader(data))
-	if err != nil {
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", userAgent())
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return
-	}
-	_ = resp.Body.Close()
-}
-
-// Close stops accepting new events, drains the event buffer, and blocks until
-// all pending HTTP requests have completed. Call it before process exit to
-// avoid dropping telemetry events.
+// Close hands pending events to a detached subprocess and returns immediately,
+// so analytics endpoint latency never delays command exit.
 func (c *Client) Close() {
 	if !c.enabled {
 		return
 	}
 	c.closeOnce.Do(func() {
-		close(c.events)
-		<-c.done
+		c.mu.Lock()
+		pending := c.pending
+		traceCtx := c.traceCtx
+		c.pending = nil
+		c.mu.Unlock()
+		if len(pending) == 0 {
+			return
+		}
+		if traceCtx == nil {
+			traceCtx = context.Background()
+		}
+		c.flushFn(traceCtx, c.endpoint, pending)
 	})
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,58 +24,133 @@ func TestClose_IsIdempotent(t *testing.T) {
 	c.Close()
 }
 
-func TestTrack_SendsCorrectPayloadAndHeaders(t *testing.T) {
-	type captured struct {
-		event  map[string]any
-		header http.Header
-	}
-	ch := make(chan captured, 1)
+func TestEmit_EnrichesPayloadIntoPending(t *testing.T) {
+	c := New("http://localhost", false)
+	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		assert.NoError(t, err)
+	require.Len(t, c.pending, 1)
+	ev := c.pending[0]
+	assert.Equal(t, "cli_cmd", ev.Name)
+	assert.Equal(t, c.sessionID, ev.Metadata.SessionID)
+	_, err := time.Parse("2006-01-02 15:04:05.000000", ev.Metadata.ClientTime)
+	assert.NoError(t, err)
 
-		var req struct {
-			Events []map[string]any `json:"events"`
-		}
-		assert.NoError(t, json.Unmarshal(body, &req))
-		assert.Len(t, req.Events, 1)
-
-		if len(req.Events) == 1 {
-			ch <- captured{event: req.Events[0], header: r.Header.Clone()}
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	c := New(srv.URL, false)
-	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start", "params": []string{}})
-	c.Close()
-
-	var got captured
-	select {
-	case got = <-ch:
-	default:
-		t.Fatal("no telemetry event received")
-	}
-
-	assert.Equal(t, "cli_cmd", got.event["name"])
-
-	metadata, ok := got.event["metadata"].(map[string]any)
-	require.True(t, ok, "metadata should be an object")
-	assert.Equal(t, c.sessionID, metadata["session_id"])
-	_, err := time.Parse("2006-01-02 15:04:05.000000", metadata["client_time"].(string))
-	assert.NoError(t, err, "client_time should match expected format")
-	assert.Nil(t, metadata["version"], "version should not be in metadata")
-	assert.Nil(t, metadata["machine_id"], "machine_id should not be in metadata")
-
-	payload, ok := got.event["payload"].(map[string]any)
-	require.True(t, ok, "payload should be an object")
+	payload, ok := ev.Payload.(map[string]any)
+	require.True(t, ok)
 	assert.Equal(t, "lstk start", payload["cmd"])
 	assert.Equal(t, runtime.GOOS, payload["os"])
 	assert.Equal(t, runtime.GOARCH, payload["arch"])
 	_, isCI := os.LookupEnv("CI")
 	assert.Equal(t, isCI, payload["is_ci"])
+}
 
-	assert.Equal(t, userAgent(), got.header.Get("User-Agent"))
+func TestEmit_DropsOldestWhenFull(t *testing.T) {
+	c := New("http://localhost", false)
+	for i := 0; i < pendingCap+5; i++ {
+		c.Emit(context.Background(), "cli_cmd", map[string]any{"i": i})
+	}
+	assert.Len(t, c.pending, pendingCap, "pending must be capped")
+	// The oldest 5 events should have been dropped.
+	first := c.pending[0].Payload.(map[string]any)
+	assert.EqualValues(t, 5, first["i"])
+}
+
+func TestEmit_NoopWhenDisabled(t *testing.T) {
+	c := New("http://localhost", true)
+	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
+	assert.Empty(t, c.pending)
+}
+
+func TestClose_HandsOffPendingEventsToFlusher(t *testing.T) {
+	var (
+		gotEPs []string
+		gotEvs [][]eventBody
+	)
+	c := New("http://example.test/events", false)
+	c.flushFn = func(_ context.Context, endpoint string, events []eventBody) {
+		gotEPs = append(gotEPs, endpoint)
+		gotEvs = append(gotEvs, events)
+	}
+
+	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
+	c.Close()
+
+	require.Len(t, gotEPs, 1)
+	assert.Equal(t, "http://example.test/events", gotEPs[0])
+	require.Len(t, gotEvs, 1)
+	require.Len(t, gotEvs[0], 1)
+	assert.Equal(t, "cli_cmd", gotEvs[0][0].Name)
+
+	// Second close must not spawn again.
+	c.Close()
+	assert.Len(t, gotEPs, 1)
+}
+
+func TestClose_SkipsSpawnWhenNoPending(t *testing.T) {
+	var called bool
+	c := New("http://example.test/events", false)
+	c.flushFn = func(context.Context, string, []eventBody) { called = true }
+
+	c.Close()
+	assert.False(t, called, "the flusher must not run when there are no events")
+}
+
+func TestRunFlush_PostsEachEventWithCorrectPayloadAndHeaders(t *testing.T) {
+	type captured struct {
+		event  map[string]any
+		header http.Header
+	}
+	ch := make(chan captured, 4)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		var req struct {
+			Events []map[string]any `json:"events"`
+		}
+		assert.NoError(t, json.Unmarshal(body, &req))
+		for _, ev := range req.Events {
+			ch <- captured{event: ev, header: r.Header.Clone()}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Build the input the way the parent process would.
+	c := New(srv.URL, false)
+	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
+	c.Emit(context.Background(), "cli_lifecycle", map[string]any{"event_type": "stop"})
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, ev := range c.pending {
+		require.NoError(t, enc.Encode(ev))
+	}
+
+	require.NoError(t, RunFlush(context.Background(), srv.URL, &buf))
+
+	got := drain(ch, 2, 2*time.Second)
+	require.Len(t, got, 2)
+
+	byName := map[string]captured{}
+	for _, c := range got {
+		byName[c.event["name"].(string)] = c
+	}
+	assert.Contains(t, byName, "cli_cmd")
+	assert.Contains(t, byName, "cli_lifecycle")
+	assert.True(t, strings.HasPrefix(byName["cli_cmd"].header.Get("User-Agent"), "localstack lstk/"))
+}
+
+func drain[T any](ch <-chan T, n int, timeout time.Duration) []T {
+	out := make([]T, 0, n)
+	deadline := time.After(timeout)
+	for len(out) < n {
+		select {
+		case v := <-ch:
+			out = append(out, v)
+		case <-deadline:
+			return out
+		}
+	}
+	return out
 }

--- a/internal/telemetry/events_test.go
+++ b/internal/telemetry/events_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// captureEvents wires a fake analytics server behind an in-process flush.
 func captureEvents(t *testing.T) (*Client, <-chan map[string]any) {
 	t.Helper()
 	ch := make(chan map[string]any, 8)
@@ -30,7 +31,7 @@ func captureEvents(t *testing.T) (*Client, <-chan map[string]any) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
-	return New(srv.URL, false), ch
+	return NewWithInProcessFlush(srv.URL), ch
 }
 
 func drainEvent(t *testing.T, tel *Client, ch <-chan map[string]any) map[string]any {

--- a/internal/telemetry/flush.go
+++ b/internal/telemetry/flush.go
@@ -1,0 +1,137 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/localstack/lstk/internal/tracing"
+	"github.com/localstack/lstk/internal/version"
+)
+
+// flushTimeout caps the flusher's lifetime so orphans can't linger if the endpoint hangs.
+const flushTimeout = 10 * time.Second
+
+// FlushCommandName is the argv[1] sentinel for the detached flusher subprocess.
+// cmd.Execute must short-circuit on it before constructing a telemetry client,
+// otherwise the flusher would emit events and spawn flushers recursively.
+const FlushCommandName = "__flush-telemetry"
+
+func userAgent() string {
+	return fmt.Sprintf("localstack lstk/%s (%s; %s)", version.Version(), runtime.GOOS, runtime.GOARCH)
+}
+
+// RunFlush reads JSON-line eventBody values from `in` and POSTs each one to
+// `endpoint`. It runs in the detached subprocess, bounded by flushTimeout.
+func RunFlush(ctx context.Context, endpoint string, in io.Reader) error {
+	ctx, cancel := context.WithTimeout(ctx, flushTimeout)
+	defer cancel()
+
+	ctx, span := otel.Tracer("github.com/localstack/lstk/internal/telemetry").Start(ctx, "telemetry flush")
+	defer span.End()
+
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: otelhttp.NewTransport(
+			http.DefaultTransport,
+			otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+				return "telemetry " + r.Method + " " + r.URL.Path
+			}),
+		),
+	}
+
+	count := 0
+	dec := json.NewDecoder(in)
+	for dec.More() {
+		if ctx.Err() != nil {
+			break
+		}
+		var ev eventBody
+		if err := dec.Decode(&ev); err != nil {
+			span.RecordError(err)
+			span.SetAttributes(attribute.Int("telemetry.events", count))
+			return err
+		}
+		postEvent(ctx, client, endpoint, ev)
+		count++
+	}
+	span.SetAttributes(attribute.Int("telemetry.events", count))
+	return nil
+}
+
+func postEvent(ctx context.Context, client *http.Client, endpoint string, ev eventBody) {
+	data, err := json.Marshal(requestBody{Events: []eventBody{ev}})
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgent())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+// NewWithInProcessFlush returns an enabled Client whose Close flushes synchronously
+// in-process, so tests can verify event delivery without forking the binary.
+func NewWithInProcessFlush(endpoint string) *Client {
+	c := New(endpoint, false)
+	c.flushFn = func(ctx context.Context, endpoint string, events []eventBody) {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		for _, ev := range events {
+			_ = enc.Encode(ev)
+		}
+		_ = RunFlush(ctx, endpoint, &buf)
+	}
+	return c
+}
+
+// spawnDetachedFlusher launches the current binary as a detached subprocess and
+// streams events to its stdin as JSON lines, without waiting for it to finish.
+func spawnDetachedFlusher(ctx context.Context, endpoint string, events []eventBody) {
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(exe, FlushCommandName, "--endpoint", endpoint)
+	cmd.SysProcAttr = detachedSysProcAttr()
+	if traceEnv := tracing.SubprocessEnv(ctx); len(traceEnv) > 0 {
+		cmd.Env = append(os.Environ(), traceEnv...)
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return
+	}
+
+	enc := json.NewEncoder(stdin)
+	for _, ev := range events {
+		if err := enc.Encode(ev); err != nil {
+			break
+		}
+	}
+	_ = stdin.Close()
+	_ = cmd.Process.Release()
+}

--- a/internal/telemetry/flush_unix.go
+++ b/internal/telemetry/flush_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package telemetry
+
+import "syscall"
+
+// Setsid puts the child in a new session so it isn't killed when the parent's
+// controlling terminal goes away.
+func detachedSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/telemetry/flush_windows.go
+++ b/internal/telemetry/flush_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package telemetry
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP: detach from the parent's console
+// and put the child in its own process group so Ctrl+C in the parent doesn't
+// signal it.
+func detachedSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP}
+}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -13,6 +13,7 @@ package tracing
 import (
 	"context"
 	stdruntime "runtime"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -56,4 +57,28 @@ func Init(ctx context.Context, logger log.Logger) func(context.Context) error {
 	))
 
 	return tp.Shutdown
+}
+
+// SubprocessEnv returns env entries (TRACEPARENT, TRACESTATE) carrying the span
+// context from ctx, or nil when tracing is disabled or no span is active.
+func SubprocessEnv(ctx context.Context) []string {
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+	var env []string
+	for _, k := range carrier.Keys() {
+		env = append(env, strings.ToUpper(k)+"="+carrier.Get(k))
+	}
+	return env
+}
+
+// ContextWithRemoteParent extracts a span context from the TRACEPARENT and
+// TRACESTATE environment variables — the inverse of SubprocessEnv.
+func ContextWithRemoteParent(ctx context.Context, getenv func(string) string) context.Context {
+	carrier := propagation.MapCarrier{}
+	for _, k := range []string{"traceparent", "tracestate"} {
+		if v := getenv(strings.ToUpper(k)); v != "" {
+			carrier.Set(k, v)
+		}
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, carrier)
 }

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -1,0 +1,67 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func setupPropagation(t *testing.T) {
+	t.Helper()
+	prevTP := otel.GetTracerProvider()
+	prevProp := otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTP)
+		otel.SetTextMapPropagator(prevProp)
+	})
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+}
+
+func TestSubprocessEnvRoundTripsSpanContext(t *testing.T) {
+	setupPropagation(t)
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent command")
+	defer span.End()
+
+	envEntries := SubprocessEnv(ctx)
+	require.NotEmpty(t, envEntries, "expected TRACEPARENT env entry")
+
+	// Simulate the subprocess: look up the injected entries via getenv.
+	getenv := func(key string) string {
+		for _, e := range envEntries {
+			if len(e) > len(key) && e[:len(key)] == key && e[len(key)] == '=' {
+				return e[len(key)+1:]
+			}
+		}
+		return ""
+	}
+	require.NotEmpty(t, getenv("TRACEPARENT"))
+
+	childCtx := ContextWithRemoteParent(context.Background(), getenv)
+	remote := trace.SpanContextFromContext(childCtx)
+	require.True(t, remote.IsValid(), "extracted span context should be valid")
+	assert.Equal(t, span.SpanContext().TraceID(), remote.TraceID(), "subprocess spans must join the parent's trace")
+	assert.Equal(t, span.SpanContext().SpanID(), remote.SpanID(), "subprocess spans must parent to the command span")
+	assert.True(t, remote.IsRemote())
+}
+
+func TestSubprocessEnvEmptyWithoutActiveSpan(t *testing.T) {
+	setupPropagation(t)
+	assert.Empty(t, SubprocessEnv(context.Background()))
+}
+
+func TestContextWithRemoteParentNoEnvIsNoop(t *testing.T) {
+	setupPropagation(t)
+	ctx := ContextWithRemoteParent(context.Background(), func(string) string { return "" })
+	assert.False(t, trace.SpanContextFromContext(ctx).IsValid())
+}

--- a/test/integration/awsconfig_test.go
+++ b/test/integration/awsconfig_test.go
@@ -131,11 +131,10 @@ func TestStartSkipsAWSProfilePromptWhenAlreadyConfigured(t *testing.T) {
 		return bytes.Contains(out.Bytes(), []byte("LocalStack is running"))
 	}, 2*time.Minute, 200*time.Millisecond, "container should become ready")
 
+	// Teardown only: lstk may already have exited on its own, so don't assert on Wait's error.
 	_ = cmd.Process.Kill()
-	err = cmd.Wait()
+	_ = cmd.Wait()
 	<-outputCh
-	// Process was killed, so we expect an error from Wait()
-	require.Error(t, err, "lstk start should exit after kill")
 
 	assert.NotContains(t, out.String(), awsSetupPrompt,
 		"profile prompt should not appear when profile is already correctly configured")

--- a/test/integration/telemetry_test.go
+++ b/test/integration/telemetry_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -64,7 +65,8 @@ func TestStartCommandSendsTelemetryEvent(t *testing.T) {
 	runCmd := func(t *testing.T, args ...string) {
 		t.Helper()
 		cmd := exec.CommandContext(ctx, binaryPath(), args...)
-		cmd.Env = env.With(env.AuthToken, "fake-token").
+		cmd.Env = env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.AuthToken, "fake-token").
 			With(env.AnalyticsEndpoint, analyticsSrv.URL)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "lstk %v failed: %s", args, out)
@@ -123,7 +125,8 @@ func TestStopCommandSendsTelemetryEvents(t *testing.T) {
 
 	analyticsSrv, events := mockAnalyticsServer(t)
 
-	_, stderr, err := runLstk(t, ctx, "", env.With(env.AuthToken, "fake-token").
+	_, stderr, err := runLstk(t, ctx, "", env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.AuthToken, "fake-token").
 		With(env.AnalyticsEndpoint, analyticsSrv.URL), "stop")
 	require.NoError(t, err, "lstk stop failed: %s", stderr)
 	requireExitCode(t, 0, err)
@@ -169,7 +172,8 @@ func TestStartCommandSucceedsWhenAnalyticsEndpointUnreachable(t *testing.T) {
 	startTestContainer(t, ctx)
 
 	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = env.With(env.AuthToken, "fake-token").
+	cmd.Env = env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.AuthToken, "fake-token").
 		With(env.AnalyticsEndpoint, "http://127.0.0.1:1")
 	out, err := cmd.CombinedOutput()
 
@@ -190,7 +194,8 @@ func TestStartCommandDoesNotSendTelemetryWhenDisabled(t *testing.T) {
 	analyticsSrv, events := mockAnalyticsServer(t)
 
 	cmd := exec.CommandContext(ctx, binaryPath(), "start")
-	cmd.Env = env.With(env.AuthToken, "fake-token").
+	cmd.Env = env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.AuthToken, "fake-token").
 		With(env.AnalyticsEndpoint, analyticsSrv.URL).
 		With(env.DisableEvents, "1")
 	out, err := cmd.CombinedOutput()
@@ -235,41 +240,148 @@ func assertCommandTelemetry(t *testing.T, events <-chan map[string]any, command 
 	assert.InDelta(t, exitCode, result["exit_code"], 0)
 }
 
-// TestOtelTelemetrySpanIsExported verifies that the span created for the
-// analytics POST request reaches the OTLP collector.
-func TestOtelTelemetrySpanIsExported(t *testing.T) {
+// Regression test for FLC-648: a slow analytics endpoint must not add to
+// command latency since the flush happens in a detached subprocess.
+func TestStartCommand_DoesNotBlockOnSlowAnalyticsEndpoint(t *testing.T) {
 	requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
+
+	const endpointDelay = 3 * time.Second
+	const maxParentDuration = endpointDelay / 3 // generous: anything <1s proves the point
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	startTestContainer(t, ctx)
 
-	analyticsSrv, _ := mockAnalyticsServer(t)
-	otlpSrv, otlpBodies := mockOTLPCollector(t)
+	received := make(chan map[string]any, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Events []map[string]any `json:"events"`
+		}
+		if err := json.Unmarshal(body, &req); err == nil {
+			for _, ev := range req.Events {
+				received <- ev
+			}
+		}
+		time.Sleep(endpointDelay)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
 
 	cmd := exec.CommandContext(ctx, binaryPath(), "start")
 	cmd.Env = env.Environ(testEnvWithHome(t.TempDir(), "")).
 		With(env.AuthToken, "fake-token").
+		With(env.AnalyticsEndpoint, srv.URL)
+
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	parentDuration := time.Since(start)
+
+	require.NoError(t, err, "lstk start failed: %s", out)
+	require.Less(t, parentDuration, maxParentDuration,
+		"parent process took %v, expected <%v — subprocess flush should not block parent", parentDuration, maxParentDuration)
+
+	// The detached subprocess should still deliver the event.
+	select {
+	case <-received:
+	case <-time.After(endpointDelay + 5*time.Second):
+		t.Fatal("subprocess flusher never delivered the telemetry event")
+	}
+}
+
+// Verifies the detached flush path without Docker, so it also covers the
+// platform-specific detach flags on Windows CI.
+func TestCommandTelemetryIsDeliveredByDetachedFlusher(t *testing.T) {
+	t.Parallel()
+
+	ctx := testContext(t)
+	analyticsSrv, events := mockAnalyticsServer(t)
+
+	// Dead DOCKER_HOST: start fails fast without Docker but still emits telemetry.
+	_, _, err := runLstk(t, ctx, "", env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.AuthToken, "fake-token").
+		With(env.AnalyticsEndpoint, analyticsSrv.URL).
+		With(env.Key("DOCKER_HOST"), "tcp://127.0.0.1:1"), "start")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+
+	assertCommandTelemetry(t, events, "start", 1)
+}
+
+// Pipes events into the hidden __flush-telemetry subcommand and verifies they
+// are POSTed without the subcommand emitting telemetry about itself.
+func TestFlushTelemetrySubcommandDoesNotSpawnRecursively(t *testing.T) {
+	t.Parallel()
+
+	ctx := testContext(t)
+	analyticsSrv, events := mockAnalyticsServer(t)
+
+	input := `{"name":"first_event","metadata":{"client_time":"2026-06-02 00:00:00.000000","session_id":"s1"},"payload":{"k":"v1"}}
+{"name":"second_event","metadata":{"client_time":"2026-06-02 00:00:00.000000","session_id":"s1"},"payload":{"k":"v2"}}
+`
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "__flush-telemetry", "--endpoint", analyticsSrv.URL)
+	// Route the subprocess's own telemetry at the mock too, so a recursive event would be observable.
+	cmd.Env = env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.AnalyticsEndpoint, analyticsSrv.URL)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "__flush-telemetry failed: %s", out)
+
+	got := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case ev := <-events:
+			got[ev["name"].(string)] = true
+		default:
+			t.Fatalf("expected 2 flushed events, got %d: %v", i, got)
+		}
+	}
+	assert.True(t, got["first_event"] && got["second_event"], "expected both piped events, got: %v", got)
+
+	// No further events may arrive: that would mean the flusher emitted telemetry about itself.
+	select {
+	case ev := <-events:
+		t.Fatalf("unexpected extra telemetry event from flusher: %v", ev)
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// Verifies the detached flusher exports its spans to the OTLP collector via the
+// propagated TRACEPARENT; trace-ID equality is covered in internal/tracing.
+func TestOtelFlushSpansJoinCommandTrace(t *testing.T) {
+	t.Parallel()
+
+	ctx := testContext(t)
+	analyticsSrv, _ := mockAnalyticsServer(t)
+	otlpSrv, otlpBodies := mockOTLPCollector(t)
+
+	// Dead DOCKER_HOST: start fails fast without Docker but still emits telemetry.
+	_, _, err := runLstk(t, ctx, "", env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.AuthToken, "fake-token").
 		With(env.AnalyticsEndpoint, analyticsSrv.URL).
 		With(env.Otel, "1").
-		With(env.OtelEndpoint, otlpSrv.URL)
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "lstk start failed: %s", out)
+		With(env.OtelEndpoint, otlpSrv.URL).
+		With(env.Key("DOCKER_HOST"), "tcp://127.0.0.1:1"), "start")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
 
-	deadline := time.After(5 * time.Second)
+	// The flusher subprocess exports after the parent exits; allow for its
+	// startup, the POST, and the batcher flush on shutdown.
+	deadline := time.After(10 * time.Second)
 	for {
 		select {
 		case body := <-otlpBodies:
 			// otlptracehttp serializes spans as protobuf; UTF-8 strings appear
 			// inline in the wire format, so a substring search is sufficient.
-			if bytes.Contains(body, []byte("telemetry POST")) {
+			if bytes.Contains(body, []byte("telemetry flush")) {
 				return
 			}
 		case <-deadline:
-			t.Fatal("timed out waiting for telemetry span in OTLP export — likely tel.Close() ran after tracing shutdown")
+			t.Fatal("timed out waiting for flush span in OTLP export — TRACEPARENT propagation or subprocess tracing broken")
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

`lstk aws` took ~2x as long as `awslocal` for simple calls (~1.6s vs ~0.75s). The overhead came from `telemetry.Client.Close()` blocking on HTTP POSTs to the analytics endpoint before process exit (~900ms confirmed via `LOCALSTACK_DISABLE_EVENTS=1`). As discussed on the ticket, the flush now happens in a detached subprocess after the CLI returns, so analytics latency no longer affects command responsiveness.

## Changes

- `telemetry.Client` buffers events in memory; `Close()` hands them to a detached subprocess and returns immediately instead of draining HTTP requests
  - The buffer is capped at 64 events (`pendingCap`) as a safety bound — a single CLI run emits only 1–3 events in practice. On overflow the **oldest** event is dropped, keeping the most valuable one: the final `lstk_command` event emitted after the command completes. (The previous channel-based implementation had the same cap but dropped the *newest* event on overflow.)
- New `__flush-telemetry` mode reads JSON-line events from stdin and POSTs them, bounded by a 10s wall-clock cap so orphaned flushers can't linger
  - It is short-circuited at the top of `Execute()`, before logger/keyring/telemetry/cobra init: the flusher writes nothing to the filesystem (no `lstk.log`, no config dir creation — which raced with test temp-home cleanup on macOS)
- Platform-specific detach: `Setsid` on Unix, `windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP` (via `golang.org/x/sys`) on Windows
- Trace context is propagated to the flusher via `TRACEPARENT`/`TRACESTATE` env vars, so its `telemetry flush` and `telemetry POST` spans join the originating command's trace
- The flusher never constructs a telemetry client or cobra command, so it structurally cannot emit events about itself or spawn another flusher recursively

## Tests

- `TestStartCommand_DoesNotBlockOnSlowAnalyticsEndpoint`: parent exits in <1s while the endpoint hangs 3s, and the event is still delivered
- `TestCommandTelemetryIsDeliveredByDetachedFlusher`: Docker-free end-to-end flush — also runs on Windows CI, covering the Windows detach flags (the Docker-based telemetry tests skip there)
- `TestFlushTelemetrySubcommandDoesNotSpawnRecursively`: guards against recursive flusher spawning
- `TestOtelFlushSpansJoinCommandTrace`: flush spans from the subprocess reach the OTLP collector
- Unit tests for event buffering/handoff (including cap/drop-oldest behavior) and the `TRACEPARENT` round-trip (trace/span ID equality)
- Manually verified in Jaeger: `telemetry flush` appears as `CHILD_OF` the command span in a single trace; `lstk aws sts get-caller-identity`-style commands no longer wait on analytics

Closes FLC-648

## Tracing

The fact that the telemetry event is emitted after the main command's process returned is clearly visible on this trace:
<img width="1911" height="720" alt="image" src="https://github.com/user-attachments/assets/783cdeb4-1b1c-4749-84cc-d52cc8279c3f" />

