### PR TITLE
Check runtime availability before login and emulator selection

### DIFF
--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -70,6 +70,14 @@ func Run(parentCtx context.Context, runOpts RunOptions) error {
 			p.Send(runDoneMsg{})
 			return
 		}
+		if healthErr := runOpts.Runtime.IsHealthy(ctx); healthErr != nil {
+			if errors.Is(healthErr, context.Canceled) {
+				return
+			}
+			runOpts.Runtime.EmitUnhealthyError(sink, healthErr)
+			p.Send(runErrMsg{err: output.NewSilentError(healthErr)})
+			return
+		}
 		// Resolve the auth token before any emulator-selection prompt so the user
 		// logs in first and only configures an emulator once they're authenticated.
 		// container.Start still calls GetToken as a safety net for non-interactive

--- a/test/integration/emulator_select_test.go
+++ b/test/integration/emulator_select_test.go
@@ -60,6 +60,7 @@ func TestNoEmulatorSelectionWhenConfigExists(t *testing.T) {
 }
 
 func TestFirstRunShowsEmulatorSelectionPrompt(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
@@ -115,6 +116,7 @@ func TestFirstRunShowsEmulatorSelectionPrompt(t *testing.T) {
 }
 
 func TestFirstRunCanSelectAzureEmulator(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
@@ -169,6 +171,7 @@ func TestFirstRunCanSelectAzureEmulator(t *testing.T) {
 }
 
 func TestFirstRunPromptsForLoginBeforeEmulatorSelection(t *testing.T) {
+	requireDocker(t)
 	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
@@ -239,4 +242,34 @@ func TestFirstRunNonInteractiveEmitsDefaultEmulatorNote(t *testing.T) {
 	stdout, _, runErr := runLstk(t, testContext(t), "", e.With(env.AuthToken, "test-token"), "--non-interactive")
 	assert.Error(t, runErr, "expected failure: no Docker available")
 	assert.Contains(t, stdout, "Configured with default emulator", "non-interactive first run should note the default emulator")
+}
+
+func TestFirstRunChecksDockerBeforeAuthAndSelection(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY/Unix socket test")
+	}
+
+	mockServer := createMockAPIServer(t, "test-license-token", true)
+	defer mockServer.Close()
+
+	tmpHome := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, ".config"), 0755))
+	e := env.Environ(testEnvWithHome(tmpHome, tmpHome)).
+		Without(env.AuthToken).
+		With(env.APIEndpoint, mockServer.URL).
+		With(env.DisableEvents, "1").
+		With(env.Key("DOCKER_HOST"), "unix:///var/run/docker-does-not-exist.sock")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	out, err := runLstkInPTY(t, ctx, e, "start")
+	require.Error(t, err)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, out, "Docker is not available")
+	assert.NotContains(t, out, "Press any key when complete",
+		"login prompt must not appear when the runtime is unavailable")
+	assert.NotContains(t, out, "Which emulator would you like to use?",
+		"emulator selection must not appear when the runtime is unavailable")
 }


### PR DESCRIPTION
The Docker health check ran inside `container.Start`, after login and emulator selection — so a user without Docker would log in, pick an emulator (with the choice persisted), and only then hit `Docker is not available`. This moves it to a pre-flight gate that runs before the login and emulator-selection prompts, so a missing runtime is reported up front.

Closes [PRO-302](https://linear.app/localstack/issue/PRO-302/check-runtime-availability-before-login-and-emulator-selection)

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

<!-- linear:table-colwidths:800 -->
| BEFORE/AFTER |
| -- |
| <img src="https://uploads.linear.app/3888efef-62d8-4ae8-9866-dbabfd802020/098e28ba-c9e2-408d-a000-cb02fd4aaa95/cde37b47-08c2-4719-80d0-735bbd6c2fed?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzM4ODhlZmVmLTYyZDgtNGFlOC05ODY2LWRiYWJmZDgwMjAyMC8wOThlMjhiYS1jOWUyLTQwOGQtYTAwMC1jYjAyZmQ0YWFhOTUvY2RlMzdiNDctMDhjMi00NzE5LTgwZDAtNzM1YmJkNmMyZmVkIiwiaWF0IjoxNzgwNDk3MzQ1LCJleHAiOjE4MTIwNjc5MDV9.ZL00Jac2dMRLm0VwhQq2IjNHOQ7uu28gkJ8I1ZZoI5o " alt="Frame@2x (8).png" width="5328" data-linear-height="2300" /> |
