### PR TITLE
List snapshots without requiring a running emulator

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/container"
 	"github.com/localstack/lstk/internal/emulator/aws"
@@ -71,7 +72,7 @@ func newSnapshotCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cob
 	}
 	cmd.AddCommand(newSnapshotSaveCmd(cfg))
 	cmd.AddCommand(newSnapshotLoadCmd(cfg, tel, logger))
-	cmd.AddCommand(newSnapshotListCmd(cfg))
+	cmd.AddCommand(newSnapshotListCmd(cfg, logger))
 	cmd.AddCommand(newSnapshotRemoveCmd(cfg))
 	return cmd
 }
@@ -232,20 +233,20 @@ func resolveSnapshotDeps(ctx context.Context, cfg *env.Env) (rt runtime.Runtime,
 	return rt, aws.NewClient(), host, []config.ContainerConfig{awsContainer}, appConfig, nil
 }
 
-func newSnapshotListCmd(cfg *env.Env) *cobra.Command {
+func newSnapshotListCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List Cloud Pod snapshots available on the LocalStack platform",
 		Long:    snapshotListLong,
 		Args:    cobra.NoArgs,
 		PreRunE: initConfig(nil),
-		RunE:    runSnapshotList(cfg),
+		RunE:    runSnapshotList(cfg, logger),
 	}
 	cmd.Flags().Bool("all", false, "List all snapshots in the organisation")
 	return cmd
 }
 
-func runSnapshotList(cfg *env.Env) func(*cobra.Command, []string) error {
+func runSnapshotList(cfg *env.Env, logger log.Logger) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		all, err := cmd.Flags().GetBool("all")
 		if err != nil {
@@ -255,15 +256,12 @@ func runSnapshotList(cfg *env.Env) func(*cobra.Command, []string) error {
 		if all {
 			creator = ""
 		}
-		rt, client, host, containers, _, err := resolveSnapshotDeps(cmd.Context(), cfg)
-		if err != nil {
-			return err
-		}
+		client := api.NewPlatformClient(cfg.APIEndpoint, logger)
 		if isInteractiveMode(cfg) {
-			return ui.RunSnapshotList(cmd.Context(), rt, containers, client, host, cfg.AuthToken, creator)
+			return ui.RunSnapshotList(cmd.Context(), client, cfg.AuthToken, creator)
 		}
 		sink := output.NewPlainSink(os.Stdout)
-		return snapshot.List(cmd.Context(), rt, containers, client, host, cfg.AuthToken, creator, sink)
+		return snapshot.List(cmd.Context(), client, cfg.AuthToken, creator, sink)
 	}
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3,10 +3,12 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -108,6 +110,12 @@ type LicenseError struct {
 
 func (e *LicenseError) Error() string {
 	return fmt.Sprintf("license validation failed: %s", e.Message)
+}
+
+type CloudPod struct {
+	Name        string
+	Version     int
+	LastChanged *time.Time
 }
 
 type PlatformClient struct {
@@ -337,5 +345,53 @@ func (c *PlatformClient) GetLicense(ctx context.Context, licReq *LicenseRequest)
 			Detail:  detail,
 		}
 	}
+}
+
+func (c *PlatformClient) ListCloudPods(ctx context.Context, authToken, creator string) ([]CloudPod, error) {
+	u := c.baseURL + "/v1/cloudpods"
+	if creator != "" {
+		// "" lists all org pods; "me" filters server-side to the current user.
+		u += "?" + url.Values{"creator": {creator}}.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(":"+authToken)))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cloud pods: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			c.logger.Error("failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("failed to list cloud pods: status %d: %s", resp.StatusCode, strings.TrimSpace(string(detail)))
+	}
+
+	// The platform returns a bare top-level array, not an object wrapping the entries.
+	var raw []struct {
+		PodName    string `json:"pod_name"`
+		MaxVersion int    `json:"max_version"`
+		LastChange *int64 `json:"last_change"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("failed to decode cloud pods response: %w", err)
+	}
+
+	pods := make([]CloudPod, len(raw))
+	for i, p := range raw {
+		pods[i] = CloudPod{Name: p.PodName, Version: p.MaxVersion}
+		if p.LastChange != nil {
+			t := time.Unix(*p.LastChange, 0)
+			pods[i].LastChanged = &t
+		}
+	}
+	return pods, nil
 }
 

--- a/internal/emulator/aws/client.go
+++ b/internal/emulator/aws/client.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/localstack/lstk/internal/snapshot"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -292,55 +291,6 @@ func (c *Client) LoadPodSnapshot(ctx context.Context, host, podName, authToken, 
 		return nil, fmt.Errorf("reading response: %w", err)
 	}
 	return services, nil
-}
-
-func (c *Client) ListPodSnapshots(ctx context.Context, host, authToken, creator string) ([]snapshot.PodSnapshot, error) {
-	u := fmt.Sprintf("http://%s/_localstack/pods", host)
-	if creator != "" {
-		u += "?creator=" + creator
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, bytes.NewReader([]byte("{}")))
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if authToken != "" {
-		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(":"+authToken)))
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("connect to LocalStack: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("list pods failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var response struct {
-		CloudPods []struct {
-			PodName    string `json:"pod_name"`
-			MaxVersion int    `json:"max_version"`
-			LastChange *int64 `json:"last_change"`
-		} `json:"cloudpods"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
-	}
-	pods := make([]snapshot.PodSnapshot, len(response.CloudPods))
-	for i, p := range response.CloudPods {
-		pods[i] = snapshot.PodSnapshot{
-			Name:    p.PodName,
-			Version: p.MaxVersion,
-		}
-		if p.LastChange != nil {
-			t := time.Unix(*p.LastChange, 0)
-			pods[i].LastChanged = &t
-		}
-	}
-	return pods, nil
 }
 
 func (c *Client) SavePodSnapshot(ctx context.Context, host, podName, authToken string) (snapshot.PodSaveResult, error) {

--- a/internal/snapshot/list.go
+++ b/internal/snapshot/list.go
@@ -3,51 +3,29 @@ package snapshot
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/localstack/lstk/internal/config"
-	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/output"
-	"github.com/localstack/lstk/internal/runtime"
 )
 
