### PR TITLE
Fix silently ignored error when resolving license file path on logout

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -42,7 +42,10 @@ func newLogoutCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to initialize token storage: %w", err)
 			}
-			licenseFilePath, _ := config.LicenseFilePath()
+			licenseFilePath, err := config.LicenseFilePath()
+			if err != nil {
+				return fmt.Errorf("failed to resolve license file path: %w", err)
+			}
 			a := auth.New(sink, platformClient, tokenStorage, cfg.AuthToken, "", false, licenseFilePath)
 			if err := a.Logout(); err != nil {
 				if errors.Is(err, auth.ErrNotLoggedIn) {


### PR DESCRIPTION
When `os.UserCacheDir()` fails (e.g. in a minimal container environment), the license file path would silently fall back to an empty string, meaning logout couldn't clean up the cached license file.

This change propagates the error to the caller instead, so the failure is surfaced with a clear message rather than ignored.