### PR TITLE
docs: snapshot commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Environment variables:
 
 - `lstk snapshot save [destination]` — export state to a local `.zip` or a named cloud snapshot.
 - `lstk snapshot load REF` — restore state, starting the emulator first if needed; `--merge` controls how snapshot state combines with running state (`account-region-merge` (default), `overwrite`, `service-merge`).
+- `lstk snapshot list` — list cloud snapshots on the LocalStack platform. Lists only snapshots you created by default; pass `--all` to include every snapshot in your organization. Cloud-only; requires auth.
 - `lstk snapshot remove REF` — delete a cloud snapshot. Cloud-only; local files are never deleted by the CLI. Prompts for confirmation in interactive mode; `--force` is required to skip the prompt in non-interactive mode.
 
 A REF is parsed by helpers in `internal/snapshot/destination.go`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,20 @@ Environment variables:
 - `LOCALSTACK_AUTH_TOKEN` - Auth token (skips browser login if set)
 - `LSTK_OTEL=1` - Enables OpenTelemetry trace export (disabled by default); when enabled, standard `OTEL_EXPORTER_OTLP_*` env vars are respected by the SDK. Requires an OTLP-compatible backend to receive and visualize telemetry — for local development, `make otel` starts one (UI at http://localhost:16686).
 
+# Snapshots
+
+`lstk snapshot` captures and restores the running emulator's state (AWS emulator only). Domain logic lives in `internal/snapshot/`; `cmd/snapshot.go` is wiring + output-mode selection.
+
+- `lstk snapshot save [destination]` — export state to a local `.zip` or a named cloud snapshot.
+- `lstk snapshot load REF` — restore state, starting the emulator first if needed; `--merge` controls how snapshot state combines with running state (`account-region-merge` (default), `overwrite`, `service-merge`).
+- `lstk snapshot remove REF` — delete a cloud snapshot. Cloud-only; local files are never deleted by the CLI. Prompts for confirmation in interactive mode; `--force` is required to skip the prompt in non-interactive mode.
+
+A REF is parsed by helpers in `internal/snapshot/destination.go`:
+- **local file** — absolute/relative path; `.zip` is appended if omitted.
+- **cloud snapshot** — `pod:` prefix (e.g. `pod:my-baseline`), stored on the LocalStack platform. Requires auth (`LOCALSTACK_AUTH_TOKEN` or `lstk login`).
+
+`ParseDestination` (save), `ParseSource` (load), and `ParseRemovable` (remove) share pod-name validation; `ParseRemovable` rejects local paths so the CLI cannot delete local files.
+
 # Code Style
 
 - Don't add comments for self-explanatory code. Only comment when the "why" isn't obvious from the code itself.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ lstk snapshot save pod:my-baseline
 # Load a snapshot back into the running emulator
 lstk snapshot load pod:my-baseline
 
+# List cloud snapshots on the LocalStack platform (--all for the whole organization)
+lstk snapshot list
+
 # Delete a cloud snapshot (prompts for confirmation; --force to skip)
 lstk snapshot remove pod:my-baseline
 
@@ -242,6 +245,10 @@ lstk snapshot save pod:my-baseline
 
 # Load (starts the emulator first if needed)
 lstk snapshot load pod:my-baseline
+
+# List cloud snapshots — only your own by default, --all for the whole organization
+lstk snapshot list
+lstk snapshot list --all
 
 # Remove — cloud snapshots only; local files are never deleted by the CLI
 lstk snapshot remove pod:my-baseline          # prompts for confirmation

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Running `lstk` will automatically handle configuration setup and start LocalStac
 - **Interactive TUI** — a Bubble Tea-powered terminal UI shown in an interactive terminal for commands like `start`, `login`, `status`, etc.
 - **Plain output** for CI/CD and scripting (auto-detected in non-interactive environments or forced with `--non-interactive`)
 - **Log streaming** — tail emulator logs in real-time with `--follow`; use `--verbose` to show all logs without filtering
+- **Snapshots** — save, load, and remove emulator state as local files or named cloud snapshots (`pod:` prefix)
 - **Browser-based login** — authenticate via browser and store credentials securely in the system keyring
 - **AWS CLI profile** — optionally configure a `localstack` profile in `~/.aws/` after start
 - **Self-update** — check for and install the latest `lstk` release with `lstk update`
@@ -211,7 +212,43 @@ lstk setup azure
 # Run Azure CLI commands against LocalStack
 lstk az group list
 
+# Save emulator state to a local file
+lstk snapshot save ./my-snapshot.zip
+
+# Save emulator state as a named cloud snapshot on the LocalStack platform
+lstk snapshot save pod:my-baseline
+
+# Load a snapshot back into the running emulator
+lstk snapshot load pod:my-baseline
+
+# Delete a cloud snapshot (prompts for confirmation; --force to skip)
+lstk snapshot remove pod:my-baseline
+
 ```
+
+## Snapshots
+
+Snapshots capture the running emulator's state so you can restore it later.
+
+A snapshot reference is either a **local file** or a **cloud snapshot**:
+
+- **Local file** — an absolute or relative path. A `.zip` extension is added if omitted.
+- **Cloud snapshot** — a name with the `pod:` prefix (e.g. `pod:my-baseline`), stored on the LocalStack platform. Requires authentication (`LOCALSTACK_AUTH_TOKEN` or `lstk login`).
+
+```bash
+# Save (local or cloud)
+lstk snapshot save ./my-snapshot.zip
+lstk snapshot save pod:my-baseline
+
+# Load (starts the emulator first if needed)
+lstk snapshot load pod:my-baseline
+
+# Remove — cloud snapshots only; local files are never deleted by the CLI
+lstk snapshot remove pod:my-baseline          # prompts for confirmation
+lstk snapshot remove pod:my-baseline --force  # skip the prompt (required in non-interactive mode)
+```
+
+`lstk snapshot load` supports merge strategies via `--merge` (`account-region-merge` (default), `overwrite`, `service-merge`) to control how snapshot state combines with running state.
 
 ## Reporting bugs
 


### PR DESCRIPTION
## Summary

Documents the `snapshot` subcommands, which previously had no user- or agent-facing docs (only in-CLI `--help` text):

- `lstk snapshot save` (local file and `pod:` cloud snapshot)
- `lstk snapshot load` (with `--merge` strategies)
- `lstk snapshot list` (cloud snapshots; `--all` for the whole organization)
- `lstk snapshot remove` (cloud-only, confirmation + `--force`)

Changes:
- **README.md** — Features bullet, Usage examples, and a dedicated **Snapshots** section explaining local vs. cloud refs.
- **CLAUDE.md / AGENTS.md** (AGENTS.md is a symlink to CLAUDE.md) — a **Snapshots** section covering the subcommands, domain-package location (`internal/snapshot/`), and the `ParseDestination`/`ParseSource`/`ParseRemovable` helpers. Closes a pre-existing gap: `save`/`load` were never documented in these files either.

## Note

This PR documents commands whose implementations are not all merged yet:
- `snapshot remove` — implementation in #281
- `snapshot list` — implementation in #285

:warning: do not merge before `snapshot remove` (#281) and `snapshot list` (#285) ship.