-// PodSnapshot holds metadata for a single Cloud Pod returned by the list endpoint.
-type PodSnapshot struct {
-	Name        string
-	Version     int
-	LastChanged *time.Time
+type CloudPodLister interface {
+	ListCloudPods(ctx context.Context, authToken, creator string) ([]api.CloudPod, error)
 }
 
-// PodLister retrieves available Cloud Pods from the running LocalStack instance.
-type PodLister interface {
-	ListPodSnapshots(ctx context.Context, host, authToken, creator string) ([]PodSnapshot, error)
-}
-
-// List fetches Cloud Pod snapshots from the running emulator and emits a SnapshotListEvent.
-// creator filters results server-side: "me" for the current user's pods, "" for all org pods.
-func List(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, lister PodLister, host, authToken, creator string, sink output.Sink) error {
-	if err := rt.IsHealthy(ctx); err != nil {
-		rt.EmitUnhealthyError(sink, err)
-		return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
-	}
-
-	runningContainers, err := container.RunningEmulators(ctx, rt, containers)
-	if err != nil {
-		return fmt.Errorf("checking emulator status: %w", err)
-	}
-	if len(runningContainers) == 0 {
+func List(ctx context.Context, lister CloudPodLister, authToken, creator string, sink output.Sink) error {
+	if authToken == "" {
 		sink.Emit(output.ErrorEvent{
-			Title: "LocalStack is not running",
+			Title: "Authentication required to list snapshots",
 			Actions: []output.ErrorAction{
-				{Label: "Start LocalStack:", Value: "lstk"},
-				{Label: "See help:", Value: "lstk -h"},
+				{Label: "Log in:", Value: "lstk login"},
+				{Label: "Or set a token:", Value: "export LOCALSTACK_AUTH_TOKEN=<token>"},
 			},
 		})
-		return output.NewSilentError(fmt.Errorf("LocalStack is not running"))
+		return output.NewSilentError(fmt.Errorf("authentication required: no auth token"))
 	}
 
 	sink.Emit(output.SpinnerStart("Fetching snapshots"))
-	pods, err := lister.ListPodSnapshots(ctx, host, authToken, creator)
+	pods, err := lister.ListCloudPods(ctx, authToken, creator)
 	sink.Emit(output.SpinnerStop())
 	if err != nil {
 		return fmt.Errorf("list snapshots: %w", err)

--- a/internal/ui/run_snapshot_list.go
+++ b/internal/ui/run_snapshot_list.go
@@ -3,14 +3,12 @@ package ui
 import (
 	"context"
 
-	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/output"
-	"github.com/localstack/lstk/internal/runtime"
 	"github.com/localstack/lstk/internal/snapshot"
 )
 
-func RunSnapshotList(parentCtx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, lister snapshot.PodLister, host, authToken, creator string) error {
+func RunSnapshotList(parentCtx context.Context, lister snapshot.CloudPodLister, authToken, creator string) error {
 	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
-		return snapshot.List(ctx, rt, containers, lister, host, authToken, creator, sink)
+		return snapshot.List(ctx, lister, authToken, creator, sink)
 	})
 }

--- a/test/integration/snapshot_list_test.go
+++ b/test/integration/snapshot_list_test.go
@@ -1,10 +1,12 @@
 package integration_test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/localstack/lstk/test/integration/env"
@@ -12,15 +14,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockPodListServer returns a test server that handles GET /_localstack/pods.
-// pods is the list of cloud pod objects to return regardless of query params.
-func mockPodListServer(t *testing.T, pods []map[string]any) *httptest.Server {
+// listCapture records what the platform list endpoint received. It is written from the
+// httptest handler goroutine and read from the test body, so access is mutex-guarded.
+type listCapture struct {
+	mu      sync.Mutex
+	called  bool
+	creator string
+	auth    string
+}
+
+func (c *listCapture) record(r *http.Request) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.called = true
+	c.creator = r.URL.Query().Get("creator")
+	c.auth = r.Header.Get("Authorization")
+}
+
+func (c *listCapture) get() (called bool, creator, auth string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.called, c.creator, c.auth
+}
+
+func mockCloudPodsServer(t *testing.T, pods []map[string]any, cap *listCapture) *httptest.Server {
 	t.Helper()
-	body, err := json.Marshal(map[string]any{"cloudpods": pods})
+	body, err := json.Marshal(pods)
 	require.NoError(t, err)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/_localstack/pods" && r.Method == http.MethodGet {
+		if r.URL.Path == "/v1/cloudpods" && r.Method == http.MethodGet {
+			if cap != nil {
+				cap.record(r)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(body)
@@ -32,45 +58,29 @@ func mockPodListServer(t *testing.T, pods []map[string]any) *httptest.Server {
 	return srv
 }
 
-// mockPodListServerCapture returns a test server that records the creator query param on each request.
-func mockPodListServerCapture(t *testing.T, pods []map[string]any, creatorOut *string) *httptest.Server {
+func listEnv(t *testing.T, srv *httptest.Server, token string) []string {
 	t.Helper()
-	body, err := json.Marshal(map[string]any{"cloudpods": pods})
-	require.NoError(t, err)
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/_localstack/pods" && r.Method == http.MethodGet {
-			*creatorOut = r.URL.Query().Get("creator")
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(body)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	t.Cleanup(srv.Close)
-	return srv
+	return env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.APIEndpoint, srv.URL).
+		With(env.AuthToken, token)
 }
 
-func TestSnapshotListSuccess(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
+func TestSnapshotListSuccessWithoutDocker(t *testing.T) {
+	t.Parallel()
 
-	ctx := testContext(t)
-	startTestContainer(t, ctx)
-
-	var creator string
-	srv := mockPodListServerCapture(t, []map[string]any{
+	var cap listCapture
+	srv := mockCloudPodsServer(t, []map[string]any{
 		{"pod_name": "baseline-q2", "max_version": 3, "last_change": 1744727520},
 		{"pod_name": "infra-2026-04", "max_version": 1, "last_change": nil},
-	}, &creator)
+	}, &cap)
 
-	stdout, stderr, err := runLstk(t, ctx, t.TempDir(),
-		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.LocalStackHost, lsHost(srv)),
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(),
+		listEnv(t, srv, "test-token"),
 		"--non-interactive", "snapshot", "list",
 	)
 	require.NoError(t, err, "lstk snapshot list failed: %s", stderr)
+	called, creator, _ := cap.get()
+	require.True(t, called, "the platform list endpoint should have been called")
 	assert.Equal(t, "me", creator, "default list should send ?creator=me")
 	assert.Contains(t, stdout, "NAME")
 	assert.Contains(t, stdout, "VERSION")
@@ -81,67 +91,77 @@ func TestSnapshotListSuccess(t *testing.T) {
 }
 
 func TestSnapshotListAllFlag(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
+	t.Parallel()
 
-	ctx := testContext(t)
-	startTestContainer(t, ctx)
-
-	var creator string
-	srv := mockPodListServerCapture(t, []map[string]any{
+	var cap listCapture
+	srv := mockCloudPodsServer(t, []map[string]any{
 		{"pod_name": "org-pod", "max_version": 1, "last_change": nil},
-	}, &creator)
+	}, &cap)
 
-	stdout, stderr, err := runLstk(t, ctx, t.TempDir(),
-		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.LocalStackHost, lsHost(srv)),
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(),
+		listEnv(t, srv, "test-token"),
 		"--non-interactive", "snapshot", "list", "--all",
 	)
 	require.NoError(t, err, "lstk snapshot list --all failed: %s", stderr)
-	assert.Equal(t, "", creator, "--all should omit ?creator param")
+	called, creator, _ := cap.get()
+	require.True(t, called, "the platform list endpoint should have been called")
+	assert.Equal(t, "", creator, "--all should omit the ?creator param")
 	assert.Contains(t, stdout, "org-pod")
 }
 
 func TestSnapshotListEmpty(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
+	t.Parallel()
 
-	ctx := testContext(t)
-	startTestContainer(t, ctx)
-	srv := mockPodListServer(t, []map[string]any{})
+	srv := mockCloudPodsServer(t, []map[string]any{}, nil)
 
-	stdout, stderr, err := runLstk(t, ctx, t.TempDir(),
-		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.LocalStackHost, lsHost(srv)),
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(),
+		listEnv(t, srv, "test-token"),
 		"--non-interactive", "snapshot", "list",
 	)
 	require.NoError(t, err, "lstk snapshot list failed: %s", stderr)
 	assert.Contains(t, stdout, "No snapshots found")
 }
 
-func TestSnapshotListEmulatorNotRunning(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
+func TestSnapshotListSendsBasicAuthHeader(t *testing.T) {
+	t.Parallel()
 
-	// Intentionally no startTestContainer: the emulator is not running.
-	ctx := testContext(t)
+	var cap listCapture
+	srv := mockCloudPodsServer(t, []map[string]any{}, &cap)
 
-	stdout, _, err := runLstk(t, ctx, t.TempDir(),
-		env.Environ(testEnvWithHome(t.TempDir(), "")),
+	_, stderr, err := runLstk(t, testContext(t), t.TempDir(),
+		listEnv(t, srv, "test-token"),
+		"--non-interactive", "snapshot", "list",
+	)
+	require.NoError(t, err, "lstk snapshot list failed: %s", stderr)
+	_, _, auth := cap.get()
+	expected := "Basic " + base64.StdEncoding.EncodeToString([]byte(":test-token"))
+	assert.Equal(t, expected, auth, "list should authenticate to the platform with Basic base64(\":\"+token)")
+}
+
+func TestSnapshotListRequiresAuthToken(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("platform must not be called without an auth token; got %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	environ := env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.APIEndpoint, srv.URL).
+		Without(env.AuthToken)
+
+	stdout, _, err := runLstk(t, testContext(t), t.TempDir(),
+		environ,
 		"--non-interactive", "snapshot", "list",
 	)
 	requireExitCode(t, 1, err)
-	assert.Contains(t, stdout, "not running")
+	assert.Contains(t, stdout, "Authentication required")
+	assert.Contains(t, stdout, "lstk login")
 }
 
 func TestSnapshotListServerError(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
-
-	ctx := testContext(t)
-	startTestContainer(t, ctx)
+	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -149,59 +169,25 @@ func TestSnapshotListServerError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	_, stderr, err := runLstk(t, ctx, t.TempDir(),
-		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.LocalStackHost, lsHost(srv)),
+	_, stderr, err := runLstk(t, testContext(t), t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.APIEndpoint, srv.URL).
+			With(env.AuthToken, "test-token"),
 		"--non-interactive", "snapshot", "list",
 	)
 	requireExitCode(t, 1, err)
 	assert.Contains(t, strings.ToLower(stderr), "error")
 }
 
-func TestSnapshotListWithAuthToken(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
-
-	ctx := testContext(t)
-	startTestContainer(t, ctx)
-
-	var receivedAuth string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/_localstack/pods" && r.Method == http.MethodGet {
-			receivedAuth = r.Header.Get("Authorization")
-			body, _ := json.Marshal(map[string]any{"cloudpods": []map[string]any{}})
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(body)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	t.Cleanup(srv.Close)
-
-	_, stderr, err := runLstk(t, ctx, t.TempDir(),
-		env.Environ(testEnvWithHome(t.TempDir(), "")).
-			With(env.LocalStackHost, lsHost(srv)).
-			With(env.AuthToken, "test-token"),
-		"--non-interactive", "snapshot", "list",
-	)
-	require.NoError(t, err, "lstk snapshot list failed: %s", stderr)
-	assert.NotEmpty(t, receivedAuth, "Authorization header should be sent when auth token is set")
-}
-
 func TestSnapshotListInteractive(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
+	t.Parallel()
 
-	ctx := testContext(t)
-	startTestContainer(t, ctx)
-	srv := mockPodListServer(t, []map[string]any{
+	srv := mockCloudPodsServer(t, []map[string]any{
 		{"pod_name": "my-pod", "max_version": 1, "last_change": 1744727520},
-	})
+	}, nil)
 
-	out, err := runLstkInPTY(t, ctx,
-		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.LocalStackHost, lsHost(srv)),
+	out, err := runLstkInPTY(t, testContext(t),
+		listEnv(t, srv, "test-token"),
 		"snapshot", "list",
 	)
 	require.NoError(t, err, "interactive lstk snapshot list failed")


### PR DESCRIPTION
In https://github.com/localstack/lstk/pull/285 we added `snapshot list` to list snapshots.

The previous implementation routed the request through the container's `GET /_localstack/pods`, so it required Docker to be up *and* an emulator running just to read remote metadata. 

That inverts the normal flow and blocks a common use case (browse snapshots, then load one).

| BEFORE (without runtime) | BEFORE (without instance) | AFTER |
|--------|--------|--------|
| <img width="669" height="532" alt="Screenshot 2026-06-10 at 15 11 49" src="https://github.com/user-attachments/assets/d3017629-d5b9-402f-ab57-62e05bf13190" /> | <img width="669" height="532" alt="Screenshot 2026-06-10 at 15 11 58" src="https://github.com/user-attachments/assets/508d524b-f4b7-414c-9fec-7cf3c1ddba4a" /> | <img width="669" height="532" alt="Screenshot 2026-06-10 at 14 15 41" src="https://github.com/user-attachments/assets/38d01a89-ce37-409e-ba7a-55126a9a138f" /> | 