### PR TITLE
Refactor: reuse TableEvent for snapshot list output

### DIFF
--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -84,15 +84,10 @@ type PodSnapshotSavedEvent struct {
 	Size     int64
 }
 
-// PodSnapshotEntry holds display metadata for a single Cloud Pod in a list.
-type PodSnapshotEntry struct {
-	Name        string
-	Version     int
-	LastChanged *time.Time
-}
-
-type SnapshotListEvent struct {
-	Pods []PodSnapshotEntry
+// DeferredEvent wraps another event so that the TUI renders it after the interface
+// exits rather than inline. Plain sinks format the inner event immediately.
+type DeferredEvent struct {
+	Inner Event
 }
 
 type SnapshotLoadedEvent struct {
@@ -119,8 +114,8 @@ func (InstanceInfoEvent) sealedEvent()     {}
 func (TableEvent) sealedEvent()            {}
 func (ResourceSummaryEvent) sealedEvent()  {}
 func (PodSnapshotSavedEvent) sealedEvent()   {}
+func (DeferredEvent) sealedEvent()           {}
 func (SnapshotLoadedEvent) sealedEvent()     {}
-func (SnapshotListEvent) sealedEvent()       {}
 func (PodSnapshotRemovedEvent) sealedEvent() {}
 func (ContainerStatusEvent) sealedEvent()  {}
 func (ProgressEvent) sealedEvent()         {}

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -44,8 +44,8 @@ func FormatEventLine(event Event) (string, bool) {
 		return formatPodSnapshotSaved(e), true
 	case SnapshotLoadedEvent:
 		return formatSnapshotLoaded(e), true
-	case SnapshotListEvent:
-		return formatSnapshotList(e)
+	case DeferredEvent:
+		return FormatEventLine(e.Inner)
 	case PodSnapshotRemovedEvent:
 		return formatPodSnapshotRemoved(e), true
 	case AuthCompleteEvent:
@@ -243,30 +243,6 @@ func formatBytes(b int64) string {
 	default:
 		return fmt.Sprintf("%d B", b)
 	}
-}
-
-func formatSnapshotList(e SnapshotListEvent) (string, bool) {
-	if len(e.Pods) == 0 {
-		return formatMessageEvent(MessageEvent{Severity: SeverityNote, Text: "No snapshots found"}), true
-	}
-	noun := "snapshots"
-	if len(e.Pods) == 1 {
-		noun = "snapshot"
-	}
-	summary := fmt.Sprintf("~ %d %s", len(e.Pods), noun)
-	rows := make([][]string, len(e.Pods))
-	for i, p := range e.Pods {
-		lastChanged := "-"
-		if p.LastChanged != nil {
-			lastChanged = p.LastChanged.UTC().Format("2006-01-02 15:04 UTC")
-		}
-		rows[i] = []string{p.Name, fmt.Sprintf("%d", p.Version), lastChanged}
-	}
-	table := formatTableWidth(TableEvent{
-		Headers: []string{"Name", "Version", "Last Changed"},
-		Rows:    rows,
-	}, terminalWidth())
-	return summary + "\n\n" + table, true
 }
 
 func formatTable(e TableEvent) (string, bool) {

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 )
 
-func ptrTime(t time.Time) *time.Time { return &t }
-
 func TestFormatEventLine(t *testing.T) {
 	t.Parallel()
 
@@ -239,32 +237,29 @@ func TestFormatEventLine(t *testing.T) {
 			wantOK: true,
 		},
 
-		// snapshot list events
+		// deferred events — plain sinks render the inner event immediately
 		{
-			name: "snapshot list with pods",
-			event: SnapshotListEvent{
-				Pods: []PodSnapshotEntry{
-					{Name: "baseline-q2", Version: 3, LastChanged: ptrTime(time.Date(2026, 4, 15, 14, 32, 0, 0, time.UTC))},
-					{Name: "infra-2026-04", Version: 1, LastChanged: nil},
-				},
-			},
-			want:   "~ 2 snapshots\n\n  NAME           VERSION  LAST CHANGED\n  baseline-q2    3        2026-04-15 14:32 UTC\n  infra-2026-04  1        -",
-			wantOK: true,
-		},
-		{
-			name:   "snapshot list empty",
-			event:  SnapshotListEvent{Pods: []PodSnapshotEntry{}},
+			name:   "deferred note message",
+			event:  DeferredEvent{Inner: MessageEvent{Severity: SeverityNote, Text: "No snapshots found"}},
 			want:   "> Note: No snapshots found",
 			wantOK: true,
 		},
 		{
-			name: "snapshot list singular count",
-			event: SnapshotListEvent{
-				Pods: []PodSnapshotEntry{
-					{Name: "my-pod", Version: 2, LastChanged: ptrTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))},
+			name:   "deferred secondary message",
+			event:  DeferredEvent{Inner: MessageEvent{Severity: SeveritySecondary, Text: "~ 2 snapshots"}},
+			want:   "~ 2 snapshots",
+			wantOK: true,
+		},
+		{
+			name: "deferred table",
+			event: DeferredEvent{Inner: TableEvent{
+				Headers: []string{"Name", "Version", "Last Changed"},
+				Rows: [][]string{
+					{"baseline-q2", "3", "2026-04-15 14:32 UTC"},
+					{"infra-2026-04", "1", "-"},
 				},
-			},
-			want:   "~ 1 snapshot\n\n  NAME    VERSION  LAST CHANGED\n  my-pod  2        2026-01-01 00:00 UTC",
+			}},
+			want:   "  NAME           VERSION  LAST CHANGED\n  baseline-q2    3        2026-04-15 14:32 UTC\n  infra-2026-04  1        -",
 			wantOK: true,
 		},
 

--- a/internal/snapshot/list.go
+++ b/internal/snapshot/list.go
@@ -47,7 +47,7 @@ func List(ctx context.Context, lister CloudPodLister, authToken, creator string,
 		}
 		rows[i] = []string{p.Name, fmt.Sprintf("%d", p.Version), lastChanged}
 	}
-	sink.Emit(output.DeferredEvent{Inner: output.MessageEvent{Severity: output.SeveritySecondary, Text: fmt.Sprintf("~ %d %s", len(pods), noun)}})
+	sink.Emit(output.DeferredEvent{Inner: output.MessageEvent{Severity: output.SeveritySecondary, Text: fmt.Sprintf("~ %d %s\n", len(pods), noun)}})
 	sink.Emit(output.DeferredEvent{Inner: output.TableEvent{
 		Headers: []string{"Name", "Version", "Last Changed"},
 		Rows:    rows,

--- a/internal/snapshot/list.go
+++ b/internal/snapshot/list.go
@@ -31,14 +31,26 @@ func List(ctx context.Context, lister CloudPodLister, authToken, creator string,
 		return fmt.Errorf("list snapshots: %w", err)
 	}
 
-	entries := make([]output.PodSnapshotEntry, len(pods))
-	for i, p := range pods {
-		entries[i] = output.PodSnapshotEntry{
-			Name:        p.Name,
-			Version:     p.Version,
-			LastChanged: p.LastChanged,
-		}
+	if len(pods) == 0 {
+		sink.Emit(output.DeferredEvent{Inner: output.MessageEvent{Severity: output.SeverityNote, Text: "No snapshots found"}})
+		return nil
 	}
-	sink.Emit(output.SnapshotListEvent{Pods: entries})
+	noun := "snapshots"
+	if len(pods) == 1 {
+		noun = "snapshot"
+	}
+	rows := make([][]string, len(pods))
+	for i, p := range pods {
+		lastChanged := "-"
+		if p.LastChanged != nil {
+			lastChanged = p.LastChanged.UTC().Format("2006-01-02 15:04 UTC")
+		}
+		rows[i] = []string{p.Name, fmt.Sprintf("%d", p.Version), lastChanged}
+	}
+	sink.Emit(output.DeferredEvent{Inner: output.MessageEvent{Severity: output.SeveritySecondary, Text: fmt.Sprintf("~ %d %s", len(pods), noun)}})
+	sink.Emit(output.DeferredEvent{Inner: output.TableEvent{
+		Headers: []string{"Name", "Version", "Last Changed"},
+		Rows:    rows,
+	}})
 	return nil
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -304,9 +304,12 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.addSuccessLines(line)
 		}
 		return a, nil
-	case output.SnapshotListEvent:
+	case output.DeferredEvent:
 		if line, ok := output.FormatEventLine(msg); ok {
-			a.deferredOutput = line
+			if a.deferredOutput != "" {
+				a.deferredOutput += "\n"
+			}
+			a.deferredOutput += line
 		}
 		return a, nil
 	default:

--- a/test/integration/snapshot_list_test.go
+++ b/test/integration/snapshot_list_test.go
@@ -82,6 +82,8 @@ func TestSnapshotListSuccessWithoutDocker(t *testing.T) {
 	called, creator, _ := cap.get()
 	require.True(t, called, "the platform list endpoint should have been called")
 	assert.Equal(t, "me", creator, "default list should send ?creator=me")
+	assert.Contains(t, stdout, "~ 2 snapshots")
+	assert.Contains(t, stdout, "~ 2 snapshots\n\n  NAME")
 	assert.Contains(t, stdout, "NAME")
 	assert.Contains(t, stdout, "VERSION")
 	assert.Contains(t, stdout, "LAST CHANGED")
@@ -106,6 +108,7 @@ func TestSnapshotListAllFlag(t *testing.T) {
 	called, creator, _ := cap.get()
 	require.True(t, called, "the platform list endpoint should have been called")
 	assert.Equal(t, "", creator, "--all should omit the ?creator param")
+	assert.Contains(t, stdout, "~ 1 snapshot")
 	assert.Contains(t, stdout, "org-pod")
 }
 


### PR DESCRIPTION
Follow up from https://github.com/localstack/lstk/pull/285#discussion_r3373552315.

Reuses TableEvent for snapshot list output.