### PR TITLE
Document forwarding of LOCALSTACK_* env vars to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ SERVICES = "s3,sqs"
 EAGER_SERVICE_LOADING = "1"
 ```
 
+In addition, host environment variables prefixed with `LOCALSTACK_` (and the `CI` variable) are automatically forwarded to the emulator container.
+
 ## Interactive And Non-Interactive Mode
 
 `lstk` uses the TUI in an interactive terminal and plain output elsewhere. Use `--non-interactive` to force plain output even in a TTY:

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -11,9 +11,12 @@ import (
 func newStartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
 	var firstRun bool
 	cmd := &cobra.Command{
-		Use:     "start",
-		Short:   "Start emulator",
-		Long:    "Start emulator and services.",
+		Use:   "start",
+		Short: "Start emulator",
+		Long: `Start emulator and services.
+
+Host environment variables prefixed with LOCALSTACK_ (and the CI variable) are
+forwarded to the emulator container.`,
 		PreRunE: initConfig(&firstRun),
 		RunE: func(c *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)


### PR DESCRIPTION
## Motivation

lstk automatically forwards host environment variables prefixed with `LOCALSTACK_` (and `CI`) to the emulator container, but this behavior was only described in a code comment — not in the README or CLI help.

## Changes

- Document the env var forwarding in the README's "Passing environment variables to the container" section
- Mention it in `lstk start --help`

## Tests

Verified the new `lstk start --help` output after building.