### PR TITLE
Classify agents on every command invocation

### DIFF
--- a/internal/caller/caller.go
+++ b/internal/caller/caller.go
@@ -6,25 +6,40 @@ import (
 	"golang.org/x/term"
 )
 
-type Type string
-
-const (
-	TypeHuman Type = "human"
-	TypeAgent Type = "agent"
-	TypeCI    Type = "ci"
-)
-
-const (
-	MethodAgentEnv = "agent_env"
-	MethodCIEnv    = "ci_env"
-	MethodTTY      = "tty"
-	MethodNoTTY    = "no_tty"
-)
-
 type Classification struct {
-	Type     Type
-	Identity string
-	Method   string
+	AgentIdentity string
+	CIIdentity    string
+	Interactive   bool
+}
+
+func (c Classification) IsAgent() bool { return c.AgentIdentity != "" }
+
+func (c Classification) IsCI() bool { return c.CIIdentity != "" }
+
+func (c Classification) IsHuman() bool { return c.AgentIdentity == "" && c.CIIdentity == "" }
+
+func (c Classification) CallerType() string {
+	switch {
+	case c.AgentIdentity != "":
+		return "agent"
+	case c.CIIdentity != "":
+		return "ci"
+	default:
+		return "human"
+	}
+}
+
+func (c Classification) DetectionMethod() string {
+	switch {
+	case c.AgentIdentity != "":
+		return "agent_env"
+	case c.CIIdentity != "":
+		return "ci_env"
+	case c.Interactive:
+		return "tty"
+	default:
+		return "no_tty"
+	}
 }
 
 type detector struct {
@@ -90,16 +105,11 @@ func newClassifier(getenv func(string) string, isInteractive func() bool) *Class
 }
 
 func (c *Classifier) Classify() Classification {
-	if id := match(c.agentDetectors, c.getenv); id != "" {
-		return Classification{Type: TypeAgent, Identity: id, Method: MethodAgentEnv}
+	return Classification{
+		AgentIdentity: match(c.agentDetectors, c.getenv),
+		CIIdentity:    match(c.ciDetectors, c.getenv),
+		Interactive:   c.isInteractive(),
 	}
-	if id := match(c.ciDetectors, c.getenv); id != "" {
-		return Classification{Type: TypeCI, Identity: id, Method: MethodCIEnv}
-	}
-	if c.isInteractive() {
-		return Classification{Type: TypeHuman, Method: MethodTTY}
-	}
-	return Classification{Type: TypeHuman, Method: MethodNoTTY}
 }
 
 func match(detectors []detector, getenv func(string) string) string {

--- a/internal/caller/caller.go
+++ b/internal/caller/caller.go
@@ -1,0 +1,118 @@
+package caller
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+type Type string
+
+const (
+	TypeHuman Type = "human"
+	TypeAgent Type = "agent"
+	TypeCI    Type = "ci"
+)
+
+const (
+	MethodAgentEnv = "agent_env"
+	MethodCIEnv    = "ci_env"
+	MethodTTY      = "tty"
+	MethodNoTTY    = "no_tty"
+)
+
+type Classification struct {
+	Type     Type
+	Identity string
+	Method   string
+}
+
+type detector struct {
+	identity string
+	envVars  []string
+}
+
+func agentDetectors() []detector {
+	return []detector{
+		{"cursor", []string{"CURSOR_TRACE_ID"}},
+		{"cursor-cli", []string{"CURSOR_AGENT"}},
+		{"gemini", []string{"GEMINI_CLI"}},
+		{"codex", []string{"CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID"}},
+		{"cowork", []string{"CLAUDE_CODE_IS_COWORK"}},
+		{"claude-code", []string{"CLAUDECODE", "CLAUDE_CODE"}},
+		{"github-copilot", []string{"COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN"}},
+		{"goose", []string{"GOOSE_PROVIDER"}},
+		{"augment", []string{"AUGMENT_AGENT"}},
+		{"opencode", []string{"OPENCODE", "OPENCODE_CALLER", "OPENCODE_CLIENT"}},
+		{"antigravity", []string{"ANTIGRAVITY_AGENT"}},
+		{"devin", []string{"__COG_BASHRC_SOURCED", "__COG_SHELL_INTEGRATION_SCRIPT", "__COG_SKIP_PYENV"}},
+		{"replit", []string{"REPL_ID"}},
+	}
+}
+
+func ciDetectors() []detector {
+	return []detector{
+		{"github-actions", []string{"GITHUB_ACTIONS"}},
+		{"gitlab-ci", []string{"GITLAB_CI"}},
+		{"circleci", []string{"CIRCLECI"}},
+		{"travis-ci", []string{"TRAVIS"}},
+		{"jenkins", []string{"JENKINS_URL"}},
+		{"buildkite", []string{"BUILDKITE"}},
+		{"azure-pipelines", []string{"TF_BUILD"}},
+		{"bitbucket-pipelines", []string{"BITBUCKET_BUILD_NUMBER"}},
+		{"teamcity", []string{"TEAMCITY_VERSION"}},
+		{"appveyor", []string{"APPVEYOR"}},
+		{"drone", []string{"DRONE"}},
+		{"aws-codebuild", []string{"CODEBUILD_BUILD_ID"}},
+		{"semaphore", []string{"SEMAPHORE"}},
+		{"ci", []string{"CI", "CONTINUOUS_INTEGRATION"}},
+	}
+}
+
+type Classifier struct {
+	agentDetectors []detector
+	ciDetectors    []detector
+	getenv         func(string) string
+	isInteractive  func() bool
+}
+
+func New() *Classifier {
+	return newClassifier(os.Getenv, stdinStdoutAreTerminal)
+}
+
+func newClassifier(getenv func(string) string, isInteractive func() bool) *Classifier {
+	return &Classifier{
+		agentDetectors: agentDetectors(),
+		ciDetectors:    ciDetectors(),
+		getenv:         getenv,
+		isInteractive:  isInteractive,
+	}
+}
+
+func (c *Classifier) Classify() Classification {
+	if id := match(c.agentDetectors, c.getenv); id != "" {
+		return Classification{Type: TypeAgent, Identity: id, Method: MethodAgentEnv}
+	}
+	if id := match(c.ciDetectors, c.getenv); id != "" {
+		return Classification{Type: TypeCI, Identity: id, Method: MethodCIEnv}
+	}
+	if c.isInteractive() {
+		return Classification{Type: TypeHuman, Method: MethodTTY}
+	}
+	return Classification{Type: TypeHuman, Method: MethodNoTTY}
+}
+
+func match(detectors []detector, getenv func(string) string) string {
+	for _, d := range detectors {
+		for _, v := range d.envVars {
+			if getenv(v) != "" {
+				return d.identity
+			}
+		}
+	}
+	return ""
+}
+
+func stdinStdoutAreTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/internal/caller/caller_test.go
+++ b/internal/caller/caller_test.go
@@ -44,9 +44,10 @@ func TestClassify_Agents(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := classifyWith(tc.env, true)
-			assert.Equal(t, TypeAgent, got.Type)
-			assert.Equal(t, tc.identity, got.Identity)
-			assert.Equal(t, MethodAgentEnv, got.Method)
+			assert.Equal(t, tc.identity, got.AgentIdentity)
+			assert.True(t, got.IsAgent())
+			assert.Equal(t, "agent", got.CallerType())
+			assert.Equal(t, "agent_env", got.DetectionMethod())
 		})
 	}
 }
