### PR TITLE
Improve help text wrapping

### DIFF
--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -47,6 +47,7 @@ Create `cmd/$ARGUMENTS.go` with:
   - Interactive: delegate to `ui.Run<Name>(...)` or TUI path
   - Non-interactive: call domain function with `output.NewPlainSink(os.Stdout)`
 - No business logic — only Cobra wiring, dependency creation, and output mode selection
+- `Short`/`Long` help text: write each paragraph as one unbroken line (blank line between paragraphs); never hard-wrap a sentence across source lines. The help template (`cmd/help.go`) word-wraps to the terminal width at render time, and `lstk docs` reads the raw text — manual breaks fight both. Indent example/output blocks; the wrapper leaves indented lines untouched.
 
 ## Step 2: Create the domain logic package
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,10 @@ Environment variables:
 - Never print directly to stdout/stderr (e.g., `fmt.Fprintf(os.Stderr, …)`). For user-facing output, emit events through `output.Sink`. For internal diagnostics, use `log.Logger`. If neither is available (e.g., during logger setup), return errors to the caller and let them decide.
 - Do not call `config.Get()` from domain/business-logic packages. Instead, extract the values you need at the command boundary (`cmd/`) and pass them as explicit function arguments. This keeps domain functions testable without requiring Viper/config initialization.
 
+# CLI Help Text
+
+- Write command `Short`/`Long` as unbroken paragraphs (one line each, blank line between); never hard-wrap a sentence in source. `wrapText` in `cmd/help.go` re-wraps to the terminal width at render time and `lstk docs` reads the raw text, so manual breaks fight both. Indented lines (examples, aligned output) are left as-is.
+
 # Testing
 
 - Prefer integration tests to cover most cases. Use unit tests when integration tests are not practical.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ SERVICES = "s3,sqs"
 EAGER_SERVICE_LOADING = "1"
 ```
 
-In addition, host environment variables prefixed with `LOCALSTACK_` (and the `CI` variable) are automatically forwarded to the emulator container.
+Host environment variables prefixed with `LOCALSTACK_` are also forwarded to the container.
 
 ## Interactive And Non-Interactive Mode
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ SERVICES = "s3,sqs"
 EAGER_SERVICE_LOADING = "1"
 ```
 
-Host environment variables prefixed with `LOCALSTACK_` are also forwarded to the container.
+Host environment variables prefixed with `LOCALSTACK_` are also forwarded to the emulator.
 
 ## Interactive And Non-Interactive Mode
 

