### PR TITLE
Show emulator selector until one is selected

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 		Use:     "lstk",
 		Short:   "LocalStack CLI",
 		Long:    "lstk is the command-line interface for LocalStack.",
-		PreRunE: initConfig(&firstRun),
+		PreRunE: initConfigDeferCreate(&firstRun),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
@@ -210,8 +210,13 @@ func startEmulator(ctx context.Context, rt runtime.Runtime, cfg *env.Env, tel *t
 		})
 	}
 	update.NotifyUpdate(ctx, sink, update.NotifyOptions{GitHubToken: cfg.GitHubToken})
-	_, err = container.Start(ctx, rt, sink, opts, false)
-	return err
+	if _, err = container.Start(ctx, rt, sink, opts, false); err != nil {
+		return err
+	}
+	if firstRun {
+		return config.EnsureCreated()
+	}
+	return nil
 }
 
 // instrumentCommands walks the Cobra command tree and wraps every RunE with telemetry emission.
@@ -310,6 +315,14 @@ func newLogger() (log.Logger, func(), error) {
 }
 
 func initConfig(firstRun *bool) func(*cobra.Command, []string) error {
+	return initConfigWith(firstRun, config.Init)
+}
+
+func initConfigDeferCreate(firstRun *bool) func(*cobra.Command, []string) error {
+	return initConfigWith(firstRun, config.Load)
+}
+
+func initConfigWith(firstRun *bool, load func() (bool, error)) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, _ []string) error {
 		path, err := cmd.Flags().GetString("config")
 		if err != nil {
@@ -318,7 +331,7 @@ func initConfig(firstRun *bool) func(*cobra.Command, []string) error {
 		if path != "" {
 			return config.InitFromPath(path)
 		}
-		isFirstRun, err := config.Init()
+		isFirstRun, err := load()
 		if firstRun != nil {
 			*firstRun = isFirstRun
 		}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -16,7 +16,7 @@ func newStartCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.
 		Long: `Start emulator and services.
 
 Host environment variables prefixed with LOCALSTACK_ are forwarded to the emulator.`,
-		PreRunE: initConfig(&firstRun),
+		PreRunE: initConfigDeferCreate(&firstRun),
 		RunE: func(c *cobra.Command, args []string) error {
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,9 +52,8 @@ func InitFromPath(path string) error {
 	return loadConfig(path)
 }
 
-// Init loads the config file, searching the standard paths. If no config file
-// exists, it creates one from the default template and returns firstRun=true.
-func Init() (firstRun bool, err error) {
+// Load reads config.toml without creating it; Init creates on first run.
+func Load() (firstRun bool, err error) {
 	viper.Reset()
 	setDefaults()
 	viper.SetConfigName(configName)
@@ -70,45 +69,57 @@ func Init() (firstRun bool, err error) {
 
 	if err := viper.ReadInConfig(); err != nil {
 		var notFoundErr viper.ConfigFileNotFoundError
-		if !errors.As(err, &notFoundErr) {
-			if used := viper.ConfigFileUsed(); filepath.Ext(used) == ".yaml" || filepath.Ext(used) == ".yml" {
-				return false, fmt.Errorf("%s is from an old lstk version; lstk now uses TOML format — remove it or replace it with a config.toml file", used)
-			}
-			return false, fmt.Errorf("failed to read config file: %w", err)
+		if errors.As(err, &notFoundErr) {
+			return true, nil
 		}
-
-		// No config found anywhere, create one using creation policy.
-		creationDir, err := configCreationDir()
-		if err != nil {
-			return false, err
+		if used := viper.ConfigFileUsed(); filepath.Ext(used) == ".yaml" || filepath.Ext(used) == ".yml" {
+			return false, fmt.Errorf("%s is from an old lstk version; lstk now uses TOML format — remove it or replace it with a config.toml file", used)
 		}
-
-		if err := os.MkdirAll(creationDir, 0755); err != nil {
-			return false, fmt.Errorf("failed to create config directory: %w", err)
-		}
-
-		configPath := filepath.Join(creationDir, configFileName)
-		f, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
-		if err != nil {
-			if errors.Is(err, os.ErrExist) {
-				return false, loadConfig(configPath)
-			}
-			return false, fmt.Errorf("failed to create config file: %w", err)
-		}
-		_, writeErr := f.WriteString(defaultConfigTemplate)
-		closeErr := f.Close()
-		if writeErr != nil {
-			_ = os.Remove(configPath)
-			return false, fmt.Errorf("failed to write config file: %w", writeErr)
-		}
-		if closeErr != nil {
-			_ = os.Remove(configPath)
-			return false, fmt.Errorf("failed to close config file: %w", closeErr)
-		}
-
-		return true, loadConfig(configPath)
+		return false, fmt.Errorf("failed to read config file: %w", err)
 	}
 	return false, nil
+}
+
+func Init() (firstRun bool, err error) {
+	firstRun, err = Load()
+	if err != nil || !firstRun {
+		return firstRun, err
+	}
+	return true, EnsureCreated()
+}
+
+func EnsureCreated() error {
+	if resolvedConfigPath() != "" {
+		return nil
+	}
+
+	creationDir, err := configCreationDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(creationDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	configPath := filepath.Join(creationDir, configFileName)
+	f, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return loadConfig(configPath)
+		}
+		return fmt.Errorf("failed to create config file: %w", err)
+	}
+	_, writeErr := f.WriteString(defaultConfigTemplate)
+	closeErr := f.Close()
+	if writeErr != nil {
+		_ = os.Remove(configPath)
+		return fmt.Errorf("failed to write config file: %w", writeErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(configPath)
+		return fmt.Errorf("failed to close config file: %w", closeErr)
+	}
+	return loadConfig(configPath)
 }
 
 func resolvedConfigPath() string {
@@ -117,7 +128,11 @@ func resolvedConfigPath() string {
 
 func Set(key string, value any) error {
 	viper.Set(key, value)
-	return setInFile(viper.ConfigFileUsed(), key, value)
+	path := resolvedConfigPath()
+	if path == "" {
+		return nil // no config file yet; keep in memory only
+	}
+	return setInFile(path, key, value)
 }
 
 // setInFile inserts or updates a single "section.field" key in the TOML config

--- a/internal/container/select.go
+++ b/internal/container/select.go
@@ -45,6 +45,9 @@ func SelectEmulator(
 		}
 	}
 
+	if err := config.EnsureCreated(); err != nil {
+		return nil, fmt.Errorf("failed to create config file: %w", err)
+	}
 	if err := config.SetEmulatorType(selected); err != nil {
 		return nil, fmt.Errorf("failed to set emulator type: %w", err)
 	}

--- a/test/integration/emulator_select_test.go
+++ b/test/integration/emulator_select_test.go
@@ -244,6 +244,55 @@ func TestFirstRunNonInteractiveEmitsDefaultEmulatorNote(t *testing.T) {
 	assert.Contains(t, stdout, "Configured with default emulator", "non-interactive first run should note the default emulator")
 }
 
+// A first run that fails before doing any work (no Docker) leaves no config, so
+// the next run is still a first run and shows the selector instead of defaulting.
+func TestEmulatorSelectionReappearsAfterFailedFirstRun(t *testing.T) {
+	requireDocker(t)
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	tmpHome := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpHome, ".config"), 0755))
+	base := env.Environ(testEnvWithHome(tmpHome, tmpHome)).With(env.DisableEvents, "1")
+
+	configPath, _, err := runLstk(t, testContext(t), "", base, "config", "path")
+	require.NoError(t, err)
+	require.NoFileExists(t, configPath)
+
+	noDocker := base.With(env.Key("DOCKER_HOST"), "unix:///var/run/docker-does-not-exist.sock")
+	stdout, _, runErr := runLstk(t, testContext(t), "", noDocker, "--non-interactive")
+	require.Error(t, runErr, "first run should fail when Docker is unavailable")
+	assert.Contains(t, stdout, "Docker is not available")
+	require.NoFileExists(t, configPath, "a run that fails before doing any work must not create a config")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "start")
+	cmd.Env = base
+
+	ptmx, err := pty.Start(cmd)
+	require.NoError(t, err, "failed to start lstk in PTY")
+	defer func() { _ = ptmx.Close() }()
+
+	out := &syncBuffer{}
+	outputCh := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(out, ptmx)
+		close(outputCh)
+	}()
+
+	require.Eventually(t, func() bool {
+		return bytes.Contains(out.Bytes(), []byte("Which emulator would you like to use?"))
+	}, 10*time.Second, 100*time.Millisecond,
+		"emulator selection prompt should reappear after a first run that failed before selection")
+
+	cancel()
+	<-outputCh
+}
+
 func TestFirstRunChecksDockerBeforeAuthAndSelection(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Running `lstk start` shows a "Which emulator?" picker on first run. It was tied to "config file just created" — but the config is written before the Docker check, so a first run with no Docker created the config and used up the picker. Start Docker, rerun, and the picker never came back: you were stuck on the AWS default.

Now config creation is deferred until the run actually does something. A run that fails early (e.g. no Docker) writes nothing, so the next run still shows the picker.

Closes PRO-305.