@@ -54,16 +55,19 @@ func TestClassify_Agents(t *testing.T) {
 func TestClassify_CoworkBeatsClaudeCode(t *testing.T) {
 	t.Parallel()
 	got := classifyWith(map[string]string{"CLAUDE_CODE_IS_COWORK": "1", "CLAUDE_CODE": "1"}, true)
-	assert.Equal(t, TypeAgent, got.Type)
-	assert.Equal(t, "cowork", got.Identity)
+	assert.Equal(t, "cowork", got.AgentIdentity)
+	assert.True(t, got.IsAgent())
 }
 
-func TestClassify_AgentBeatsCI(t *testing.T) {
+func TestClassify_AgentAndCIAreOrthogonal(t *testing.T) {
 	t.Parallel()
 	got := classifyWith(map[string]string{"CLAUDECODE": "1", "GITHUB_ACTIONS": "true", "CI": "true"}, false)
-	assert.Equal(t, TypeAgent, got.Type)
-	assert.Equal(t, "claude-code", got.Identity)
-	assert.Equal(t, MethodAgentEnv, got.Method)
+	assert.Equal(t, "claude-code", got.AgentIdentity, "the agent is recorded")
+	assert.Equal(t, "github-actions", got.CIIdentity, "the CI host is recorded alongside the agent, not discarded")
+	assert.True(t, got.IsAgent())
+	assert.True(t, got.IsCI())
+	assert.Equal(t, "agent", got.CallerType(), "agent takes precedence for single-label segmentation")
+	assert.Equal(t, "agent_env", got.DetectionMethod())
 }
 
 func TestClassify_CISystems(t *testing.T) {
@@ -92,9 +96,11 @@ func TestClassify_CISystems(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := classifyWith(tc.env, false)
-			assert.Equal(t, TypeCI, got.Type)
-			assert.Equal(t, tc.identity, got.Identity)
-			assert.Equal(t, MethodCIEnv, got.Method)
+			assert.Equal(t, tc.identity, got.CIIdentity)
+			assert.True(t, got.IsCI())
+			assert.Empty(t, got.AgentIdentity)
+			assert.Equal(t, "ci", got.CallerType())
+			assert.Equal(t, "ci_env", got.DetectionMethod())
 		})
 	}
 }
