### PR TITLE
docs: start non-AWS emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ To see which config file is currently in use:
 lstk config path
 ```
 
+### Choosing an emulator
+
+`lstk` starts the AWS emulator by default. To run the Snowflake or Azure emulator instead, either select it interactively when prompted at start, or set the `type` in your config:
+
+```toml
+[[containers]]
+type = "azure"   # or "snowflake"
+port = "4566"
+```
+
+The chosen emulator must be running before you set up or use its CLI integration below.
+
 You can also configure cloud CLI integration:
 
 ```bash
@@ -90,7 +102,7 @@ lstk setup aws    # localstack profile in ~/.aws/
 lstk setup azure  # isolated Azure CLI config for `lstk az` (requires the Azure CLI)
 ```
 
-After `lstk setup azure`, run Azure CLI commands against LocalStack with `lstk az`:
+After starting the Azure emulator and running `lstk setup azure`, run Azure CLI commands against LocalStack with `lstk az`:
 
 ```bash
 lstk az group list
@@ -116,7 +128,7 @@ port = "4566"    # Host port the emulator will be accessible on
 ```
 
 **Fields:**
-- `type`: emulator type; only `"aws"` is supported for now
+- `type`: emulator type; one of `"aws"`, `"snowflake"`, or `"azure"`
 - `tag`: Docker image tag for LocalStack (e.g. `"latest"`, `"4.14.0"`); useful for pinning a version
 - `port`: port LocalStack listens on (default `4566`)
 - `volume`: (optional) host directory for persistent emulator state (default: OS cache dir)


### PR DESCRIPTION
## Summary

Fixes two README gaps around Azure (and Snowflake) emulator support:

1. **Stale field doc** — the Configuration "Fields" list claimed `type` only supports `"aws"`, contradicting the line directly above it and the code (`SelectableEmulatorTypes = [aws, snowflake, azure]`). Now lists all three.
2. **Missing prerequisite** — the README jumped straight to `lstk setup azure` / `lstk az`, but both require a running Azure emulator and nothing explained how to start one. Adds a "Choosing an emulator" subsection showing how to select Snowflake/Azure (interactively or via `type` in config), and clarifies the emulator must be running before CLI setup.