--- a/cmd/az.go
+++ b/cmd/az.go
@@ -24,10 +24,7 @@ func newAzCmd(cfg *env.Env) *cobra.Command {
 		Short: "Run Azure CLI commands against LocalStack",
 		Long: `Run Azure CLI commands against the LocalStack Azure emulator.
 
-Runs 'az <args>' with an isolated AZURE_CONFIG_DIR in which a custom Azure cloud
-is registered against LocalStack's endpoints, so your global ~/.azure
-configuration is left untouched and plain 'az' commands keep talking to real
-Azure.
+Runs 'az <args>' with an isolated AZURE_CONFIG_DIR in which a custom Azure cloud is registered against LocalStack's endpoints, so your global ~/.azure configuration is left untouched and plain 'az' commands keep talking to real Azure.
 
 Run 'lstk setup azure' once before using this command.
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -41,11 +41,8 @@ const helpTemplate = `{{if not .HasParent}}{{if or .Runnable .HasSubCommands}}{{
 {{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{end}}
 `
 
-func init() {
-	cobra.AddTemplateFunc("wrapText", wrapText)
-}
-
 func configureHelp(cmd *cobra.Command) {
+	cobra.AddTemplateFunc("wrapText", wrapText)
 	cmd.InitDefaultHelpFlag()
 	cmd.Flags().Lookup("help").Usage = "Show help"
 	cmd.SetUsageTemplate(usageTemplate)

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -1,6 +1,12 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
 
 const usageTemplate = `Usage: {{if .HasParent}}{{.UseLine}}{{else}}lstk [options] [command]{{end}}{{if not .HasParent}}
 
@@ -30,14 +36,69 @@ Global Options:
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}`
 
-const helpTemplate = `{{if not .HasParent}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{else}}{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+const helpTemplate = `{{if not .HasParent}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{else}}{{with (or .Long .Short)}}{{wrapText . | trimTrailingWhitespaces}}
 
 {{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{end}}
 `
+
+func init() {
+	cobra.AddTemplateFunc("wrapText", wrapText)
+}
 
 func configureHelp(cmd *cobra.Command) {
 	cmd.InitDefaultHelpFlag()
 	cmd.Flags().Lookup("help").Usage = "Show help"
 	cmd.SetUsageTemplate(usageTemplate)
 	cmd.SetHelpTemplate(helpTemplate)
+}
+
+func helpWidth() int {
+	const (
+		maxWidth      = 100
+		fallbackWidth = 80
+	)
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w <= 0 {
+		return fallbackWidth
+	}
+	if w > maxWidth {
+		return maxWidth
+	}
+	return w
+}
+
+func wrapText(s string) string {
+	width := helpWidth()
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = wrapLine(line, width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func wrapLine(line string, width int) string {
+	// Leave indented or pre-formatted lines (examples, aligned output) untouched;
+	// only reflow non-indented prose that exceeds the width.
+	if line == "" || line[0] == ' ' || line[0] == '\t' || len([]rune(line)) <= width {
+		return line
+	}
+	var b strings.Builder
+	lineLen := 0
+	for i, word := range strings.Fields(line) {
+		wordLen := len([]rune(word))
+		switch {
+		case i == 0:
+			b.WriteString(word)
+			lineLen = wordLen
+		case lineLen+1+wordLen > width:
+			b.WriteByte('\n')
+			b.WriteString(word)
+			lineLen = wordLen
+		default:
+			b.WriteByte(' ')
+			b.WriteString(word)
+			lineLen += 1 + wordLen
+		}
+	}
+	return b.String()
 }

--- a/cmd/help_wrap_test.go
+++ b/cmd/help_wrap_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWrapLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		line  string
+		width int
+		want  string
+	}{
+		{
+			name:  "wraps at word boundary",
+			line:  "Host environment variables prefixed with LOCALSTACK_ are forwarded.",
+			width: 30,
+			want:  "Host environment variables\nprefixed with LOCALSTACK_ are\nforwarded.",
+		},
+		{
+			name:  "short line is untouched",
+			line:  "Start emulator and services.",
+			width: 80,
+			want:  "Start emulator and services.",
+		},
+		{
+			name:  "word longer than width stays on its own line",
+			line:  "a supercalifragilisticexpialidocious word",
+			width: 10,
+			want:  "a\nsupercalifragilisticexpialidocious\nword",
+		},
+		{
+			name:  "empty line stays empty",
+			line:  "",
+			width: 80,
+			want:  "",
+		},
+		{
+			name:  "indented example is left untouched even when over width",
+			line:  "  lstk snapshot save     # saves to ./snapshot.zip",
+			width: 20,
+			want:  "  lstk snapshot save     # saves to ./snapshot.zip",
+		},
+		{
+			name:  "tab-indented line is left untouched even when over width",
+			line:  "\tlstk az group list extra words past the width",
+			width: 10,
+			want:  "\tlstk az group list extra words past the width",
+		},
+		{
+			name:  "length equal to width is left untouched",
+			line:  "ab cd",
+			width: 5,
+			want:  "ab cd",
+		},
+		{
+			name:  "wraps when one rune over width",
+			line:  "ab cde",
+			width: 5,
+			want:  "ab\ncde",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := wrapLine(tt.line, tt.width); got != tt.want {
+				t.Fatalf("wrapLine(%q, %d)\n got: %q\nwant: %q", tt.line, tt.width, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapTextPreservesBlankLines(t *testing.T) {
+	// Width-independent so the test never depends on the ambient terminal size.
+	in := "Start emulator and services.\n\nHost variables are forwarded."
+	got := wrapText(in)
+	if strings.Count(got, "\n\n") != strings.Count(in, "\n\n") {
+		t.Fatalf("wrapText changed the blank-line structure\n got: %q\nin:   %q", got, in)
+	}
+}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -24,11 +24,9 @@ func newResetCmd(cfg *env.Env) *cobra.Command {
 		Short: "Reset emulator state",
 		Long: `Reset the running emulator's in-memory state.
 
-All resources created in the emulator (S3 buckets, Lambda functions, etc.) are
-discarded. The emulator keeps running; only its state is cleared.
+All resources created in the emulator (S3 buckets, Lambda functions, etc.) are discarded. The emulator keeps running; only its state is cleared.
 
-To wipe the on-disk volume (certificates, persistence data, cached tools)
-instead, stop the emulator and run "lstk volume clear".`,
+To wipe the on-disk volume (certificates, persistence data, cached tools) instead, stop the emulator and run "lstk volume clear".`,
 		PreRunE: initConfig(nil),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appConfig, err := config.Get()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -15,8 +15,7 @@ func newStartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 		Short: "Start emulator",
 		Long: `Start emulator and services.
 
-Host environment variables prefixed with LOCALSTACK_ (and the CI variable) are
-forwarded to the emulator container.`,
+Host environment variables prefixed with LOCALSTACK_ are forwarded to the emulator.`,
 		PreRunE: initConfig(&firstRun),
 		RunE: func(c *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)


### PR DESCRIPTION
Command help text was hard-wrapped in the Go source (e.g. `lstk start`'s `Long` broke mid-sentence between two string lines). That froze the break at a single width: a stubby first line on wide terminals, ragged re-wrapping on narrow ones, and — because `lstk docs` generates man/markdown straight from the raw `Long` — the hard break leaked into the generated docs too. This grew out of #277, which added the `LOCALSTACK_` env-var forwarding note and hit exactly this problem.

| BEFORE | AFTER |
|--------|--------|
| <img width="866" height="375" alt="Screenshot 2026-06-04 at 00 09 07" src="https://github.com/user-attachments/assets/259e1e0b-60e4-4e96-92a2-72c3ddfa56f4" /> | <img width="866" height="375" alt="Screenshot 2026-06-04 at 00 31 57" src="https://github.com/user-attachments/assets/48630c2b-4c4e-4318-a736-fd628f32f74a" /> | 
| <img width="528" height="532" alt="Screenshot 2026-06-04 at 00 32 26" src="https://github.com/user-attachments/assets/fea27493-ff67-454a-8bc6-529a287b1df9" /> | <img width="528" height="532" alt="Screenshot 2026-06-04 at 00 32 13" src="https://github.com/user-attachments/assets/fcd45bea-f9d3-4bbd-9f54-010bcdf17c22" /> |