@@ -102,29 +108,32 @@ func TestClassify_CISystems(t *testing.T) {
 func TestClassify_SpecificCIBeatsGenericCI(t *testing.T) {
 	t.Parallel()
 	got := classifyWith(map[string]string{"GITHUB_ACTIONS": "true", "CI": "true"}, false)
-	assert.Equal(t, TypeCI, got.Type)
-	assert.Equal(t, "github-actions", got.Identity)
+	assert.Equal(t, "github-actions", got.CIIdentity)
 }
 
 func TestClassify_HumanInteractive(t *testing.T) {
 	t.Parallel()
 	got := classifyWith(map[string]string{}, true)
-	assert.Equal(t, TypeHuman, got.Type)
-	assert.Empty(t, got.Identity)
-	assert.Equal(t, MethodTTY, got.Method)
+	assert.True(t, got.IsHuman())
+	assert.Empty(t, got.AgentIdentity)
+	assert.Empty(t, got.CIIdentity)
+	assert.Equal(t, "human", got.CallerType())
+	assert.Equal(t, "tty", got.DetectionMethod())
 }
 
 func TestClassify_HumanNonInteractive(t *testing.T) {
 	t.Parallel()
 	got := classifyWith(map[string]string{"SOME_UNRELATED_VAR": "1"}, false)
-	assert.Equal(t, TypeHuman, got.Type)
-	assert.Empty(t, got.Identity)
-	assert.Equal(t, MethodNoTTY, got.Method)
+	assert.True(t, got.IsHuman())
+	assert.Empty(t, got.AgentIdentity)
+	assert.Empty(t, got.CIIdentity)
+	assert.Equal(t, "human", got.CallerType())
+	assert.Equal(t, "no_tty", got.DetectionMethod())
 }
 
 func TestClassify_EmptyEnvValueIsNotSet(t *testing.T) {
 	t.Parallel()
 	got := classifyWith(map[string]string{"CLAUDECODE": ""}, true)
-	assert.Equal(t, TypeHuman, got.Type)
-	assert.Empty(t, got.Identity)
+	assert.True(t, got.IsHuman())
+	assert.Empty(t, got.AgentIdentity)
 }

--- a/internal/caller/caller_test.go
+++ b/internal/caller/caller_test.go
@@ -1,0 +1,130 @@
+package caller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func classifyWith(env map[string]string, interactive bool) Classification {
+	getenv := func(k string) string { return env[k] }
+	return newClassifier(getenv, func() bool { return interactive }).Classify()
+}
+
+func TestClassify_Agents(t *testing.T) {
+	cases := []struct {
+		name     string
+		env      map[string]string
+		identity string
+	}{
+		{"cursor", map[string]string{"CURSOR_TRACE_ID": "abc"}, "cursor"},
+		{"cursor-cli", map[string]string{"CURSOR_AGENT": "1"}, "cursor-cli"},
+		{"gemini", map[string]string{"GEMINI_CLI": "1"}, "gemini"},
+		{"codex-sandbox", map[string]string{"CODEX_SANDBOX": "1"}, "codex"},
+		{"codex-ci", map[string]string{"CODEX_CI": "1"}, "codex"},
+		{"codex-thread", map[string]string{"CODEX_THREAD_ID": "t"}, "codex"},
+		{"cowork", map[string]string{"CLAUDE_CODE_IS_COWORK": "1"}, "cowork"},
+		{"claudecode", map[string]string{"CLAUDECODE": "1"}, "claude-code"},
+		{"claude_code", map[string]string{"CLAUDE_CODE": "1"}, "claude-code"},
+		{"copilot-model", map[string]string{"COPILOT_MODEL": "gpt-5"}, "github-copilot"},
+		{"copilot-allow", map[string]string{"COPILOT_ALLOW_ALL": "true"}, "github-copilot"},
+		{"copilot-token", map[string]string{"COPILOT_GITHUB_TOKEN": "tok"}, "github-copilot"},
+		{"goose", map[string]string{"GOOSE_PROVIDER": "openai"}, "goose"},
+		{"augment", map[string]string{"AUGMENT_AGENT": "1"}, "augment"},
+		{"opencode", map[string]string{"OPENCODE": "1"}, "opencode"},
+		{"opencode-caller", map[string]string{"OPENCODE_CALLER": "1"}, "opencode"},
+		{"opencode-client", map[string]string{"OPENCODE_CLIENT": "1"}, "opencode"},
+		{"antigravity", map[string]string{"ANTIGRAVITY_AGENT": "1"}, "antigravity"},
+		{"devin-bashrc", map[string]string{"__COG_BASHRC_SOURCED": "1"}, "devin"},
+		{"devin-shell", map[string]string{"__COG_SHELL_INTEGRATION_SCRIPT": "/p"}, "devin"},
+		{"devin-pyenv", map[string]string{"__COG_SKIP_PYENV": "1"}, "devin"},
+		{"replit", map[string]string{"REPL_ID": "r123"}, "replit"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyWith(tc.env, true)
+			assert.Equal(t, TypeAgent, got.Type)
+			assert.Equal(t, tc.identity, got.Identity)
+			assert.Equal(t, MethodAgentEnv, got.Method)
+		})
+	}
+}
+
+func TestClassify_CoworkBeatsClaudeCode(t *testing.T) {
+	t.Parallel()
+	got := classifyWith(map[string]string{"CLAUDE_CODE_IS_COWORK": "1", "CLAUDE_CODE": "1"}, true)
+	assert.Equal(t, TypeAgent, got.Type)
+	assert.Equal(t, "cowork", got.Identity)
+}
+
+func TestClassify_AgentBeatsCI(t *testing.T) {
+	t.Parallel()
+	got := classifyWith(map[string]string{"CLAUDECODE": "1", "GITHUB_ACTIONS": "true", "CI": "true"}, false)
+	assert.Equal(t, TypeAgent, got.Type)
+	assert.Equal(t, "claude-code", got.Identity)
+	assert.Equal(t, MethodAgentEnv, got.Method)
+}
+
+func TestClassify_CISystems(t *testing.T) {
+	cases := []struct {
+		name     string
+		env      map[string]string
+		identity string
+	}{
+		{"github-actions", map[string]string{"GITHUB_ACTIONS": "true"}, "github-actions"},
+		{"gitlab-ci", map[string]string{"GITLAB_CI": "true"}, "gitlab-ci"},
+		{"circleci", map[string]string{"CIRCLECI": "true"}, "circleci"},
+		{"travis-ci", map[string]string{"TRAVIS": "true"}, "travis-ci"},
+		{"jenkins", map[string]string{"JENKINS_URL": "http://ci"}, "jenkins"},
+		{"buildkite", map[string]string{"BUILDKITE": "true"}, "buildkite"},
+		{"azure-pipelines", map[string]string{"TF_BUILD": "True"}, "azure-pipelines"},
+		{"bitbucket", map[string]string{"BITBUCKET_BUILD_NUMBER": "42"}, "bitbucket-pipelines"},
+		{"teamcity", map[string]string{"TEAMCITY_VERSION": "2024"}, "teamcity"},
+		{"appveyor", map[string]string{"APPVEYOR": "true"}, "appveyor"},
+		{"drone", map[string]string{"DRONE": "true"}, "drone"},
+		{"aws-codebuild", map[string]string{"CODEBUILD_BUILD_ID": "id"}, "aws-codebuild"},
+		{"semaphore", map[string]string{"SEMAPHORE": "true"}, "semaphore"},
+		{"generic-ci", map[string]string{"CI": "true"}, "ci"},
+		{"continuous-integration", map[string]string{"CONTINUOUS_INTEGRATION": "true"}, "ci"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyWith(tc.env, false)
+			assert.Equal(t, TypeCI, got.Type)
+			assert.Equal(t, tc.identity, got.Identity)
+			assert.Equal(t, MethodCIEnv, got.Method)
+		})
+	}
+}
+
+func TestClassify_SpecificCIBeatsGenericCI(t *testing.T) {
+	t.Parallel()
+	got := classifyWith(map[string]string{"GITHUB_ACTIONS": "true", "CI": "true"}, false)
+	assert.Equal(t, TypeCI, got.Type)
+	assert.Equal(t, "github-actions", got.Identity)
+}
+
+func TestClassify_HumanInteractive(t *testing.T) {
+	t.Parallel()
+	got := classifyWith(map[string]string{}, true)
+	assert.Equal(t, TypeHuman, got.Type)
+	assert.Empty(t, got.Identity)
+	assert.Equal(t, MethodTTY, got.Method)
+}
+
+func TestClassify_HumanNonInteractive(t *testing.T) {
+	t.Parallel()
+	got := classifyWith(map[string]string{"SOME_UNRELATED_VAR": "1"}, false)
+	assert.Equal(t, TypeHuman, got.Type)
+	assert.Empty(t, got.Identity)
+	assert.Equal(t, MethodNoTTY, got.Method)
+}
+
+func TestClassify_EmptyEnvValueIsNotSet(t *testing.T) {
+	t.Parallel()
+	got := classifyWith(map[string]string{"CLAUDECODE": ""}, true)
+	assert.Equal(t, TypeHuman, got.Type)
+	assert.Empty(t, got.Identity)
+}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -688,8 +688,8 @@ func filterHostEnv(envList []string) []string {
 }
 
 func agentEnv(cl caller.Classification) []string {
-	if cl.Type == caller.TypeAgent && cl.Identity != "" {
-		return []string{"AI_AGENT=" + cl.Identity}
+	if cl.AgentIdentity != "" {
+		return []string{"AI_AGENT=" + cl.AgentIdentity}
 	}
 	return nil
 }

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -18,6 +18,7 @@ import (
 	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/auth"
 	"github.com/localstack/lstk/internal/awsconfig"
+	"github.com/localstack/lstk/internal/caller"
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/emulator/snowflake"
 	"github.com/localstack/lstk/internal/endpoint"
@@ -72,6 +73,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 	tel := opts.Telemetry
 
 	hostEnv := filterHostEnv(os.Environ())
+	agentEnvVars := agentEnv(caller.New().Classify())
 
 	containers := make([]runtime.ContainerConfig, len(opts.Containers))
 	for i, c := range opts.Containers {
@@ -107,6 +109,7 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		)
 
 		env = append(env, hostEnv...)
+		env = append(env, agentEnvVars...)
 
 		if opts.Persist {
 			env = append(env, envPersistenceEnabled)
@@ -682,6 +685,13 @@ func filterHostEnv(envList []string) []string {
 		}
 	}
 	return out
+}
+
+func agentEnv(cl caller.Classification) []string {
+	if cl.Type == caller.TypeAgent && cl.Identity != "" {
+		return []string{"AI_AGENT=" + cl.Identity}
+	}
+	return nil
 }
 
 func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/localstack/lstk/internal/caller"
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/log"
 	"github.com/localstack/lstk/internal/output"
@@ -324,6 +325,16 @@ func TestFilterHostEnv(t *testing.T) {
 	assert.NotContains(t, got, "PATH=/usr/bin")
 	assert.NotContains(t, got, "HOME=/home/user")
 	assert.NotContains(t, got, "CI_PIPELINE=foo", "only exact CI= must be forwarded, not CI_*")
+}
+
+func TestAgentEnv(t *testing.T) {
+	assert.Equal(t, []string{"AI_AGENT=claude-code"},
+		agentEnv(caller.Classification{Type: caller.TypeAgent, Identity: "claude-code", Method: caller.MethodAgentEnv}),
+		"a detected agent is forwarded as AI_AGENT")
+	assert.Nil(t, agentEnv(caller.Classification{Type: caller.TypeHuman, Method: caller.MethodTTY}),
+		"a human start forwards no AI_AGENT")
+	assert.Nil(t, agentEnv(caller.Classification{Type: caller.TypeCI, Identity: "github-actions", Method: caller.MethodCIEnv}),
+		"CI is carried by the forwarded CI variable, not AI_AGENT")
 }
 
 func TestStartContainers_SnowflakeLicenseError(t *testing.T) {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -329,12 +329,15 @@ func TestFilterHostEnv(t *testing.T) {
 
 func TestAgentEnv(t *testing.T) {
 	assert.Equal(t, []string{"AI_AGENT=claude-code"},
-		agentEnv(caller.Classification{Type: caller.TypeAgent, Identity: "claude-code", Method: caller.MethodAgentEnv}),
+		agentEnv(caller.Classification{AgentIdentity: "claude-code"}),
 		"a detected agent is forwarded as AI_AGENT")
-	assert.Nil(t, agentEnv(caller.Classification{Type: caller.TypeHuman, Method: caller.MethodTTY}),
+	assert.Nil(t, agentEnv(caller.Classification{Interactive: true}),
 		"a human start forwards no AI_AGENT")
-	assert.Nil(t, agentEnv(caller.Classification{Type: caller.TypeCI, Identity: "github-actions", Method: caller.MethodCIEnv}),
-		"CI is carried by the forwarded CI variable, not AI_AGENT")
+	assert.Nil(t, agentEnv(caller.Classification{CIIdentity: "github-actions"}),
+		"CI without an agent is carried by the forwarded CI variable, not AI_AGENT")
+	assert.Equal(t, []string{"AI_AGENT=claude-code"},
+		agentEnv(caller.Classification{AgentIdentity: "claude-code", CIIdentity: "github-actions"}),
+		"an agent running inside CI still forwards its AI_AGENT identity")
 }
 
 func TestStartContainers_SnowflakeLicenseError(t *testing.T) {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"context"
-	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -21,9 +20,7 @@ type Client struct {
 	machineID string
 	authToken string
 
-	callerType      string
-	callerIdentity  string
-	detectionMethod string
+	classification caller.Classification
 
 	endpoint string
 	flushFn  func(ctx context.Context, endpoint string, events []eventBody)
@@ -50,14 +47,12 @@ func New(endpoint string, disabled bool) *Client {
 
 func newClient(endpoint string, cl caller.Classification) *Client {
 	return &Client{
-		enabled:         true,
-		sessionID:       uuid.NewString(),
-		callerType:      string(cl.Type),
-		callerIdentity:  cl.Identity,
-		detectionMethod: cl.Method,
-		endpoint:        endpoint,
-		flushFn:         spawnDetachedFlusher,
-		pending:         make([]eventBody, 0, pendingCap),
+		enabled:        true,
+		sessionID:      uuid.NewString(),
+		classification: cl,
+		endpoint:       endpoint,
+		flushFn:        spawnDetachedFlusher,
+		pending:        make([]eventBody, 0, pendingCap),
 	}
 }
 
@@ -81,17 +76,20 @@ func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) 
 		return
 	}
 
-	enriched := make(map[string]any, len(payload)+5)
+	enriched := make(map[string]any, len(payload)+8)
 	for k, v := range payload {
 		enriched[k] = v
 	}
 	enriched["os"] = runtime.GOOS
 	enriched["arch"] = runtime.GOARCH
-	_, enriched["is_ci"] = os.LookupEnv("CI")
-	enriched["caller_type"] = c.callerType
-	enriched["detection_method"] = c.detectionMethod
-	if c.callerIdentity != "" {
-		enriched["caller_identity"] = c.callerIdentity
+	enriched["caller_type"] = c.classification.CallerType()
+	enriched["detection_method"] = c.classification.DetectionMethod()
+	enriched["is_ci"] = c.classification.IsCI()
+	if c.classification.AgentIdentity != "" {
+		enriched["agent_identity"] = c.classification.AgentIdentity
+	}
+	if c.classification.CIIdentity != "" {
+		enriched["ci_identity"] = c.classification.CIIdentity
 	}
 	if c.machineID != "" {
 		enriched["machine_id"] = c.machineID

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/localstack/lstk/internal/caller"
 )
 
 // pendingCap bounds in-memory events; on overflow the oldest is dropped.
@@ -18,6 +20,10 @@ type Client struct {
 	sessionID string
 	machineID string
 	authToken string
+
+	callerType      string
+	callerIdentity  string
+	detectionMethod string
 
 	endpoint string
 	flushFn  func(ctx context.Context, endpoint string, events []eventBody)
@@ -39,12 +45,19 @@ func New(endpoint string, disabled bool) *Client {
 	if disabled {
 		return &Client{enabled: false}
 	}
+	return newClient(endpoint, caller.New().Classify())
+}
+
+func newClient(endpoint string, cl caller.Classification) *Client {
 	return &Client{
-		enabled:   true,
-		sessionID: uuid.NewString(),
-		endpoint:  endpoint,
-		flushFn:   spawnDetachedFlusher,
-		pending:   make([]eventBody, 0, pendingCap),
+		enabled:         true,
+		sessionID:       uuid.NewString(),
+		callerType:      string(cl.Type),
+		callerIdentity:  cl.Identity,
+		detectionMethod: cl.Method,
+		endpoint:        endpoint,
+		flushFn:         spawnDetachedFlusher,
+		pending:         make([]eventBody, 0, pendingCap),
 	}
 }
 
@@ -75,6 +88,11 @@ func (c *Client) Emit(ctx context.Context, name string, payload map[string]any) 
 	enriched["os"] = runtime.GOOS
 	enriched["arch"] = runtime.GOARCH
 	_, enriched["is_ci"] = os.LookupEnv("CI")
+	enriched["caller_type"] = c.callerType
+	enriched["detection_method"] = c.detectionMethod
+	if c.callerIdentity != "" {
+		enriched["caller_identity"] = c.callerIdentity
+	}
 	if c.machineID != "" {
 		enriched["machine_id"] = c.machineID
 	}

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -29,7 +28,7 @@ func TestClose_IsIdempotent(t *testing.T) {
 
 func TestEmit_EnrichesPayloadIntoPending(t *testing.T) {
 	t.Parallel()
-	c := newClient("http://localhost", caller.Classification{Type: caller.TypeHuman, Method: caller.MethodTTY})
+	c := newClient("http://localhost", caller.Classification{Interactive: true})
 	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
 
 	require.Len(t, c.pending, 1)
@@ -44,36 +43,48 @@ func TestEmit_EnrichesPayloadIntoPending(t *testing.T) {
 	assert.Equal(t, "lstk start", payload["cmd"])
 	assert.Equal(t, runtime.GOOS, payload["os"])
 	assert.Equal(t, runtime.GOARCH, payload["arch"])
-	_, isCI := os.LookupEnv("CI")
-	assert.Equal(t, isCI, payload["is_ci"])
+	assert.Equal(t, false, payload["is_ci"])
 	assert.Equal(t, "human", payload["caller_type"])
-	assert.Equal(t, caller.MethodTTY, payload["detection_method"])
-	assert.NotContains(t, payload, "caller_identity")
+	assert.Equal(t, "tty", payload["detection_method"])
+	assert.NotContains(t, payload, "agent_identity")
+	assert.NotContains(t, payload, "ci_identity")
 }
 
-func TestEmit_IncludesCallerIdentityWhenPresent(t *testing.T) {
+func TestEmit_IncludesAgentIdentityWhenPresent(t *testing.T) {
 	t.Parallel()
-	c := newClient("http://localhost", caller.Classification{
-		Type:     caller.TypeAgent,
-		Identity: "claude-code",
-		Method:   caller.MethodAgentEnv,
-	})
+	c := newClient("http://localhost", caller.Classification{AgentIdentity: "claude-code"})
 	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
 
 	require.Len(t, c.pending, 1)
 	payload, ok := c.pending[0].Payload.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "agent", payload["caller_type"])
-	assert.Equal(t, caller.MethodAgentEnv, payload["detection_method"])
-	assert.Equal(t, "claude-code", payload["caller_identity"])
+	assert.Equal(t, "agent_env", payload["detection_method"])
+	assert.Equal(t, "claude-code", payload["agent_identity"])
+	assert.Equal(t, false, payload["is_ci"])
 }
 
-func TestNew_DisabledClientHasNoClassification(t *testing.T) {
+func TestEmit_AgentInCIRecordsBothAxes(t *testing.T) {
+	t.Parallel()
+	c := newClient("http://localhost", caller.Classification{
+		AgentIdentity: "github-copilot",
+		CIIdentity:    "github-actions",
+	})
+	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
+
+	require.Len(t, c.pending, 1)
+	payload, ok := c.pending[0].Payload.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "agent", payload["caller_type"], "agent takes precedence for segmentation")
+	assert.Equal(t, true, payload["is_ci"], "the CI signal is retained alongside the agent")
+	assert.Equal(t, "github-copilot", payload["agent_identity"])
+	assert.Equal(t, "github-actions", payload["ci_identity"])
+}
+
+func TestNew_DisabledClientIsDisabled(t *testing.T) {
 	t.Parallel()
 	c := New("http://localhost", true)
-	assert.Empty(t, c.callerType)
-	assert.Empty(t, c.callerIdentity)
-	assert.Empty(t, c.detectionMethod)
+	assert.False(t, c.enabled)
 }
 
 func TestEmit_DropsOldestWhenFull(t *testing.T) {

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -15,9 +15,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/localstack/lstk/internal/caller"
 )
 
 func TestClose_IsIdempotent(t *testing.T) {
+	t.Parallel()
 	c := New("http://localhost", false)
 	c.Close()
 	// Second call must not panic.
@@ -25,7 +28,8 @@ func TestClose_IsIdempotent(t *testing.T) {
 }
 
 func TestEmit_EnrichesPayloadIntoPending(t *testing.T) {
-	c := New("http://localhost", false)
+	t.Parallel()
+	c := newClient("http://localhost", caller.Classification{Type: caller.TypeHuman, Method: caller.MethodTTY})
 	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
 
 	require.Len(t, c.pending, 1)
@@ -42,9 +46,38 @@ func TestEmit_EnrichesPayloadIntoPending(t *testing.T) {
 	assert.Equal(t, runtime.GOARCH, payload["arch"])
 	_, isCI := os.LookupEnv("CI")
 	assert.Equal(t, isCI, payload["is_ci"])
+	assert.Equal(t, "human", payload["caller_type"])
+	assert.Equal(t, caller.MethodTTY, payload["detection_method"])
+	assert.NotContains(t, payload, "caller_identity")
+}
+
+func TestEmit_IncludesCallerIdentityWhenPresent(t *testing.T) {
+	t.Parallel()
+	c := newClient("http://localhost", caller.Classification{
+		Type:     caller.TypeAgent,
+		Identity: "claude-code",
+		Method:   caller.MethodAgentEnv,
+	})
+	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
+
+	require.Len(t, c.pending, 1)
+	payload, ok := c.pending[0].Payload.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "agent", payload["caller_type"])
+	assert.Equal(t, caller.MethodAgentEnv, payload["detection_method"])
+	assert.Equal(t, "claude-code", payload["caller_identity"])
+}
+
+func TestNew_DisabledClientHasNoClassification(t *testing.T) {
+	t.Parallel()
+	c := New("http://localhost", true)
+	assert.Empty(t, c.callerType)
+	assert.Empty(t, c.callerIdentity)
+	assert.Empty(t, c.detectionMethod)
 }
 
 func TestEmit_DropsOldestWhenFull(t *testing.T) {
+	t.Parallel()
 	c := New("http://localhost", false)
 	for i := 0; i < pendingCap+5; i++ {
 		c.Emit(context.Background(), "cli_cmd", map[string]any{"i": i})
@@ -56,12 +89,14 @@ func TestEmit_DropsOldestWhenFull(t *testing.T) {
 }
 
 func TestEmit_NoopWhenDisabled(t *testing.T) {
+	t.Parallel()
 	c := New("http://localhost", true)
 	c.Emit(context.Background(), "cli_cmd", map[string]any{"cmd": "lstk start"})
 	assert.Empty(t, c.pending)
 }
 
 func TestClose_HandsOffPendingEventsToFlusher(t *testing.T) {
+	t.Parallel()
 	var (
 		gotEPs []string
 		gotEvs [][]eventBody
@@ -87,6 +122,7 @@ func TestClose_HandsOffPendingEventsToFlusher(t *testing.T) {
 }
 
 func TestClose_SkipsSpawnWhenNoPending(t *testing.T) {
+	t.Parallel()
 	var called bool
 	c := New("http://example.test/events", false)
 	c.flushFn = func(context.Context, string, []eventBody) { called = true }
@@ -96,6 +132,7 @@ func TestClose_SkipsSpawnWhenNoPending(t *testing.T) {
 }
 
 func TestRunFlush_PostsEachEventWithCorrectPayloadAndHeaders(t *testing.T) {
+	t.Parallel()
 	type captured struct {
 		event  map[string]any
 		header http.Header


### PR DESCRIPTION
Tags every command invocation in CLI telemetry so we can answer "are agents using lstk?". Detection is environment-based (the strongest signal) with a TTY fallback for humans, and is attached to every telemetry event. A detected agent is also forwarded into the emulator container as `AI_AGENT`.

Agent and CI are tracked as independent axes — an agent can run inside CI, so each is recorded separately rather than collapsed into one mutually exclusive value. Every event carries `is_ci` plus `agent_identity` / `ci_identity` when detected, and a derived `caller_type` (agent/ci/human) for single-label segmentation. This mirrors the legacy CLI (localstack/localstack-cli-standalone#19), where `is_ci` is its own field independent of agent detection.

See [PRO-276](https://linear.app/localstack/issue/PRO-276/classify-agents-on-every-command-invocation) for more context.

### Notes

- Orthogonal axes — an agent running inside CI is recorded on both (`agent_identity` and `is_ci`/`ci_identity`); `caller_type` derives to `agent` (agent > ci > human) so segmentation stays single-label without discarding the CI signal.
- `is_ci` is sourced from the single caller classifier (14 known CI providers), not a separate bare `CI` env lookup.
- `AI_AGENT` on the container is session-origin — it reflects who started the container, not who makes later calls into it, and is forwarded whenever an agent is detected (including inside CI).
- Detection-only, no free-text override, so no user-supplied value reaches telemetry and no sanitization is needed.
