### PR TITLE
Document semver label conventions

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,5 +1,15 @@
 # Releasing `lstk`
 
+## Choosing a semver label
+
+Every PR must carry exactly one release label (enforced by `Require release label`). The automated release workflow uses these labels to compute the next version bump:
+
+- `semver: minor` — new user-facing feature or command (e.g. a new subcommand, support for a new emulator).
+- `semver: patch` — everything else: bug fixes, dependency bumps, internal refactors, docs, specs.
+- `semver: major` — reserved for breaking changes once lstk reaches 1.0; do not use before then.
+
+## Release workflows
+
 Release automation uses two workflows:
 
 1. `Create Release Tag` (`.github/workflows/create-release-tag.yml`)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,8 +4,8 @@
 
 Every PR must carry exactly one release label (enforced by `Require release label`). The automated release workflow uses these labels to compute the next version bump:
 
+- `semver: patch` — anything that isn't a new feature: bug fixes, dependency bumps, internal refactors, docs, specs.
 - `semver: minor` — new user-facing feature or command (e.g. a new subcommand, support for a new emulator).
-- `semver: patch` — everything else: bug fixes, dependency bumps, internal refactors, docs, specs.
 - `semver: major` — reserved for breaking changes once lstk reaches 1.0; do not use before then.
 
 ## Release workflows


### PR DESCRIPTION
## Motivation

Every PR requires a `semver: *` label that drives the automated release version bump, but the criteria for choosing one were not documented anywhere — leading to inconsistent labeling (e.g. `semver: major` on a specs-only PR).

## Changes

- Add a "Choosing a semver label" section to `docs/RELEASING.md` documenting the convention established by past releases: `minor` for new user-facing features/commands, `patch` for everything else, `major` reserved for breaking changes post-1.0

## Tests

Docs-only change.