### PR TITLE
Implement snapshot remove

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -26,6 +26,16 @@ const snapshotListLong = `List Cloud Pod snapshots available on the LocalStack p
 
 By default only snapshots you created are listed. Pass --all to include all snapshots in your organisation.`
 
+const snapshotRemoveLong = `Delete a cloud snapshot from the LocalStack platform.
+
+Only cloud snapshots (pod: prefix) can be removed. This operation cannot be undone.
+
+  lstk snapshot remove pod:my-baseline    # deletes the cloud snapshot named my-baseline
+
+To skip the confirmation prompt in non-interactive mode, use --force:
+
+  lstk snapshot remove pod:my-baseline --force`
+
 const snapshotSaveLong = `Save a snapshot of the running emulator's state.
 
 Pass [destination] as an absolute or relative path for the exported file:
@@ -62,6 +72,7 @@ func newSnapshotCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cob
 	cmd.AddCommand(newSnapshotSaveCmd(cfg))
 	cmd.AddCommand(newSnapshotLoadCmd(cfg, tel, logger))
 	cmd.AddCommand(newSnapshotListCmd(cfg))
+	cmd.AddCommand(newSnapshotRemoveCmd(cfg))
 	return cmd
 }
 
@@ -138,6 +149,56 @@ func runSnapshotLoad(cfg *env.Env, tel *telemetry.Client, logger log.Logger) fun
 		default:
 			return snapshot.LoadLocal(cmd.Context(), rt, containers, client, host, src.Value, strategy, starter, sink)
 		}
+	}
+}
+
+func newSnapshotRemoveCmd(cfg *env.Env) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "remove REF",
+		Short:   "Delete a cloud snapshot from the LocalStack platform",
+		Long:    snapshotRemoveLong,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: initConfig(nil),
+		RunE:    runSnapshotRemove(cfg),
+	}
+	cmd.Flags().Bool("force", false, "Skip confirmation prompt")
+	return cmd
+}
+
+func runSnapshotRemove(cfg *env.Env) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		ref, err := snapshot.ParseRemovable(args[0], cwd, home)
+		if err != nil {
+			return err
+		}
+
+		if !isInteractiveMode(cfg) && !force {
+			return fmt.Errorf("snapshot remove requires confirmation; use --force to skip in non-interactive mode")
+		}
+
+		rt, client, host, containers, _, err := resolveSnapshotDeps(cmd.Context(), cfg)
+		if err != nil {
+			return err
+		}
+
+		if isInteractiveMode(cfg) {
+			return ui.RunSnapshotRemove(cmd.Context(), rt, containers, client, host, ref.Value, cfg.AuthToken, force)
+		}
+		sink := output.NewPlainSink(os.Stdout)
+		return snapshot.Remove(cmd.Context(), rt, containers, ref.Value, cfg.AuthToken, client, host, force, sink)
 	}
 }
 

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -180,25 +180,28 @@ func runSnapshotRemove(cfg *env.Env) func(*cobra.Command, []string) error {
 		if err != nil {
 			return err
 		}
-		ref, err := snapshot.ParseRemovable(args[0], cwd, home)
-		if err != nil {
-			return err
-		}
 
-		if !isInteractiveMode(cfg) && !force {
-			return fmt.Errorf("snapshot remove requires confirmation; use --force to skip in non-interactive mode")
+		if !isInteractiveMode(cfg) {
+			ref, err := snapshot.ParseRemovable(args[0], cwd, home)
+			if err != nil {
+				return err
+			}
+			if !force {
+				return fmt.Errorf("snapshot remove requires confirmation; use --force to skip in non-interactive mode")
+			}
+			rt, client, host, containers, _, err := resolveSnapshotDeps(cmd.Context(), cfg)
+			if err != nil {
+				return err
+			}
+			sink := output.NewPlainSink(os.Stdout)
+			return snapshot.Remove(cmd.Context(), rt, containers, ref.Value, cfg.AuthToken, client, host, force, sink)
 		}
 
 		rt, client, host, containers, _, err := resolveSnapshotDeps(cmd.Context(), cfg)
 		if err != nil {
 			return err
 		}
-
-		if isInteractiveMode(cfg) {
-			return ui.RunSnapshotRemove(cmd.Context(), rt, containers, client, host, ref.Value, cfg.AuthToken, force)
-		}
-		sink := output.NewPlainSink(os.Stdout)
-		return snapshot.Remove(cmd.Context(), rt, containers, ref.Value, cfg.AuthToken, client, host, force, sink)
+		return ui.RunSnapshotRemove(cmd.Context(), rt, containers, client, host, args[0], cwd, home, cfg.AuthToken, force)
 	}
 }
 

--- a/internal/emulator/aws/client.go
+++ b/internal/emulator/aws/client.go
@@ -402,3 +402,29 @@ func (c *Client) SavePodSnapshot(ctx context.Context, host, podName, authToken s
 	}
 	return snapshot.PodSaveResult{}, fmt.Errorf("pod save: server closed stream without a completion event")
 }
+
+func (c *Client) RemovePodSnapshot(ctx context.Context, host, podName, authToken string) error {
+	url := fmt.Sprintf("http://%s/_localstack/pods/%s", host, podName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(":"+authToken)))
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("connect to LocalStack: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		bodyStr := strings.TrimSpace(string(body))
+		if strings.Contains(strings.ToLower(bodyStr), "not found") {
+			return fmt.Errorf("%w: %s", snapshot.ErrPodNotFound, bodyStr)
+		}
+		return fmt.Errorf("pod remove failed (HTTP %d): %s", resp.StatusCode, bodyStr)
+	}
+	return nil
+}

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -100,6 +100,10 @@ type SnapshotLoadedEvent struct {
 	Services []string // services restored
 }
 
+type PodSnapshotRemovedEvent struct {
+	PodName string
+}
+
 type AuthCompleteEvent struct{}
 
 // Event is a sealed marker — only event types in this package implement it,
@@ -114,9 +118,10 @@ func (AuthCompleteEvent) sealedEvent()     {}
 func (InstanceInfoEvent) sealedEvent()     {}
 func (TableEvent) sealedEvent()            {}
 func (ResourceSummaryEvent) sealedEvent()  {}
-func (PodSnapshotSavedEvent) sealedEvent()  {}
-func (SnapshotLoadedEvent) sealedEvent()    {}
-func (SnapshotListEvent) sealedEvent()      {}
+func (PodSnapshotSavedEvent) sealedEvent()   {}
+func (SnapshotLoadedEvent) sealedEvent()     {}
+func (SnapshotListEvent) sealedEvent()       {}
+func (PodSnapshotRemovedEvent) sealedEvent() {}
 func (ContainerStatusEvent) sealedEvent()  {}
 func (ProgressEvent) sealedEvent()         {}
 func (UserInputRequestEvent) sealedEvent() {}

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -46,6 +46,8 @@ func FormatEventLine(event Event) (string, bool) {
 		return formatSnapshotLoaded(e), true
 	case SnapshotListEvent:
 		return formatSnapshotList(e)
+	case PodSnapshotRemovedEvent:
+		return formatPodSnapshotRemoved(e), true
 	case AuthCompleteEvent:
 		return "", false
 	default:
@@ -224,6 +226,10 @@ func formatPodSnapshotSaved(e PodSnapshotSavedEvent) string {
 		sb.WriteString("\n• Size: " + formatBytes(e.Size))
 	}
 	return sb.String()
+}
+
+func formatPodSnapshotRemoved(e PodSnapshotRemovedEvent) string {
+	return SuccessMarker() + fmt.Sprintf(" Cloud snapshot 'pod:%s' deleted", e.PodName)
 }
 
 func formatBytes(b int64) string {

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -267,6 +267,14 @@ func TestFormatEventLine(t *testing.T) {
 			want:   "~ 1 snapshot\n\n  NAME    VERSION  LAST CHANGED\n  my-pod  2        2026-01-01 00:00 UTC",
 			wantOK: true,
 		},
+
+		// snapshot remove events
+		{
+			name:   "pod snapshot removed",
+			event:  PodSnapshotRemovedEvent{PodName: "my-baseline"},
+			want:   SuccessMarker() + " Cloud snapshot 'pod:my-baseline' deleted",
+			wantOK: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/snapshot/destination.go
+++ b/internal/snapshot/destination.go
@@ -39,6 +39,21 @@ type Destination struct {
 	Value string
 }
 
+// ParseRemovable parses a ref for snapshot remove. Only cloud (pod:) refs are accepted;
+// local file paths are rejected because the CLI cannot delete local files.
+// cwd and home are used to produce a human-readable path in error messages.
+func ParseRemovable(ref, cwd, home string) (Destination, error) {
+	lower := strings.ToLower(ref)
+	if !strings.HasPrefix(lower, "pod:") && !strings.Contains(lower, "://") {
+		abs, _ := filepath.Abs(ref)
+		if !strings.EqualFold(filepath.Ext(abs), ".zip") {
+			abs += ".zip"
+		}
+		return Destination{}, fmt.Errorf("'%s' resolves to a local file (%s); CLI cannot delete local files", ref, displayPath(abs, cwd, home))
+	}
+	return ParseSource(ref, home)
+}
+
 // displayPath shortens abs for human-readable output:
 // under cwd → ./rel, under home → ~/rel, otherwise unchanged.
 func displayPath(abs, cwd, home string) string {

--- a/internal/snapshot/remove.go
+++ b/internal/snapshot/remove.go
@@ -1,7 +1,5 @@
 package snapshot
 
-//go:generate mockgen -source=remove.go -destination=mock_pod_remover_test.go -package=snapshot_test
-
 import (
 	"context"
 	"errors"

--- a/internal/snapshot/remove.go
+++ b/internal/snapshot/remove.go
@@ -1,0 +1,88 @@
+package snapshot
+
+//go:generate mockgen -source=remove.go -destination=mock_pod_remover_test.go -package=snapshot_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+// ErrPodNotFound is returned when the cloud pod does not exist on the platform.
+var ErrPodNotFound = errors.New("cloud pod not found")
+
+// PodRemover deletes a remote pod snapshot on the LocalStack platform.
+type PodRemover interface {
+	RemovePodSnapshot(ctx context.Context, host, podName, authToken string) error
+}
+
+// Remove deletes a remote pod snapshot, prompting for confirmation unless force is true.
+func Remove(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, podName, authToken string, remover PodRemover, host string, force bool, sink output.Sink) error {
+	if authToken == "" {
+		return fmt.Errorf("pod snapshots require authentication — set LOCALSTACK_AUTH_TOKEN or run %q", "lstk login")
+	}
+
+	if err := rt.IsHealthy(ctx); err != nil {
+		rt.EmitUnhealthyError(sink, err)
+		return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
+	}
+
+	runningContainers, err := container.RunningEmulators(ctx, rt, containers)
+	if err != nil {
+		return fmt.Errorf("checking emulator status: %w", err)
+	}
+	if len(runningContainers) == 0 {
+		sink.Emit(output.ErrorEvent{
+			Title: "LocalStack is not running",
+			Actions: []output.ErrorAction{
+				{Label: "Start LocalStack:", Value: "lstk"},
+				{Label: "See help:", Value: "lstk -h"},
+			},
+		})
+		return output.NewSilentError(fmt.Errorf("LocalStack is not running"))
+	}
+
+	if !force {
+		responseCh := make(chan output.InputResponse, 1)
+		sink.Emit(output.UserInputRequestEvent{
+			Prompt: fmt.Sprintf("Delete cloud snapshot 'pod:%s'? This operation cannot be undone.", podName),
+			Options: []output.InputOption{
+				{Key: "y", Label: "Y"},
+				{Key: "n", Label: "n"},
+			},
+			ResponseCh: responseCh,
+		})
+
+		select {
+		case resp := <-responseCh:
+			if resp.Cancelled || resp.SelectedKey != "y" {
+				sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: "Cancelled"})
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return remove(ctx, podName, authToken, remover, host, sink)
+}
+
+func remove(ctx context.Context, podName, authToken string, remover PodRemover, host string, sink output.Sink) (retErr error) {
+	sink.Emit(output.SpinnerStart(fmt.Sprintf("Deleting snapshot 'pod:%s'...", podName)))
+	defer func() {
+		sink.Emit(output.SpinnerStop())
+		if retErr == nil {
+			sink.Emit(output.PodSnapshotRemovedEvent{PodName: podName})
+		}
+	}()
+	err := remover.RemovePodSnapshot(ctx, host, podName, authToken)
+	if errors.Is(err, ErrPodNotFound) {
+		return fmt.Errorf("cloud pod %q not found", podName)
+	}
+	return err
+}

--- a/internal/ui/run_snapshot_remove.go
+++ b/internal/ui/run_snapshot_remove.go
@@ -1,0 +1,16 @@
+package ui
+
+import (
+	"context"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/snapshot"
+)
+
+func RunSnapshotRemove(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, client snapshot.PodRemover, host, podName, authToken string, force bool) error {
+	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
+		return snapshot.Remove(ctx, rt, containers, podName, authToken, client, host, force, sink)
+	})
+}

--- a/internal/ui/run_snapshot_remove.go
+++ b/internal/ui/run_snapshot_remove.go
@@ -9,8 +9,12 @@ import (
 	"github.com/localstack/lstk/internal/snapshot"
 )
 
-func RunSnapshotRemove(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, client snapshot.PodRemover, host, podName, authToken string, force bool) error {
+func RunSnapshotRemove(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, client snapshot.PodRemover, host, ref, cwd, home, authToken string, force bool) error {
 	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
-		return snapshot.Remove(ctx, rt, containers, podName, authToken, client, host, force, sink)
+		dst, err := snapshot.ParseRemovable(ref, cwd, home)
+		if err != nil {
+			return err
+		}
+		return snapshot.Remove(ctx, rt, containers, dst.Value, authToken, client, host, force, sink)
 	})
 }

--- a/test/integration/snapshot_remove_test.go
+++ b/test/integration/snapshot_remove_test.go
@@ -1,0 +1,286 @@
+package integration_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPodRemoveServer returns a test server that handles DELETE /_localstack/pods/{name}.
+// status is the HTTP status code to respond with.
+// The returned function reports how many times the endpoint was called.
+func mockPodRemoveServer(t *testing.T, status int) (*httptest.Server, func() int32) {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/_localstack/pods/") && r.Method == http.MethodDelete {
+			calls.Add(1)
+			w.WriteHeader(status)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, calls.Load
+}
+
+// --- no Docker required (parallel) ---
+
+func TestSnapshotRemoveLocalRefRejected(t *testing.T) {
+	t.Parallel()
+	ctx := testContext(t)
+
+	_, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "remove", "./my-baseline.zip",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "resolves to a local file")
+	assert.Contains(t, stderr, "CLI cannot delete local files")
+}
+
+func TestSnapshotRemoveLocalBareNameRejected(t *testing.T) {
+	t.Parallel()
+	ctx := testContext(t)
+
+	_, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "remove", "my-baseline",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "resolves to a local file")
+	assert.Contains(t, stderr, "CLI cannot delete local files")
+}
+
+func TestSnapshotRemovePodNoAuthToken(t *testing.T) {
+	t.Parallel()
+	ctx := testContext(t)
+
+	_, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).Without(env.AuthToken),
+		"--non-interactive", "snapshot", "remove", "pod:my-baseline", "--force",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "authentication")
+}
+
+func TestSnapshotRemovePodInvalidName(t *testing.T) {
+	t.Parallel()
+	for _, ref := range []string{"pod:", "pod:-bad", "pod:my_pod"} {
+		t.Run(ref, func(t *testing.T) {
+			t.Parallel()
+			ctx := testContext(t)
+
+			_, stderr, err := runLstk(t, ctx, t.TempDir(),
+				testEnvWithHome(t.TempDir(), ""),
+				"--non-interactive", "snapshot", "remove", ref,
+			)
+			requireExitCode(t, 1, err)
+			assert.Contains(t, stderr, "invalid pod name")
+		})
+	}
+}
+
+func TestSnapshotRemoveNonInteractiveRequiresForce(t *testing.T) {
+	t.Parallel()
+	ctx := testContext(t)
+
+	_, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "remove", "pod:my-baseline",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "--force")
+}
+
+func TestSnapshotRemoteSchemeRejected(t *testing.T) {
+	t.Parallel()
+	for _, ref := range []string{"s3://bucket/snap", "oras://registry/snap"} {
+		t.Run(ref, func(t *testing.T) {
+			t.Parallel()
+			ctx := testContext(t)
+
+			_, stderr, err := runLstk(t, ctx, t.TempDir(),
+				testEnvWithHome(t.TempDir(), ""),
+				"--non-interactive", "snapshot", "remove", ref,
+			)
+			requireExitCode(t, 1, err)
+			assert.Contains(t, stderr, "not yet supported")
+		})
+	}
+}
+
+// --- Docker required ---
+
+func TestSnapshotRemovePodSuccess(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+	srv, calls := mockPodRemoveServer(t, http.StatusOK)
+
+	stdout, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.LocalStackHost, lsHost(srv)).
+			With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "remove", "pod:my-baseline", "--force",
+	)
+	require.NoError(t, err, "lstk snapshot remove pod:my-baseline failed: %s", stderr)
+	assert.Contains(t, stdout, "my-baseline")
+	assert.Contains(t, stdout, "deleted")
+	assert.Equal(t, int32(1), calls(), "DELETE endpoint should be called exactly once")
+}
+
+func TestSnapshotRemovePodServerError(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+	srv, calls := mockPodRemoveServer(t, http.StatusInternalServerError)
+
+	_, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.LocalStackHost, lsHost(srv)).
+			With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "remove", "pod:my-baseline", "--force",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "pod remove failed")
+	assert.Equal(t, int32(1), calls(), "DELETE endpoint should be called even when server errors")
+}
+
+func TestSnapshotRemovePodNotFound(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/_localstack/pods/") && r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("Error: Cloud Pod 'my-snapshot' not found."))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.LocalStackHost, lsHost(srv)).
+			With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "remove", "pod:my-snapshot", "--force",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, `"my-snapshot"`)
+	assert.Contains(t, stderr, "not found")
+	assert.NotContains(t, stderr, "HTTP 500")
+	assert.NotContains(t, stderr, "pod remove failed")
+}
+
+func TestSnapshotRemoveInteractive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("PTY test skipped in short mode")
+	}
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	startTestContainer(t, testContext(t))
+
+	startRemove := func(t *testing.T, srv *httptest.Server) (*os.File, *syncBuffer, chan struct{}, *exec.Cmd) {
+		t.Helper()
+		binPath, err := filepath.Abs(binaryPath())
+		require.NoError(t, err)
+
+		cmd := exec.CommandContext(testContext(t), binPath, "snapshot", "remove", "pod:my-baseline")
+		cmd.Env = env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.LocalStackHost, lsHost(srv)).
+			With(env.AuthToken, "test-token")
+		ptmx, err := pty.Start(cmd)
+		require.NoError(t, err, "failed to start command in PTY")
+		t.Cleanup(func() { _ = ptmx.Close() })
+
+		out := &syncBuffer{}
+		outputCh := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(out, ptmx)
+			close(outputCh)
+		}()
+		require.Eventually(t, func() bool {
+			return bytes.Contains(out.Bytes(), []byte("Delete cloud snapshot"))
+		}, 10*time.Second, 100*time.Millisecond, "confirmation prompt should appear")
+		return ptmx, out, outputCh, cmd
+	}
+
+	t.Run("confirms with y", func(t *testing.T) {
+		srv, calls := mockPodRemoveServer(t, http.StatusOK)
+		ptmx, out, outputCh, cmd := startRemove(t, srv)
+		_, err := ptmx.Write([]byte("y"))
+		require.NoError(t, err)
+		require.NoError(t, cmd.Wait())
+		<-outputCh
+
+		assert.Contains(t, out.String(), "deleted")
+		assert.Equal(t, int32(1), calls(), "DELETE endpoint should be called after confirmation")
+	})
+
+	t.Run("cancels with n", func(t *testing.T) {
+		srv, calls := mockPodRemoveServer(t, http.StatusOK)
+		ptmx, out, outputCh, cmd := startRemove(t, srv)
+		_, err := ptmx.Write([]byte("n"))
+		require.NoError(t, err)
+		require.NoError(t, cmd.Wait())
+		<-outputCh
+
+		assert.Contains(t, out.String(), "Cancelled")
+		assert.Equal(t, int32(0), calls(), "DELETE endpoint must not be called when user cancels")
+	})
+
+	t.Run("force skips confirmation prompt", func(t *testing.T) {
+		srv, calls := mockPodRemoveServer(t, http.StatusOK)
+
+		binPath, err := filepath.Abs(binaryPath())
+		require.NoError(t, err)
+		cmd := exec.CommandContext(testContext(t), binPath, "snapshot", "remove", "pod:my-baseline", "--force")
+		cmd.Env = env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.LocalStackHost, lsHost(srv)).
+			With(env.AuthToken, "test-token")
+		ptmx, err := pty.Start(cmd)
+		require.NoError(t, err, "failed to start command in PTY")
+		t.Cleanup(func() { _ = ptmx.Close() })
+
+		out := &syncBuffer{}
+		outputCh := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(out, ptmx)
+			close(outputCh)
+		}()
+
+		require.NoError(t, cmd.Wait())
+		<-outputCh
+
+		assert.NotContains(t, out.String(), "Delete cloud snapshot", "confirmation prompt must not appear with --force")
+		assert.Contains(t, out.String(), "deleted")
+		assert.Equal(t, int32(1), calls(), "DELETE endpoint should be called without confirmation")
+	})
+}


### PR DESCRIPTION
Implemented snapshot remove. Works for cloud pods only, and throws an error in local for safety reason. It requires confirmation (Y/n) and in non-interactive mode can be bypassed by using `--force` flag.

<img width="850" height="51" alt="image" src="https://github.com/user-attachments/assets/9d256b52-8a2e-48d0-aac3-d5f65f27af00" />
<img width="1707" height="93" alt="602367388-62f127ad-65a7-45ac-8f79-e322daac7c83" src="https://github.com/user-attachments/assets/054e10bb-80b3-446c-b997-3fd9f6c7a169" />
<img width="797" height="47" alt="image" src="https://github.com/user-attachments/assets/5af2ee97-e6e5-4a63-a3b7-c00459672ed9" />
<img width="816" height="52" alt="image" src="https://github.com/user-attachments/assets/fb82d3f2-7ef4-4a1b-9ae0-490f5e119c50" />
<img width="793" height="46" alt="image" src="https://github.com/user-attachments/assets/c907fa67-7866-4ecf-a161-4f9d889a8934" />
