### PR TITLE
Add .claude/worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ completions/
 manpages/
 
 .idea
+.claude/worktrees/


### PR DESCRIPTION
Ignores temporary worktree directories under `.claude/worktrees/` so they don't show up as untracked files.