### PR TITLE
feat: Add `lstk cdk` proxy command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,14 @@ jobs:
         with:
           tofu_wrapper: false
 
+      # Install the AWS CDK CLI so the `lstk cdk` end-to-end tests
+      # (cdk_e2e_test.go) run on the Docker-capable Linux shards. They skip
+      # automatically wherever cdk is absent (macOS/Windows). lstk requires
+      # CDK >= 2.177.0; the latest release satisfies that.
+      - name: Install AWS CDK
+        if: matrix.os == 'ubuntu-latest'
+        run: npm install -g aws-cdk
+
       - name: Run integration tests
         run: make test-integration
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Note: Integration tests require `LOCALSTACK_AUTH_TOKEN` environment variable for
   - `ui/` - Bubble Tea views for interactive output
   - `update/` - Self-update logic: version check via GitHub API, binary/Homebrew/npm update paths, archive extraction
   - `log/` - Internal diagnostic logging (not for user-facing output — use `output/` for that)
-  - `iac/` - Wrappers for third-party infrastructure as code tools, such as Terraform.
+  - `iac/` - Wrappers for third-party infrastructure as code tools, such as Terraform and CDK.
 
 # Logging
 

--- a/README.md
+++ b/README.md
@@ -205,17 +205,14 @@ lstk --non-interactive
 
 **lstk-specific flags** (appear after the `cdk` subcommand):
 - `--region <region>` — Deployment region (default: `us-east-1`)
-- `--account <id>` — Target AWS account ID, 12 digits (default: `test`)
+
+CDK always targets the default LocalStack account 000000000000; there is no --account flag.
 
 **Environment variables:**
 - `LSTK_CDK_CMD` — CDK binary to invoke (default: `cdk`)
 - `AWS_ENDPOINT_URL` — Override the auto-resolved LocalStack endpoint
 - `AWS_ENDPOINT_URL_S3` — Override the auto-derived S3 endpoint
 - `AWS_REGION` — Fallback for `--region` flag
-- `AWS_ACCESS_KEY_ID` — Fallback for `--account` flag
-
-> [!NOTE]
-> If `localhost.localstack.cloud` cannot be resolved (e.g. DNS-rebind protection) lstk falls back to `127.0.0.1`. CDK S3 asset operations (`bootstrap`, asset deploys) need virtual-host addressing and may fail on the loopback fallback — ensure `localhost.localstack.cloud` resolves, or set `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3` to a virtual-host-capable host.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Running `lstk` will automatically handle configuration setup and start LocalStac
 - **Browser-based login** — authenticate via browser and store credentials securely in the system keyring
 - **AWS CLI profile** — optionally configure a `localstack` profile in `~/.aws/` after start
 - **Terraform integration** — proxy Terraform commands to LocalStack with automatic AWS provider endpoint configuration
+- **CDK integration** — proxy AWS CDK commands to LocalStack with automatic endpoint configuration (requires AWS CDK >= 2.177.0)
 - **Self-update** — check for and install the latest `lstk` release with `lstk update`
 - **Shell completions** — bash, zsh, and fish completions included
 
@@ -196,6 +197,26 @@ lstk --non-interactive
 - `AWS_REGION` — Fallback for `--region` flag
 - `AWS_ACCESS_KEY_ID` — Fallback for `--account` flag
 
+### CDK Integration
+
+`lstk cdk` is a proxy that runs AWS CDK commands against LocalStack, pointing the CDK CLI at LocalStack's endpoints via environment variables (so deploys target the running emulator instead of real AWS).
+
+**Requires AWS CDK CLI version 2.177.0 or newer** on your `PATH` (lstk targets LocalStack purely through environment variables, which older CDK versions ignore).
+
+**lstk-specific flags** (appear after the `cdk` subcommand):
+- `--region <region>` — Deployment region (default: `us-east-1`)
+- `--account <id>` — Target AWS account ID, 12 digits (default: `test`)
+
+**Environment variables:**
+- `LSTK_CDK_CMD` — CDK binary to invoke (default: `cdk`)
+- `AWS_ENDPOINT_URL` — Override the auto-resolved LocalStack endpoint
+- `AWS_ENDPOINT_URL_S3` — Override the auto-derived S3 endpoint
+- `AWS_REGION` — Fallback for `--region` flag
+- `AWS_ACCESS_KEY_ID` — Fallback for `--account` flag
+
+> [!NOTE]
+> If `localhost.localstack.cloud` cannot be resolved (e.g. DNS-rebind protection) lstk falls back to `127.0.0.1`. CDK S3 asset operations (`bootstrap`, asset deploys) need virtual-host addressing and may fail on the loopback fallback — ensure `localhost.localstack.cloud` resolves, or set `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3` to a virtual-host-capable host.
+
 ## Usage
 
 ```bash
@@ -264,6 +285,13 @@ lstk terraform --region us-west-2 plan
 
 # Apply Terraform configuration (short form)
 lstk tf apply
+
+# Bootstrap and deploy an AWS CDK app against LocalStack
+lstk cdk bootstrap
+lstk cdk deploy --require-approval never
+
+# Synthesize a CDK app (offline, no running emulator needed)
+lstk cdk synth
 
 ```
 

--- a/cmd/cdk.go
+++ b/cmd/cdk.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/localstack/lstk/internal/endpoint"
+	"github.com/localstack/lstk/internal/env"
+	cdkcli "github.com/localstack/lstk/internal/iac/cdk/cli"
+	"github.com/localstack/lstk/internal/log"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+	"github.com/spf13/cobra"
+)
+
+func newCDKCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
+	// DisableFlagParsing means Cobra won't strip lstk's own flags; PreRunE does
+	// that and stashes the remaining args here for RunE to forward to cdk.
+	var passthrough []string
+	return &cobra.Command{
+		Use:   "cdk [args...]",
+		Short: "Run AWS CDK against LocalStack",
+		Long: `Proxy AWS CDK commands to the real cdk CLI, so deploys target the running emulator instead of real AWS.
+
+Requires the AWS CDK CLI version 2.177.0 or newer on your PATH (lstk targets LocalStack purely through environment variables, which older CDK versions ignore). LocalStack must be running for commands that contact AWS (bootstrap, deploy, destroy, diff, …); offline commands (init, synth, ls, version, doctor) run without it.
+
+lstk-specific flags (must appear before the cdk action):
+  --region <region>    Deployment region (default us-east-1)
+  --account <id>       Target AWS account id, 12 digits (default test)
+
+Supported environment variables:
+  AWS_ENDPOINT_URL      Override the auto-resolved LocalStack endpoint
+  AWS_ENDPOINT_URL_S3   Override the auto-derived S3 endpoint
+  LSTK_CDK_CMD          CDK binary to invoke (default cdk)
+  AWS_REGION            Fallback for --region
+  AWS_ACCESS_KEY_ID     Fallback for --account
+
+Examples:
+  lstk cdk bootstrap
+  lstk cdk --region us-west-2 deploy
+  lstk cdk synth`,
+		DisableFlagParsing: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			var gf globalFlags
+			passthrough, gf = stripGlobalFlags(args)
+			if gf.nonInteractive {
+				cfg.NonInteractive = true
+			}
+			if gf.configPath != "" {
+				if err := cmd.Flags().Set("config", gf.configPath); err != nil {
+					return err
+				}
+			}
+			return initConfig(nil)(cmd, args)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			sink := output.NewPlainSink(os.Stdout)
+
+			if err := rejectPreSubcommandFlags(cmd.CalledAs()); err != nil {
+				return emitValidationError(sink, err)
+			}
+
+			cdkArgs, regionFlag, accountFlag, _, err := stripLeadingIaCFlags(passthrough, false)
+			if err != nil {
+				return emitValidationError(sink, err)
+			}
+
+			region := resolveRegion(regionFlag)
+			account, err := resolveAccount(accountFlag)
+			if err != nil {
+				return emitValidationError(sink, err)
+			}
+
+			awsContainer := resolveAWSContainer()
+
+			// Offline subcommands never contact AWS, so they run without a
+			// running emulator. We still resolve the endpoint (DNS only) and
+			// inject it, so a synth-time context lookup routes to LocalStack.
+			if cdkcli.IsOffline(cdkArgs) {
+				host, _ := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
+				return cdkcli.Run(cmd.Context(), "http://"+host, region, account, sink, logger, cdkArgs)
+			}
+
+			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
+			if err != nil {
+				return err
+			}
+
+			if err := rt.IsHealthy(cmd.Context()); err != nil {
+				rt.EmitUnhealthyError(sink, err)
+				return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
+			}
+
+			if err := requireRunningAWSEmulator(cmd.Context(), rt, sink, awsContainer, "cdk"); err != nil {
+				return err
+			}
+
+			host, dnsOK := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
+			if !dnsOK {
+				// CDK has no env-only lever to force S3 path style, so on the
+				// loopback fallback its S3 asset operations (bootstrap, asset
+				// deploys) may fail virtual-host addressing. Warn rather than
+				// block — non-S3 services still work. See the cdk-proxy design.
+				sink.Emit(output.MessageEvent{
+					Severity: output.SeverityWarning,
+					Text:     "Could not resolve localhost.localstack.cloud; using 127.0.0.1. CDK S3 asset operations (bootstrap, asset deploys) may fail on this host — ensure localhost.localstack.cloud resolves, or set AWS_ENDPOINT_URL/AWS_ENDPOINT_URL_S3 to a virtual-host-capable host.",
+				})
+			}
+
+			return cdkcli.Run(cmd.Context(), "http://"+host, region, account, sink, logger, cdkArgs)
+		},
+	}
+}

--- a/cmd/cdk.go
+++ b/cmd/cdk.go
@@ -20,20 +20,20 @@ func newCDKCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
 	return &cobra.Command{
 		Use:   "cdk [args...]",
 		Short: "Run AWS CDK against LocalStack",
-		Long: `Proxy AWS CDK commands to the real cdk CLI, so deploys target the running emulator instead of real AWS.
+		Long: `Proxy CDK commands to the running LocalStack emulator.
 
-Requires the AWS CDK CLI version 2.177.0 or newer on your PATH (lstk targets LocalStack purely through environment variables, which older CDK versions ignore). LocalStack must be running for commands that contact AWS (bootstrap, deploy, destroy, diff, …); offline commands (init, synth, ls, version, doctor) run without it.
+Requires the AWS CDK CLI version 2.177.0 or newer on your PATH.
 
 lstk-specific flags (must appear before the cdk action):
   --region <region>    Deployment region (default us-east-1)
-  --account <id>       Target AWS account id, 12 digits (default test)
+
+CDK always targets the default LocalStack account 000000000000; there is no --account flag.
 
 Supported environment variables:
   AWS_ENDPOINT_URL      Override the auto-resolved LocalStack endpoint
   AWS_ENDPOINT_URL_S3   Override the auto-derived S3 endpoint
   LSTK_CDK_CMD          CDK binary to invoke (default cdk)
   AWS_REGION            Fallback for --region
-  AWS_ACCESS_KEY_ID     Fallback for --account
 
 Examples:
   lstk cdk bootstrap
@@ -65,11 +65,16 @@ Examples:
 				return emitValidationError(sink, err)
 			}
 
-			region := resolveRegion(regionFlag)
-			account, err := resolveAccount(accountFlag)
-			if err != nil {
-				return emitValidationError(sink, err)
+			// CDK has no reliable way to target a non-default account (the
+			// account is derived by LocalStack from the access key id via an
+			// STS round-trip CDK does not honor consistently), so --account is
+			// rejected rather than silently ignored. CDK always uses the
+			// default account 000000000000.
+			if accountFlag != "" {
+				return emitValidationError(sink, fmt.Errorf("--account is not supported by lstk cdk; CDK always uses the default LocalStack account 000000000000"))
 			}
+
+			region := resolveRegion(regionFlag)
 
 			awsContainer := resolveAWSContainer()
 
@@ -78,7 +83,7 @@ Examples:
 			// inject it, so a synth-time context lookup routes to LocalStack.
 			if cdkcli.IsOffline(cdkArgs) {
 				host, _ := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
-				return cdkcli.Run(cmd.Context(), "http://"+host, region, account, sink, logger, cdkArgs)
+				return cdkcli.Run(cmd.Context(), "http://"+host, region, sink, logger, cdkArgs)
 			}
 
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
@@ -107,7 +112,7 @@ Examples:
 				})
 			}
 
-			return cdkcli.Run(cmd.Context(), "http://"+host, region, account, sink, logger, cdkArgs)
+			return cdkcli.Run(cmd.Context(), "http://"+host, region, sink, logger, cdkArgs)
 		},
 	}
 }

--- a/cmd/iac.go
+++ b/cmd/iac.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/container"
+	tfcli "github.com/localstack/lstk/internal/iac/terraform/cli"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+// Shared command-boundary helpers for the IaC proxy commands (terraform, cdk).
+// These live here rather than in any one command's file because both commands
+// depend on them equally; keeping them in cmd/ (not a domain package) is
+// deliberate — they touch config.Get(), the output.Sink, and the raw CLI args,
+// all of which are command-boundary concerns.
+
+var accountIDRe = regexp.MustCompile(`^\d{12}$`)
+
+// requireRunningAWSEmulator verifies the AWS emulator is running before an IaC
+// proxy command (terraform/cdk) that contacts AWS proceeds. When it is not
+// running it emits an actionable error through the sink — an AWS-specific
+// message naming the other emulator when a non-AWS one is up, otherwise the
+// generic "not running" error — and returns a silent error. cmdLabel is the
+// lstk command name used in the message (e.g. "terraform"/"cdk"). It returns nil
+// when the AWS emulator is running.
+func requireRunningAWSEmulator(ctx context.Context, rt runtime.Runtime, sink output.Sink, awsContainer config.ContainerConfig, cmdLabel string) error {
+	runningName, err := container.ResolveRunningContainerName(ctx, rt, awsContainer)
+	if err != nil {
+		return fmt.Errorf("checking emulator status: %w", err)
+	}
+	if runningName != "" {
+		return nil
+	}
+	// These commands only work with the AWS emulator. If a different emulator
+	// is running, say so specifically rather than reporting a misleading
+	// "AWS not running".
+	if other := runningNonAWSEmulator(ctx, rt); other != "" {
+		sink.Emit(output.ErrorEvent{
+			Title: fmt.Sprintf("lstk %s requires the %s, but the %s is running", cmdLabel, awsContainer.DisplayName(), other),
+			Actions: []output.ErrorAction{
+				{Label: "Start the AWS emulator:", Value: "lstk"},
+			},
+		})
+		return output.NewSilentError(fmt.Errorf("lstk %s requires the AWS emulator, but the %s is running", cmdLabel, other))
+	}
+	sink.Emit(output.ErrorEvent{
+		Title: fmt.Sprintf("%s is not running", awsContainer.DisplayName()),
+		Actions: []output.ErrorAction{
+			{Label: "Start LocalStack:", Value: "lstk"},
+			{Label: "See help:", Value: "lstk -h"},
+		},
+	})
+	return output.NewSilentError(fmt.Errorf("%s is not running", awsContainer.Name()))
+}
+
+// runningNonAWSEmulator returns the display name of a running non-AWS emulator
+// (e.g. Snowflake or Azure), or "" if none is running. The IaC proxy commands
+// support only the AWS emulator, so this lets them give a specific error when a
+// different emulator is running instead of a misleading "AWS not running".
+func runningNonAWSEmulator(ctx context.Context, rt runtime.Runtime) string {
+	var others []config.ContainerConfig
+	for _, t := range config.SelectableEmulatorTypes {
+		if t == config.EmulatorAWS {
+			continue
+		}
+		others = append(others, config.ContainerConfig{Type: t, Port: config.DefaultPort})
+	}
+	running, err := container.RunningEmulators(ctx, rt, others)
+	if err != nil || len(running) == 0 {
+		return ""
+	}
+	return running[0].DisplayName()
+}
+
+// resolveAWSContainer returns the configured AWS emulator container, falling
+// back to defaults when no matching entry exists (mirrors cmd/aws.go).
+func resolveAWSContainer() config.ContainerConfig {
+	awsContainer := config.ContainerConfig{Type: config.EmulatorAWS, Port: config.DefaultPort}
+	appCfg, err := config.Get()
+	if err != nil {
+		return awsContainer
+	}
+	for _, c := range appCfg.Containers {
+		if c.Type == config.EmulatorAWS {
+			return c
+		}
+	}
+	return awsContainer
+}
+
+// emitValidationError renders a command-boundary validation failure through the
+// sink (consistent with the other IaC proxy error events) and returns a silent
+// error so the top-level handler does not print it a second time.
+func emitValidationError(sink output.Sink, err error) error {
+	sink.Emit(output.ErrorEvent{Title: err.Error()})
+	return output.NewSilentError(err)
+}
+
+// rejectPreSubcommandFlags returns an error if --region or --account appears in
+// the raw command line before the subcommand token. Such flags are consumed by
+// Cobra during command resolution and would otherwise be silently dropped;
+// calledAs is the name the command was invoked as (e.g. "terraform"/"tf"/"cdk").
+func rejectPreSubcommandFlags(calledAs string) error {
+	cmdIdx := -1
+	for i, a := range os.Args {
+		if a == calledAs {
+			cmdIdx = i
+			break
+		}
+	}
+	if cmdIdx <= 0 {
+		return nil
+	}
+	for _, a := range os.Args[1:cmdIdx] {
+		if a == "--region" || a == "--account" ||
+			strings.HasPrefix(a, "--region=") || strings.HasPrefix(a, "--account=") {
+			return fmt.Errorf("--region and --account must appear after the %s subcommand (e.g. `lstk %s --region us-west-2 ...`)", calledAs, calledAs)
+		}
+	}
+	return nil
+}
+
+// stripLeadingIaCFlags extracts the lstk-specific --region/--account flags, and
+// (when recognizeChdir is set) reads terraform's global -chdir, but only in
+// leading position (between the subcommand alias and the action). It accepts
+// both --flag value and --flag=value forms for the lstk flags and -chdir=DIR for
+// chdir, stops at the first token that is none of these (forwarding the rest
+// verbatim), and errors if a leading lstk flag is missing its value.
+//
+// --region/--account are consumed and removed from the returned args; -chdir is
+// read for lstk's own working-directory resolution but kept in the returned
+// args, because terraform itself must also see it to switch directories. Only
+// the -chdir=DIR form is recognized (terraform does not accept a space-separated
+// -chdir DIR); any other spelling falls through and is forwarded verbatim. CDK
+// has no -chdir equivalent, so it calls this with recognizeChdir=false and
+// ignores the returned chdir.
+func stripLeadingIaCFlags(args []string, recognizeChdir bool) (remaining []string, region, account, chdir string, err error) {
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+		switch {
+		case arg == "--region":
+			if i+1 >= len(args) {
+				return nil, "", "", "", fmt.Errorf("--region requires a value")
+			}
+			region = args[i+1]
+			i += 2
+		case strings.HasPrefix(arg, "--region="):
+			region = strings.TrimPrefix(arg, "--region=")
+			i++
+		case arg == "--account":
+			if i+1 >= len(args) {
+				return nil, "", "", "", fmt.Errorf("--account requires a value")
+			}
+			account = args[i+1]
+			i += 2
+		case strings.HasPrefix(arg, "--account="):
+			account = strings.TrimPrefix(arg, "--account=")
+			i++
+		case recognizeChdir && strings.HasPrefix(arg, "-chdir="):
+			// Read the value but keep -chdir in the forwarded args so terraform
+			// also switches into it; continue scanning so leading --region/--account
+			// positioned after -chdir are still consumed.
+			chdir = strings.TrimPrefix(arg, "-chdir=")
+			remaining = append(remaining, arg)
+			i++
+		default:
+			return append(remaining, args[i:]...), region, account, chdir, nil
+		}
+	}
+	return remaining, region, account, chdir, nil
+}
+
+// resolveRegion applies the precedence --region flag → AWS_REGION → us-east-1.
+// The deprecated AWS_DEFAULT_REGION is intentionally not consulted.
+func resolveRegion(flag string) string {
+	if flag != "" {
+		return flag
+	}
+	if v := os.Getenv("AWS_REGION"); v != "" {
+		return v
+	}
+	return "us-east-1"
+}
+
+// resolveAccount applies the precedence --account flag → AWS_ACCESS_KEY_ID →
+// test. A flag value must be exactly 12 digits. An AWS_ACCESS_KEY_ID value is
+// run through DeactivateAccessKey so a real key (AKIA…/ASIA…) accidentally
+// present in the environment is never written into the override or sent to
+// LocalStack; the validated 12-digit flag is used as-is.
+func resolveAccount(flag string) (string, error) {
+	if flag != "" {
+		if !accountIDRe.MatchString(flag) {
+			return "", fmt.Errorf("--account must be a 12-digit AWS account id, got %q", flag)
+		}
+		return flag, nil
+	}
+	if v := os.Getenv("AWS_ACCESS_KEY_ID"); v != "" {
+		return tfcli.DeactivateAccessKey(v), nil
+	}
+	return "test", nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,7 @@ func NewRootCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.C
 		newDocsCmd(),
 		newAWSCmd(cfg),
 		newTerraformCmd(cfg, logger),
+		newCDKCmd(cfg, logger),
 		newSnapshotCmd(cfg, tel, logger),
 		newAzCmd(cfg),
 		newResetCmd(cfg),

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -1,14 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"regexp"
-	"strings"
 
-	"github.com/localstack/lstk/internal/config"
-	"github.com/localstack/lstk/internal/container"
 	"github.com/localstack/lstk/internal/endpoint"
 	"github.com/localstack/lstk/internal/env"
 	tfcli "github.com/localstack/lstk/internal/iac/terraform/cli"
@@ -17,8 +12,6 @@ import (
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
-
-var accountIDRe = regexp.MustCompile(`^\d{12}$`)
 
 func newTerraformCmd(cfg *env.Env, logger log.Logger) *cobra.Command {
 	// DisableFlagParsing means Cobra won't strip lstk's own flags; PreRunE does
@@ -71,7 +64,7 @@ Examples:
 				return emitValidationError(sink, err)
 			}
 
-			tfArgs, regionFlag, accountFlag, chdir, err := stripLeadingTerraformFlags(passthrough)
+			tfArgs, regionFlag, accountFlag, chdir, err := stripLeadingIaCFlags(passthrough, true)
 			if err != nil {
 				return emitValidationError(sink, err)
 			}
@@ -100,31 +93,8 @@ Examples:
 				return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
 			}
 
-			runningName, err := container.ResolveRunningContainerName(cmd.Context(), rt, awsContainer)
-			if err != nil {
-				return fmt.Errorf("checking emulator status: %w", err)
-			}
-			if runningName == "" {
-				// lstk terraform only works with the AWS emulator. If a
-				// different emulator is running, say so specifically rather than
-				// reporting a misleading "AWS not running".
-				if other := runningNonAWSEmulator(cmd.Context(), rt); other != "" {
-					sink.Emit(output.ErrorEvent{
-						Title: fmt.Sprintf("lstk terraform requires the %s, but the %s is running", awsContainer.DisplayName(), other),
-						Actions: []output.ErrorAction{
-							{Label: "Start the AWS emulator:", Value: "lstk"},
-						},
-					})
-					return output.NewSilentError(fmt.Errorf("lstk terraform requires the AWS emulator, but the %s is running", other))
-				}
-				sink.Emit(output.ErrorEvent{
-					Title: fmt.Sprintf("%s is not running", awsContainer.DisplayName()),
-					Actions: []output.ErrorAction{
-						{Label: "Start LocalStack:", Value: "lstk"},
-						{Label: "See help:", Value: "lstk -h"},
-					},
-				})
-				return output.NewSilentError(fmt.Errorf("%s is not running", awsContainer.Name()))
+			if err := requireRunningAWSEmulator(cmd.Context(), rt, sink, awsContainer, "terraform"); err != nil {
+				return err
 			}
 
 			host, _ := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
@@ -132,151 +102,4 @@ Examples:
 			return tfcli.Run(cmd.Context(), "http://"+host, region, account, chdir, sink, logger, tfArgs)
 		},
 	}
-}
-
-// runningNonAWSEmulator returns the display name of a running non-AWS emulator
-// (e.g. Snowflake or Azure), or "" if none is running. lstk terraform supports
-// only the AWS emulator, so this lets the command give a specific error when a
-// different emulator is running instead of a misleading "AWS not running".
-func runningNonAWSEmulator(ctx context.Context, rt runtime.Runtime) string {
-	var others []config.ContainerConfig
-	for _, t := range config.SelectableEmulatorTypes {
-		if t == config.EmulatorAWS {
-			continue
-		}
-		others = append(others, config.ContainerConfig{Type: t, Port: config.DefaultPort})
-	}
-	running, err := container.RunningEmulators(ctx, rt, others)
-	if err != nil || len(running) == 0 {
-		return ""
-	}
-	return running[0].DisplayName()
-}
-
-// resolveAWSContainer returns the configured AWS emulator container, falling
-// back to defaults when no matching entry exists (mirrors cmd/aws.go).
-func resolveAWSContainer() config.ContainerConfig {
-	awsContainer := config.ContainerConfig{Type: config.EmulatorAWS, Port: config.DefaultPort}
-	appCfg, err := config.Get()
-	if err != nil {
-		return awsContainer
-	}
-	for _, c := range appCfg.Containers {
-		if c.Type == config.EmulatorAWS {
-			return c
-		}
-	}
-	return awsContainer
-}
-
-// emitValidationError renders a command-boundary validation failure through the
-// sink (consistent with the other terraform error events) and returns a silent
-// error so the top-level handler does not print it a second time.
-func emitValidationError(sink output.Sink, err error) error {
-	sink.Emit(output.ErrorEvent{Title: err.Error()})
-	return output.NewSilentError(err)
-}
-
-// rejectPreSubcommandFlags returns an error if --region or --account appears in
-// the raw command line before the terraform/tf subcommand token. Such flags are
-// consumed by Cobra during command resolution and would otherwise be silently
-// dropped; calledAs is the name the command was invoked as ("terraform"/"tf").
-func rejectPreSubcommandFlags(calledAs string) error {
-	cmdIdx := -1
-	for i, a := range os.Args {
-		if a == calledAs {
-			cmdIdx = i
-			break
-		}
-	}
-	if cmdIdx <= 0 {
-		return nil
-	}
-	for _, a := range os.Args[1:cmdIdx] {
-		if a == "--region" || a == "--account" ||
-			strings.HasPrefix(a, "--region=") || strings.HasPrefix(a, "--account=") {
-			return fmt.Errorf("--region and --account must appear after the terraform subcommand (e.g. `lstk terraform --region us-west-2 plan`)")
-		}
-	}
-	return nil
-}
-
-// stripLeadingTerraformFlags extracts the lstk-specific --region/--account
-// flags and reads terraform's global -chdir, but only in leading position
-// (between terraform/tf and the action). It accepts both --flag value and
-// --flag=value forms for the lstk flags and -chdir=DIR for chdir, stops at the
-// first token that is none of these (forwarding the rest verbatim), and errors
-// if a leading lstk flag is missing its value.
-//
-// --region/--account are consumed and removed from the returned args; -chdir is
-// read for lstk's own working-directory resolution but kept in the returned
-// args, because terraform itself must also see it to switch directories. Only
-// the -chdir=DIR form is recognized (terraform does not accept a space-separated
-// -chdir DIR); any other spelling falls through and is forwarded verbatim for
-// terraform to reject.
-func stripLeadingTerraformFlags(args []string) (remaining []string, region, account, chdir string, err error) {
-	i := 0
-	for i < len(args) {
-		arg := args[i]
-		switch {
-		case arg == "--region":
-			if i+1 >= len(args) {
-				return nil, "", "", "", fmt.Errorf("--region requires a value")
-			}
-			region = args[i+1]
-			i += 2
-		case strings.HasPrefix(arg, "--region="):
-			region = strings.TrimPrefix(arg, "--region=")
-			i++
-		case arg == "--account":
-			if i+1 >= len(args) {
-				return nil, "", "", "", fmt.Errorf("--account requires a value")
-			}
-			account = args[i+1]
-			i += 2
-		case strings.HasPrefix(arg, "--account="):
-			account = strings.TrimPrefix(arg, "--account=")
-			i++
-		case strings.HasPrefix(arg, "-chdir="):
-			// Read the value but keep -chdir in the forwarded args so terraform
-			// also switches into it; continue scanning so leading --region/--account
-			// positioned after -chdir are still consumed.
-			chdir = strings.TrimPrefix(arg, "-chdir=")
-			remaining = append(remaining, arg)
-			i++
-		default:
-			return append(remaining, args[i:]...), region, account, chdir, nil
-		}
-	}
-	return remaining, region, account, chdir, nil
-}
-
-// resolveRegion applies the precedence --region flag → AWS_REGION → us-east-1.
-// The deprecated AWS_DEFAULT_REGION is intentionally not consulted.
-func resolveRegion(flag string) string {
-	if flag != "" {
-		return flag
-	}
-	if v := os.Getenv("AWS_REGION"); v != "" {
-		return v
-	}
-	return "us-east-1"
-}
-
-// resolveAccount applies the precedence --account flag → AWS_ACCESS_KEY_ID →
-// test. A flag value must be exactly 12 digits. An AWS_ACCESS_KEY_ID value is
-// run through DeactivateAccessKey so a real key (AKIA…/ASIA…) accidentally
-// present in the environment is never written into the override or sent to
-// LocalStack; the validated 12-digit flag is used as-is.
-func resolveAccount(flag string) (string, error) {
-	if flag != "" {
-		if !accountIDRe.MatchString(flag) {
-			return "", fmt.Errorf("--account must be a 12-digit AWS account id, got %q", flag)
-		}
-		return flag, nil
-	}
-	if v := os.Getenv("AWS_ACCESS_KEY_ID"); v != "" {
-		return tfcli.DeactivateAccessKey(v), nil
-	}
-	return "test", nil
 }

--- a/cmd/terraform_test.go
+++ b/cmd/terraform_test.go
@@ -92,7 +92,7 @@ func TestStripLeadingTerraformFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			remain, region, account, chdir, err := stripLeadingTerraformFlags(tt.args)
+			remain, region, account, chdir, err := stripLeadingIaCFlags(tt.args, true)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")

--- a/internal/endpoint/s3.go
+++ b/internal/endpoint/s3.go
@@ -1,0 +1,41 @@
+package endpoint
+
+import (
+	"net/url"
+	"strings"
+)
+
+// S3Addressing decides S3 path-style and the S3 endpoint for the given base
+// endpoint. Virtual-host-style addressing (used by *.localstack.cloud hosts)
+// places the bucket as a subdomain of the S3 endpoint host, so the S3 endpoint
+// host carries an `s3.` prefix and path style is off. Non-domain hosts
+// (127.0.0.1/localhost) require path style and use the bare endpoint.
+//
+// It is used both by the Terraform proxy (to set `s3_use_path_style` and the
+// `s3` endpoint key in the generated override) and by the CDK proxy (to set
+// `AWS_ENDPOINT_URL_S3`). CDK has no env-only lever for path style, so a
+// pathStyle==true result there is informational only — see the cdk-proxy design.
+func S3Addressing(endpointURL string) (pathStyle bool, s3Endpoint string) {
+	u, err := url.Parse(endpointURL)
+	if err != nil || u.Hostname() == "" {
+		// Can't parse — safest default is path style with the bare endpoint.
+		return true, endpointURL
+	}
+	if !virtualHostCapable(u.Hostname()) {
+		return true, endpointURL
+	}
+	if strings.HasPrefix(u.Hostname(), "s3.") {
+		return false, endpointURL
+	}
+	host := "s3." + u.Hostname()
+	if port := u.Port(); port != "" {
+		host += ":" + port
+	}
+	return false, u.Scheme + "://" + host
+}
+
+// TODO: in future, replace this with a more intelligent algorithm that tries to resolve whatever DNS
+// endpoint is given.
+func virtualHostCapable(host string) bool {
+	return host == "localstack.cloud" || strings.HasSuffix(host, ".localstack.cloud")
+}

--- a/internal/endpoint/s3_test.go
+++ b/internal/endpoint/s3_test.go
@@ -1,0 +1,29 @@
+package endpoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestS3Addressing(t *testing.T) {
+	tests := []struct {
+		endpoint      string
+		wantPathStyle bool
+		wantS3        string
+	}{
+		{"http://127.0.0.1:4566", true, "http://127.0.0.1:4566"},
+		{"http://localhost:4566", true, "http://localhost:4566"},
+		{"http://localhost.localstack.cloud:4566", false, "http://s3.localhost.localstack.cloud:4566"},
+		{"https://localstack.cloud", false, "https://s3.localstack.cloud"},
+		{"http://s3.localhost.localstack.cloud:4566", false, "http://s3.localhost.localstack.cloud:4566"},
+		{"", true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.endpoint, func(t *testing.T) {
+			pathStyle, s3 := S3Addressing(tt.endpoint)
+			assert.Equal(t, tt.wantPathStyle, pathStyle)
+			assert.Equal(t, tt.wantS3, s3)
+		})
+	}
+}

--- a/internal/iac/cdk/cli/defaults.go
+++ b/internal/iac/cdk/cli/defaults.go
@@ -1,0 +1,83 @@
+package cli
+
+// minCDKVersion is the lowest AWS CDK CLI version lstk supports. From this
+// version the CDK CLI honors AWS_ENDPOINT_URL / AWS_ENDPOINT_URL_S3, which is
+// how lstk points CDK at LocalStack. Older versions ignore those variables and
+// would silently target real AWS, so lstk refuses to run against them. See the
+// cdk-proxy design doc for the full rationale.
+const (
+	minCDKMajor = 2
+	minCDKMinor = 177
+	minCDKPatch = 0
+)
+
+// minCDKVersionString is the human-facing form used in error messages.
+const minCDKVersionString = "2.177.0"
+
+// offlineCommands are the CDK subcommands that never contact AWS APIs and so do
+// not require a running emulator. Everything else (bootstrap, deploy, destroy,
+// diff, import, watch, rollback, gc, migrate, …) is treated as AWS-contacting
+// and is gated on a running AWS emulator. The set is fixed and intentionally
+// not configurable, mirroring the terraform proxy's unproxied-command set.
+//
+// The LocalStack-pointed environment is still applied to offline commands (it
+// is harmless when no API call is made), so a `synth` that performs a context
+// lookup still routes to LocalStack; only the emulator-running gate differs.
+var offlineCommands = map[string]bool{
+	"init":        true,
+	"synth":       true,
+	"synthesize":  true,
+	"ls":          true,
+	"list":        true,
+	"version":     true,
+	"doctor":      true,
+	"acknowledge": true,
+	"ack":         true,
+	"context":     true,
+	"notices":     true,
+}
+
+// valueFlags are CDK global options that consume the following token as their
+// value, so the subcommand scan must skip both the flag and its value. Only the
+// space-separated form needs listing; the --flag=value form is a single token
+// and is skipped as an ordinary flag. This covers the common value-taking
+// global options; an unlisted one could cause its value to be mistaken for the
+// subcommand, which at worst gates an offline command on a running emulator
+// (the safe direction — never a wrong real-AWS call).
+var valueFlags = map[string]bool{
+	"--app": true, "-a": true,
+	"--context": true, "-c": true,
+	"--output": true, "-o": true,
+	"--profile":  true,
+	"--role-arn": true, "-r": true,
+	"--plugin":              true,
+	"--proxy":               true,
+	"--ca-bundle-path":      true,
+	"--toolkit-stack-name":  true,
+	"--toolkit-bucket-name": true,
+}
+
+// IsOffline reports whether the CDK invocation described by args is one of the
+// offline subcommands that need no running emulator.
+func IsOffline(args []string) bool {
+	return offlineCommands[subcommand(args)]
+}
+
+// subcommand returns the first non-flag token in args that is not consumed as a
+// global option's value, or "" if there is none.
+func subcommand(args []string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if len(a) == 0 {
+			continue
+		}
+		if a[0] == '-' {
+			if valueFlags[a] && i+1 < len(args) {
+				i++ // skip this flag's value
+			}
+			continue
+		}
+		return a
+	}
+	return ""
+}

--- a/internal/iac/cdk/cli/env.go
+++ b/internal/iac/cdk/cli/env.go
@@ -1,0 +1,28 @@
+package cli
+
+import "os"
+
+// Environment variables this package reads. They are process environment, not
+// lstk config, so reading them here (the domain boundary for cdk) is consistent
+// with the rule that domain code must not call config.Get().
+
+// cdkCmd returns the CDK binary name to invoke, honoring LSTK_CDK_CMD and
+// defaulting to "cdk".
+func cdkCmd() string {
+	if v := os.Getenv("LSTK_CDK_CMD"); v != "" {
+		return v
+	}
+	return "cdk"
+}
+
+// endpointURLOverride returns AWS_ENDPOINT_URL, which takes precedence over the
+// auto-resolved LocalStack endpoint.
+func endpointURLOverride() string {
+	return os.Getenv("AWS_ENDPOINT_URL")
+}
+
+// s3EndpointOverride returns AWS_ENDPOINT_URL_S3, which takes precedence over
+// the endpoint derived from the base endpoint's host.
+func s3EndpointOverride() string {
+	return os.Getenv("AWS_ENDPOINT_URL_S3")
+}

--- a/internal/iac/cdk/cli/exec.go
+++ b/internal/iac/cdk/cli/exec.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/localstack/lstk/internal/endpoint"
+	"github.com/localstack/lstk/internal/log"
+	"github.com/localstack/lstk/internal/output"
+)
+
+// Run proxies an AWS CDK invocation against LocalStack. It locates the cdk
+// binary, verifies its version, builds a subprocess environment that points CDK
+// at the resolved LocalStack endpoint (and strips ambient AWS config that could
+// redirect it at real AWS), then runs cdk with stdio wired through.
+//
+// endpointURL is the resolved LocalStack endpoint (http://host:port). region
+// and account are encoded into the subprocess environment as AWS_REGION and
+// AWS_ACCESS_KEY_ID. CDK output is streamed unobstructed (no spinner); a
+// non-zero exit is wrapped as a silent error so lstk does not reprint it.
+func Run(ctx context.Context, endpointURL, region, account string, sink output.Sink, logger log.Logger, args []string) error {
+	ctx, span := otel.Tracer("github.com/localstack/lstk/internal/iac/cdk/cli").Start(ctx, "cdk cli")
+	defer span.End()
+
+	cdkBin, err := exec.LookPath(cdkCmd())
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		sink.Emit(output.ErrorEvent{
+			Title:   fmt.Sprintf("%s not found in PATH", cdkCmd()),
+			Actions: []output.ErrorAction{{Label: "Install the AWS CDK CLI and ensure it is on your PATH:", Value: "npm install -g aws-cdk"}},
+		})
+		return output.NewSilentError(fmt.Errorf("%s not found in PATH", cdkCmd()))
+	}
+
+	if err := CheckVersion(ctx, cdkBin); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		sink.Emit(output.ErrorEvent{
+			Title:   err.Error(),
+			Actions: []output.ErrorAction{{Label: "Upgrade the AWS CDK CLI:", Value: "npm install -g aws-cdk@latest"}},
+		})
+		return output.NewSilentError(err)
+	}
+
+	effectiveEndpoint := endpointURL
+	if override := endpointURLOverride(); override != "" {
+		effectiveEndpoint = override
+		logger.Info("cdk: using AWS_ENDPOINT_URL override %s", override)
+	}
+
+	_, s3Endpoint := endpoint.S3Addressing(effectiveEndpoint)
+	if override := s3EndpointOverride(); override != "" {
+		s3Endpoint = override
+		logger.Info("cdk: using AWS_ENDPOINT_URL_S3 override %s", override)
+	}
+
+	span.SetAttributes(
+		attribute.StringSlice("cdk.args", args),
+		attribute.Bool("cdk.offline", IsOffline(args)),
+	)
+
+	cmd := exec.CommandContext(ctx, cdkBin, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = BuildEnv(os.Environ(), effectiveEndpoint, s3Endpoint, region, account)
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			span.SetAttributes(attribute.Int("cdk.exit_code", exitErr.ExitCode()))
+			span.SetStatus(codes.Error, "cdk exited non-zero")
+			return output.NewSilentError(err)
+		}
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// strippedKeys are ambient AWS configuration variables removed from the CDK
+// subprocess environment. A named profile, default profile, or stale session
+// token could otherwise resolve real credentials/region and silently redirect a
+// deploy at real AWS — this mirrors why cdklocal clears AWS config before
+// invoking cdk.
+var strippedKeys = map[string]bool{
+	"AWS_PROFILE":         true,
+	"AWS_DEFAULT_PROFILE": true,
+	"AWS_SESSION_TOKEN":   true,
+}
+
+// BuildEnv returns the environment for the cdk subprocess: base with ambient
+// AWS configuration stripped and the LocalStack-pointing values set (overriding
+// any pre-existing entries). Empty endpoint values are not set, so they never
+// clobber a meaningful inherited value with "".
+func BuildEnv(base []string, endpointURL, s3Endpoint, region, account string) []string {
+	// Ordered so the produced environment is deterministic. Empty-valued
+	// entries are skipped below.
+	managed := []struct{ key, value string }{
+		{"AWS_ENDPOINT_URL", endpointURL},
+		{"AWS_ENDPOINT_URL_S3", s3Endpoint},
+		{"AWS_ACCESS_KEY_ID", account},
+		{"AWS_SECRET_ACCESS_KEY", "test"},
+		{"AWS_REGION", region},
+		{"AWS_DEFAULT_REGION", region},
+		{"CDK_DISABLE_LEGACY_EXPORT_WARNING", "1"},
+	}
+
+	managedKeys := make(map[string]bool, len(managed))
+	for _, m := range managed {
+		managedKeys[m.key] = true
+	}
+
+	env := make([]string, 0, len(base)+len(managed))
+	for _, e := range base {
+		key, _, ok := strings.Cut(e, "=")
+		if !ok {
+			env = append(env, e)
+			continue
+		}
+		if strippedKeys[key] || managedKeys[key] {
+			continue
+		}
+		env = append(env, e)
+	}
+	for _, m := range managed {
+		if m.value == "" {
+			continue
+		}
+		env = append(env, m.key+"="+m.value)
+	}
+	return env
+}

--- a/internal/iac/cdk/cli/exec.go
+++ b/internal/iac/cdk/cli/exec.go
@@ -37,7 +37,7 @@ func Run(ctx context.Context, endpointURL, region string, sink output.Sink, logg
 		span.SetStatus(codes.Error, err.Error())
 		sink.Emit(output.ErrorEvent{
 			Title:   fmt.Sprintf("%s not found in PATH", cdkCmd()),
-			Actions: []output.ErrorAction{{Label: "Install the AWS CDK CLI and ensure it is on your PATH:", Value: "npm install -g aws-cdk"}},
+			Actions: []output.ErrorAction{{Label: "Install CDK CLI:", Value: "npm install -g aws-cdk"}},
 		})
 		return output.NewSilentError(fmt.Errorf("%s not found in PATH", cdkCmd()))
 	}
@@ -47,7 +47,7 @@ func Run(ctx context.Context, endpointURL, region string, sink output.Sink, logg
 		span.SetStatus(codes.Error, err.Error())
 		sink.Emit(output.ErrorEvent{
 			Title:   err.Error(),
-			Actions: []output.ErrorAction{{Label: "Upgrade the AWS CDK CLI:", Value: "npm install -g aws-cdk@latest"}},
+			Actions: []output.ErrorAction{{Label: "Upgrade CDK CLI:", Value: "npm install -g aws-cdk@latest"}},
 		})
 		return output.NewSilentError(err)
 	}

--- a/internal/iac/cdk/cli/exec.go
+++ b/internal/iac/cdk/cli/exec.go
@@ -22,11 +22,12 @@ import (
 // at the resolved LocalStack endpoint (and strips ambient AWS config that could
 // redirect it at real AWS), then runs cdk with stdio wired through.
 //
-// endpointURL is the resolved LocalStack endpoint (http://host:port). region
-// and account are encoded into the subprocess environment as AWS_REGION and
+// endpointURL is the resolved LocalStack endpoint (http://host:port). region is
+// encoded into the subprocess environment as AWS_REGION. CDK has no account
+// selection: it always targets the default LocalStack account via a fixed mock
 // AWS_ACCESS_KEY_ID. CDK output is streamed unobstructed (no spinner); a
 // non-zero exit is wrapped as a silent error so lstk does not reprint it.
-func Run(ctx context.Context, endpointURL, region, account string, sink output.Sink, logger log.Logger, args []string) error {
+func Run(ctx context.Context, endpointURL, region string, sink output.Sink, logger log.Logger, args []string) error {
 	ctx, span := otel.Tracer("github.com/localstack/lstk/internal/iac/cdk/cli").Start(ctx, "cdk cli")
 	defer span.End()
 
@@ -72,7 +73,7 @@ func Run(ctx context.Context, endpointURL, region, account string, sink output.S
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = BuildEnv(os.Environ(), effectiveEndpoint, s3Endpoint, region, account)
+	cmd.Env = BuildEnv(os.Environ(), effectiveEndpoint, s3Endpoint, region)
 
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
@@ -103,13 +104,18 @@ var strippedKeys = map[string]bool{
 // AWS configuration stripped and the LocalStack-pointing values set (overriding
 // any pre-existing entries). Empty endpoint values are not set, so they never
 // clobber a meaningful inherited value with "".
-func BuildEnv(base []string, endpointURL, s3Endpoint, region, account string) []string {
+//
+// AWS_ACCESS_KEY_ID is fixed to the mock value "test" (never an account id), so
+// CDK always resolves the default LocalStack account 000000000000. This
+// unconditionally overrides any ambient AWS_ACCESS_KEY_ID — including a 12-digit
+// value that LocalStack would otherwise treat as a custom account.
+func BuildEnv(base []string, endpointURL, s3Endpoint, region string) []string {
 	// Ordered so the produced environment is deterministic. Empty-valued
 	// entries are skipped below.
 	managed := []struct{ key, value string }{
 		{"AWS_ENDPOINT_URL", endpointURL},
 		{"AWS_ENDPOINT_URL_S3", s3Endpoint},
-		{"AWS_ACCESS_KEY_ID", account},
+		{"AWS_ACCESS_KEY_ID", "test"},
 		{"AWS_SECRET_ACCESS_KEY", "test"},
 		{"AWS_REGION", region},
 		{"AWS_DEFAULT_REGION", region},

--- a/internal/iac/cdk/cli/exec_test.go
+++ b/internal/iac/cdk/cli/exec_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// envMap parses an env slice ("K=V") into a map for assertions.
+func envMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, e := range env {
+		k, v, ok := strings.Cut(e, "=")
+		if ok {
+			m[k] = v
+		}
+	}
+	return m
+}
+
+func TestBuildEnvSetsLocalStackValues(t *testing.T) {
+	env := envMap(BuildEnv(nil, "http://localhost.localstack.cloud:4566", "http://s3.localhost.localstack.cloud:4566", "eu-west-1", "123456789012"))
+
+	assert.Equal(t, "http://localhost.localstack.cloud:4566", env["AWS_ENDPOINT_URL"])
+	assert.Equal(t, "http://s3.localhost.localstack.cloud:4566", env["AWS_ENDPOINT_URL_S3"])
+	assert.Equal(t, "123456789012", env["AWS_ACCESS_KEY_ID"])
+	assert.Equal(t, "test", env["AWS_SECRET_ACCESS_KEY"])
+	assert.Equal(t, "eu-west-1", env["AWS_REGION"])
+	assert.Equal(t, "eu-west-1", env["AWS_DEFAULT_REGION"])
+	assert.Equal(t, "1", env["CDK_DISABLE_LEGACY_EXPORT_WARNING"])
+}
+
+func TestBuildEnvStripsAmbientAWSConfig(t *testing.T) {
+	base := []string{
+		"AWS_PROFILE=my-real-profile",
+		"AWS_DEFAULT_PROFILE=other",
+		"AWS_SESSION_TOKEN=realtoken",
+		"AWS_ACCESS_KEY_ID=AKIAREALKEY",
+		"AWS_SECRET_ACCESS_KEY=realsecret",
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+	}
+	env := envMap(BuildEnv(base, "http://127.0.0.1:4566", "http://127.0.0.1:4566", "us-east-1", "test"))
+
+	_, hasProfile := env["AWS_PROFILE"]
+	_, hasDefaultProfile := env["AWS_DEFAULT_PROFILE"]
+	_, hasSessionToken := env["AWS_SESSION_TOKEN"]
+	assert.False(t, hasProfile, "AWS_PROFILE must be stripped")
+	assert.False(t, hasDefaultProfile, "AWS_DEFAULT_PROFILE must be stripped")
+	assert.False(t, hasSessionToken, "AWS_SESSION_TOKEN must be stripped")
+
+	// Real creds in base are overridden with mock values, not preserved.
+	assert.Equal(t, "test", env["AWS_ACCESS_KEY_ID"])
+	assert.Equal(t, "test", env["AWS_SECRET_ACCESS_KEY"])
+
+	// Unrelated entries are preserved.
+	assert.Equal(t, "/usr/bin", env["PATH"])
+	assert.Equal(t, "/home/user", env["HOME"])
+}
+
+func TestBuildEnvSkipsEmptyEndpoint(t *testing.T) {
+	env := envMap(BuildEnv(nil, "", "", "us-east-1", "test"))
+	_, hasEndpoint := env["AWS_ENDPOINT_URL"]
+	_, hasS3 := env["AWS_ENDPOINT_URL_S3"]
+	assert.False(t, hasEndpoint, "empty AWS_ENDPOINT_URL must not be set")
+	assert.False(t, hasS3, "empty AWS_ENDPOINT_URL_S3 must not be set")
+	// Region/creds are still set even with no endpoint.
+	assert.Equal(t, "us-east-1", env["AWS_REGION"])
+	assert.Equal(t, "test", env["AWS_ACCESS_KEY_ID"])
+}
+
+func TestIsOffline(t *testing.T) {
+	offline := [][]string{
+		{"synth"},
+		{"--app", "foo", "ls"},
+		{"init", "--language", "typescript"},
+		{"doctor"},
+		{"acknowledge", "12345"},
+		{"context"},
+	}
+	for _, args := range offline {
+		assert.Truef(t, IsOffline(args), "expected %v offline", args)
+	}
+
+	awsContacting := [][]string{
+		{"deploy", "MyStack"},
+		{"bootstrap"},
+		{"destroy", "--force"},
+		{"diff"},
+		{"watch"},
+		{}, // no subcommand → not offline (gate on emulator)
+	}
+	for _, args := range awsContacting {
+		assert.Falsef(t, IsOffline(args), "expected %v not offline", args)
+	}
+}

--- a/internal/iac/cdk/cli/exec_test.go
+++ b/internal/iac/cdk/cli/exec_test.go
@@ -20,15 +20,26 @@ func envMap(env []string) map[string]string {
 }
 
 func TestBuildEnvSetsLocalStackValues(t *testing.T) {
-	env := envMap(BuildEnv(nil, "http://localhost.localstack.cloud:4566", "http://s3.localhost.localstack.cloud:4566", "eu-west-1", "123456789012"))
+	env := envMap(BuildEnv(nil, "http://localhost.localstack.cloud:4566", "http://s3.localhost.localstack.cloud:4566", "eu-west-1"))
 
 	assert.Equal(t, "http://localhost.localstack.cloud:4566", env["AWS_ENDPOINT_URL"])
 	assert.Equal(t, "http://s3.localhost.localstack.cloud:4566", env["AWS_ENDPOINT_URL_S3"])
-	assert.Equal(t, "123456789012", env["AWS_ACCESS_KEY_ID"])
+	assert.Equal(t, "test", env["AWS_ACCESS_KEY_ID"])
 	assert.Equal(t, "test", env["AWS_SECRET_ACCESS_KEY"])
 	assert.Equal(t, "eu-west-1", env["AWS_REGION"])
 	assert.Equal(t, "eu-west-1", env["AWS_DEFAULT_REGION"])
 	assert.Equal(t, "1", env["CDK_DISABLE_LEGACY_EXPORT_WARNING"])
+}
+
+// A 12-digit AWS_ACCESS_KEY_ID in the environment (which LocalStack would treat
+// as a custom account) is overridden with "test", so CDK always resolves the
+// default account 000000000000 — there is no env path to a non-default account.
+func TestBuildEnvForcesDefaultAccount(t *testing.T) {
+	base := []string{"AWS_ACCESS_KEY_ID=123456789012", "AWS_SECRET_ACCESS_KEY=somesecret"}
+	env := envMap(BuildEnv(base, "http://127.0.0.1:4566", "http://127.0.0.1:4566", "us-east-1"))
+
+	assert.Equal(t, "test", env["AWS_ACCESS_KEY_ID"])
+	assert.Equal(t, "test", env["AWS_SECRET_ACCESS_KEY"])
 }
 
 func TestBuildEnvStripsAmbientAWSConfig(t *testing.T) {
@@ -41,7 +52,7 @@ func TestBuildEnvStripsAmbientAWSConfig(t *testing.T) {
 		"PATH=/usr/bin",
 		"HOME=/home/user",
 	}
-	env := envMap(BuildEnv(base, "http://127.0.0.1:4566", "http://127.0.0.1:4566", "us-east-1", "test"))
+	env := envMap(BuildEnv(base, "http://127.0.0.1:4566", "http://127.0.0.1:4566", "us-east-1"))
 
 	_, hasProfile := env["AWS_PROFILE"]
 	_, hasDefaultProfile := env["AWS_DEFAULT_PROFILE"]
@@ -60,7 +71,7 @@ func TestBuildEnvStripsAmbientAWSConfig(t *testing.T) {
 }
 
 func TestBuildEnvSkipsEmptyEndpoint(t *testing.T) {
-	env := envMap(BuildEnv(nil, "", "", "us-east-1", "test"))
+	env := envMap(BuildEnv(nil, "", "", "us-east-1"))
 	_, hasEndpoint := env["AWS_ENDPOINT_URL"]
 	_, hasS3 := env["AWS_ENDPOINT_URL_S3"]
 	assert.False(t, hasEndpoint, "empty AWS_ENDPOINT_URL must not be set")

--- a/internal/iac/cdk/cli/version.go
+++ b/internal/iac/cdk/cli/version.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+// versionRe matches the leading MAJOR.MINOR.PATCH of a `cdk --version` line
+// (e.g. "2.177.0 (build abc1234)").
+var versionRe = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)`)
+
+// CheckVersion runs `<cdkBin> --version` and returns an error if the reported
+// version is below the minimum lstk supports, or if the output cannot be
+// parsed. lstk points CDK at LocalStack purely through environment variables,
+// which only CDK >= minCDKVersionString honors; on an older (or unparseable)
+// version lstk must refuse to run so it cannot silently target real AWS.
+func CheckVersion(ctx context.Context, cdkBin string) error {
+	out, err := exec.CommandContext(ctx, cdkBin, "--version").Output()
+	if err != nil {
+		return fmt.Errorf("could not determine cdk version (run `%s --version`): %w", cdkBin, err)
+	}
+	return checkVersionString(string(out))
+}
+
+func checkVersionString(out string) error {
+	m := versionRe.FindStringSubmatch(out)
+	if m == nil {
+		return fmt.Errorf("could not parse cdk version from %q; lstk requires AWS CDK %s or newer", out, minCDKVersionString)
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	patch, _ := strconv.Atoi(m[3])
+	if !atLeastMinVersion(major, minor, patch) {
+		return fmt.Errorf("AWS CDK %d.%d.%d is too old; lstk requires %s or newer (it points CDK at LocalStack via AWS_ENDPOINT_URL, which older versions ignore)", major, minor, patch, minCDKVersionString)
+	}
+	return nil
+}
+
+func atLeastMinVersion(major, minor, patch int) bool {
+	switch {
+	case major != minCDKMajor:
+		return major > minCDKMajor
+	case minor != minCDKMinor:
+		return minor > minCDKMinor
+	default:
+		return patch >= minCDKPatch
+	}
+}

--- a/internal/iac/cdk/cli/version_test.go
+++ b/internal/iac/cdk/cli/version_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import "testing"
+
+func TestCheckVersionString(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		wantErr bool
+	}{
+		{"exact minimum", "2.177.0 (build abc1234)", false},
+		{"newer patch", "2.177.5", false},
+		{"newer minor", "2.200.1 (build xyz)", false},
+		{"newer major", "3.0.0", false},
+		{"older patch boundary", "2.176.99", true},
+		{"older minor", "2.100.0", true},
+		{"older major", "1.999.0", true},
+		{"unparseable", "cdk: command behaving oddly", true},
+		{"empty", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkVersionString(tt.out)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error for %q, got nil", tt.out)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.out, err)
+			}
+		})
+	}
+}

--- a/internal/iac/terraform/cli/override.go
+++ b/internal/iac/terraform/cli/override.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"io/fs"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/localstack/lstk/internal/endpoint"
 	"github.com/localstack/lstk/internal/log"
 )
 
@@ -46,7 +46,7 @@ func generateOverride(opts overrideOptions) ([]string, error) {
 
 	aliases := discoverAWSAliases(opts.workdir, opts.logger)
 
-	pathStyle, s3Endpoint := s3Addressing(opts.endpointURL)
+	pathStyle, s3Endpoint := endpoint.S3Addressing(opts.endpointURL)
 
 	var b strings.Builder
 	b.WriteString(overrideFileMarker)
@@ -191,32 +191,3 @@ func writeProviderBlock(b *strings.Builder, p providerBlock) {
 	b.WriteString("}\n\n")
 }
 
-// s3Addressing decides S3 path-style and the S3 endpoint for the given base
-// endpoint. Virtual-host-style addressing (used by *.localstack.cloud hosts)
-// places the bucket as a subdomain of the S3 endpoint host, so the S3 endpoint
-// host carries an `s3.` prefix and path style is off. Non-domain hosts
-// (127.0.0.1/localhost) require path style and use the bare endpoint.
-func s3Addressing(endpointURL string) (pathStyle bool, s3Endpoint string) {
-	u, err := url.Parse(endpointURL)
-	if err != nil || u.Hostname() == "" {
-		// Can't parse — safest default is path style with the bare endpoint.
-		return true, endpointURL
-	}
-	if !virtualHostCapable(u.Hostname()) {
-		return true, endpointURL
-	}
-	if strings.HasPrefix(u.Hostname(), "s3.") {
-		return false, endpointURL
-	}
-	host := "s3." + u.Hostname()
-	if port := u.Port(); port != "" {
-		host += ":" + port
-	}
-	return false, u.Scheme + "://" + host
-}
-
-// TODO: in future, replace this with a more intelligent algorithm that tries to resolve whatever DNS
-// endpoint is given.
-func virtualHostCapable(host string) bool {
-	return host == "localstack.cloud" || strings.HasSuffix(host, ".localstack.cloud")
-}

--- a/internal/iac/terraform/cli/override_test.go
+++ b/internal/iac/terraform/cli/override_test.go
@@ -170,27 +170,6 @@ func TestGenerateOverrideRefusesOwnLeftover(t *testing.T) {
 	assert.Contains(t, err.Error(), "refusing to overwrite")
 }
 
-func TestS3Addressing(t *testing.T) {
-	tests := []struct {
-		endpoint      string
-		wantPathStyle bool
-		wantS3        string
-	}{
-		{"http://127.0.0.1:4566", true, "http://127.0.0.1:4566"},
-		{"http://localhost:4566", true, "http://localhost:4566"},
-		{"http://localhost.localstack.cloud:4566", false, "http://s3.localhost.localstack.cloud:4566"},
-		{"https://localstack.cloud", false, "https://s3.localstack.cloud"},
-		{"http://s3.localhost.localstack.cloud:4566", false, "http://s3.localhost.localstack.cloud:4566"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.endpoint, func(t *testing.T) {
-			pathStyle, s3 := s3Addressing(tt.endpoint)
-			assert.Equal(t, tt.wantPathStyle, pathStyle)
-			assert.Equal(t, tt.wantS3, s3)
-		})
-	}
-}
-
 func writeTF(t *testing.T, dir, name, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))

--- a/openspec/changes/add-cdk-proxy-command/.openspec.yaml
+++ b/openspec/changes/add-cdk-proxy-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/add-cdk-proxy-command/design.md
+++ b/openspec/changes/add-cdk-proxy-command/design.md
@@ -20,7 +20,7 @@ lstk runs `cdk` as an external subprocess and cannot reach into CDK's Node SDK, 
 - `lstk cdk <args>` forwards all args to the real `cdk`, streaming stdin/stdout/stderr and propagating the exit code.
 - Auto-resolve the LocalStack endpoint from the running AWS emulator — no host/port env vars needed.
 - Build a clean, LocalStack-pointed AWS environment for the subprocess (`AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, mock creds, region) and strip ambient AWS config that could redirect CDK at real AWS.
-- Reuse the terraform command's `--region`/`--account` parsing, validation, precedence, and `DeactivateAccessKey` safeguard.
+- Reuse the terraform command's `--region` parsing, validation, and precedence. CDK does **not** support `--account`: it always operates against the default LocalStack account `000000000000`.
 - Gate AWS-contacting subcommands on a running AWS emulator (with the same AWS-specific "wrong emulator" messaging as terraform); run a fixed offline set without that requirement.
 - Fail fast and clearly when `cdk` is missing or older than 2.177.0.
 - Keep the architecture aligned with lstk conventions: cmd/ wiring only, domain logic in `internal/iac/cdk/cli/`, output via `output.Sink`, diagnostics via `log.Logger`, no direct stdout/stderr prints, no `config.Get()` in domain code.
@@ -31,16 +31,17 @@ lstk runs `cdk` as an external subprocess and cannot reach into CDK's Node SDK, 
 - Supporting `cdklocal`-specific knobs like `LAMBDA_MOUNT_CODE`, `BUCKET_MARKER_LOCAL`, `AWS_ENVAR_ALLOWLIST`, `LOCALSTACK_HOSTNAME`, `EDGE_PORT` (lstk resolves the endpoint itself).
 - A spinner / progress UI around CDK output.
 - Managing `cdk bootstrap` for the user (bootstrap is just another proxied subcommand; lstk does not run it implicitly).
-- Pulling real credentials from the ambient AWS credential chain. Account is controlled only by `--account` / `AWS_ACCESS_KEY_ID`; `secret_key` is always `test`.
+- Pulling real credentials from the ambient AWS credential chain. The account is fixed to the default LocalStack account; `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are always `test`, and the ambient `AWS_ACCESS_KEY_ID` is never used to select a different account.
+- Per-account targeting for CDK. `--account` is intentionally unsupported (see "Why CDK has no --account").
 
 ## Decisions
 
 ### Command wiring mirrors `lstk aws` / `lstk terraform`
-`cmd/cdk.go` defines a Cobra command with `Use: "cdk [args...]"`, `DisableFlagParsing: true`, and the standard `PreRunE` that calls `stripGlobalFlags` + `initConfig(nil)`. It reuses the terraform preamble: `runtime.NewDockerRuntime`, resolve the `config.EmulatorAWS` `ContainerConfig` (via the existing `resolveAWSContainer` helper in `cmd/terraform.go`), `rt.IsHealthy`, `container.ResolveRunningContainerName`, the non-AWS-emulator-running check (`runningNonAWSEmulator`), and `endpoint.ResolveHost`. It strips and validates `--region`/`--account` at the boundary, resolves the effective region/account, builds `http://host:port`, and hands off to a new domain entry point `cdkcli.Run(...)`.
+`cmd/cdk.go` defines a Cobra command with `Use: "cdk [args...]"`, `DisableFlagParsing: true`, and the standard `PreRunE` that calls `stripGlobalFlags` + `initConfig(nil)`. It reuses the terraform preamble: `runtime.NewDockerRuntime`, resolve the `config.EmulatorAWS` `ContainerConfig` (via the existing `resolveAWSContainer` helper in `cmd/terraform.go`), `rt.IsHealthy`, `container.ResolveRunningContainerName`, the non-AWS-emulator-running check (`runningNonAWSEmulator`), and `endpoint.ResolveHost`. It strips and validates `--region` at the boundary, rejects `--account` with an actionable error, resolves the effective region, builds `http://host:port`, and hands off to a new domain entry point `cdkcli.Run(...)`.
 
 No CLI alias is added — `cdk` is already short and has no conventional shorthand (unlike terraform's `tf`).
 
-**Reuse, don't duplicate, the flag helpers.** `resolveRegion`, `resolveAccount`, `accountIDRe`, `DeactivateAccessKey`, the leading-flag stripper, `rejectPreSubcommandFlags`, and `emitValidationError` already exist for terraform. CDK needs the same `--region`/`--account` semantics, so these are shared. The terraform-specific `-chdir` handling is **not** carried over — CDK has no equivalent global directory flag, so the CDK stripper only needs to extract `--region`/`--account`. Where the existing terraform stripper is terraform-specific (it also reads `-chdir`), factor the `--region`/`--account` extraction into a form both commands call rather than copy-pasting.
+**Reuse, don't duplicate, the flag helpers.** `resolveRegion`, the leading-flag stripper, `rejectPreSubcommandFlags`, and `emitValidationError` already exist for terraform. CDK needs the same `--region` semantics, so these are shared. The shared stripper still *consumes* a leading `--account` (so the tokens cannot leak into the forwarded cdk args), but CDK rejects any non-empty account value rather than acting on it; `resolveAccount`/`accountIDRe`/`DeactivateAccessKey` remain in use by terraform only. The terraform-specific `-chdir` handling is **not** carried over — CDK has no equivalent global directory flag.
 
 **Alternative considered:** generalize `lstk aws`/`terraform`/`cdk` into one shared proxy abstraction. Rejected for now (YAGNI) — the three differ in what they do with the endpoint (CLI flag vs. override file vs. env vars). We share the discrete helpers instead of the whole command body.
 
@@ -50,8 +51,8 @@ Code lives under the existing `internal/iac/` umbrella (which already hosts `int
 import cdkcli "github.com/localstack/lstk/internal/iac/cdk/cli"
 ```
 All business logic lives here. Suggested decomposition:
-- `exec.go` — `Run(ctx, endpointURL, region, account string, sink output.Sink, logger log.Logger, args []string) error`: locate the binary via `exec.LookPath(cdkCmd())`, verify the version (see below), build the environment, then run `cdk` via `exec.CommandContext` with `os.Stdin`/stdout/stderr wired through; non-zero exit wrapped as `output.NewSilentError` (same as `awscli.Exec`). Wrap in an OpenTelemetry span like `awscli.Exec`.
-- `env.go` — `cdkCmd()` reads `LSTK_CDK_CMD` (default `cdk`); `endpointURLOverride()` reads `AWS_ENDPOINT_URL`; `s3EndpointOverride()` reads `AWS_ENDPOINT_URL_S3`. `BuildEnv(base []string, endpointURL, s3Endpoint, region, account string) []string` produces the subprocess environment (set the LocalStack values, strip ambient AWS config — see "AWS environment construction").
+- `exec.go` — `Run(ctx, endpointURL, region string, sink output.Sink, logger log.Logger, args []string) error`: locate the binary via `exec.LookPath(cdkCmd())`, verify the version (see below), build the environment, then run `cdk` via `exec.CommandContext` with `os.Stdin`/stdout/stderr wired through; non-zero exit wrapped as `output.NewSilentError` (same as `awscli.Exec`). Wrap in an OpenTelemetry span like `awscli.Exec`.
+- `env.go` — `cdkCmd()` reads `LSTK_CDK_CMD` (default `cdk`); `endpointURLOverride()` reads `AWS_ENDPOINT_URL`; `s3EndpointOverride()` reads `AWS_ENDPOINT_URL_S3`. `BuildEnv(base []string, endpointURL, s3Endpoint, region string) []string` produces the subprocess environment (hardcoding `AWS_ACCESS_KEY_ID=test`) (set the LocalStack values, strip ambient AWS config — see "AWS environment construction").
 - `version.go` — `CheckVersion(ctx, cdkBin string) error`: run `<cdkBin> --version`, parse the leading `MAJOR.MINOR.PATCH`, and return an actionable error if it is below `2.177.0` or cannot be parsed.
 - `defaults.go` — the minimum supported version constant and the fixed offline-subcommand set, with an `IsOffline(args []string) bool` helper that finds the first non-flag token (the subcommand) and looks it up. This mirrors terraform's `IsUnproxied`/`subcommand`.
 
@@ -61,7 +62,7 @@ All business logic lives here. Suggested decomposition:
 Set (overriding any existing value):
 - `AWS_ENDPOINT_URL` = resolved `http://host:port` (or `AWS_ENDPOINT_URL` override).
 - `AWS_ENDPOINT_URL_S3` = the S3 endpoint (or `AWS_ENDPOINT_URL_S3` override). Derived from the base endpoint with the same `s3.`-prefix logic terraform uses for virtual-host-capable hosts (see "S3 endpoint").
-- `AWS_ACCESS_KEY_ID` = resolved account (default `test`), `AWS_SECRET_ACCESS_KEY` = `test`.
+- `AWS_ACCESS_KEY_ID` = `test` (fixed), `AWS_SECRET_ACCESS_KEY` = `test`. A non-12-digit access key id makes LocalStack resolve the default account `000000000000`. Both are set unconditionally, overriding any ambient values (including a 12-digit `AWS_ACCESS_KEY_ID` that would otherwise select a different account).
 - `AWS_REGION` = `AWS_DEFAULT_REGION` = resolved region.
 
 Remove (so they cannot redirect CDK at real AWS or override our region):
@@ -98,13 +99,18 @@ The endpoint environment is built and applied for **every** invocation, includin
 
 **Alternative considered — gate every subcommand on a running emulator (simpler).** Rejected: requiring a running LocalStack just to `cdk synth`/`cdk init`/`cdk ls` would be a poor experience for commands that demonstrably never touch AWS, and terraform already set the precedent of a fixed offline set.
 
+### Why CDK has no `--account`
+Unlike terraform — where lstk writes the account into a provider override file the tool reads directly — lstk has no in-band way to tell CDK which account to use. The only lever is `AWS_ACCESS_KEY_ID`, and CDK does not treat it as the account: CDK resolves the account by calling STS `GetCallerIdentity` at runtime, and LocalStack then derives the account *back* from the access key id (a 12-digit key → that account; otherwise `000000000000`). That indirect chain (lstk → env → CDK → STS → LocalStack → account, with a CDK-side account cache keyed by access key in the middle) proved unreliable: the account written into `cdk.out` did not consistently track `--account`, defaulting to `000000000000` regardless. Rather than ship a flag that silently doesn't work, CDK pins the default account. `lstk cdk` therefore rejects `--account` with a clear error instead of accepting a value it cannot honor. Multi-account CDK support can be revisited if a reliable, deterministic mechanism (e.g. injecting an explicit `aws://account/region` environment argument) is designed.
+
+**Alternative considered — keep `--account` and inject `aws://<account>/<region>` for the subcommands that accept it (`bootstrap`, `deploy`).** Rejected for now: it requires per-subcommand argument rewriting and only covers commands that take an explicit environment, so it would work inconsistently across the CDK surface. Out of scope for this change; the flag is removed rather than left half-working.
+
 ### No spinner; managed subprocess
 Per the same reasoning as terraform, no spinner wraps `cdk` and stdout/stderr are **not** routed through `StopOnWriteWriter` (unlike `aws.go`). `cdk deploy`/`bootstrap` stream progress that must remain intact, and CDK prompts interactively (e.g. `--require-approval`), so `os.Stdin` is wired straight through. We run `cdk` as a managed child (`exec.CommandContext`) rather than `syscall.Exec` for consistency with the other proxies and so the OpenTelemetry span closes cleanly; there is no cleanup step to protect (no files are generated), so process replacement would also be safe, but the managed child keeps the code uniform with `awscli`/`tfcli`.
 
 ## Risks / Trade-offs
 
 - **Old CDK silently targeting real AWS** → Mitigated by the mandatory `cdk --version` >= 2.177.0 check that aborts before any command runs.
-- **Real credentials in the environment** → Mitigated by stripping `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`AWS_SESSION_TOKEN` and overriding the key/secret with mock values; the `DeactivateAccessKey` safeguard neutralizes a real `AWS_ACCESS_KEY_ID` used as the account source.
+- **Real credentials in the environment** → Mitigated by stripping `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`AWS_SESSION_TOKEN` and overriding the key/secret with the fixed mock value `test`. Because CDK never reads `AWS_ACCESS_KEY_ID` from the environment as an account source, no real key can leak through that path.
 - **S3 path style on the `127.0.0.1` fallback** → CDK S3 asset operations fail when DNS-rebind protection forces the loopback host (the bare CLI has no env/config lever for path style). Non-S3 services are unaffected. Mitigated by a warning pointing at the DNS fix; a self-sufficient fix is out of scope for v1 (see the S3 endpoint decision).
 - **Version-parsing fragility** → `cdk --version` output could change format. Mitigated by parsing only the leading `MAJOR.MINOR.PATCH` and failing safe (treat unparseable output as too old, with a clear error).
 - **Subcommand classification drift** → New CDK subcommands won't be in the offline set and will default to requiring the emulator (the safe direction — at worst an unnecessary "start LocalStack" prompt, never an accidental real-AWS call). The set is easy to extend.

--- a/openspec/changes/add-cdk-proxy-command/design.md
+++ b/openspec/changes/add-cdk-proxy-command/design.md
@@ -1,0 +1,120 @@
+## Context
+
+lstk already proxies two AWS-facing tools at LocalStack:
+- `lstk aws` ([cmd/aws.go](../../../cmd/aws.go), [internal/awscli/exec.go](../../../internal/awscli/exec.go)) — strips lstk flags, makes a Docker runtime, resolves the AWS emulator container, checks health, resolves `host:port` via `endpoint.ResolveHost`, then execs `aws --endpoint-url …` with mock `AWS_*` env defaults.
+- `lstk terraform` ([cmd/terraform.go](../../../cmd/terraform.go), [internal/iac/terraform/cli/](../../../internal/iac/terraform/cli/)) — the same preamble plus `--region`/`--account` handling, then generates a provider-override file before running the real `terraform`.
+
+We want the same ergonomics for AWS CDK. The reference behavior is LocalStack's Node wrapper `cdklocal` (the `aws-cdk-local` package), which wraps the real `aws-cdk` CLI and points its API calls at LocalStack. Critically, `cdklocal`'s mechanism is **version-dependent**:
+- For **aws-cdk >= 2.177.0**, `cdklocal` removes ambient AWS configuration from the environment and sets `AWS_ENDPOINT_URL` and `AWS_ENDPOINT_URL_S3` (the latter "must include `.s3.` to correctly identify S3 API calls"), letting CDK's own AWS SDK target the LocalStack **endpoint**. Default endpoint: `http://localhost.localstack.cloud:4566`.
+- For **older CDK**, `cdklocal` monkey-patches the in-process Node AWS SDK at runtime (`SdkProvider.withAwsCliCompatibleDefaults`, `_makeSdk`, `ToolkitInfo.lookup`, credential providers, `forcePathStyle`).
+
+A subtlety that matters for this design: even at **>= 2.177.0**, `cdklocal` does **not** rely on env vars alone — the env vars cover the *endpoint*, but S3 *addressing style* (path-style vs. virtual-host) is still applied by in-process SDK patching, which an external subprocess cannot reach. So for `lstk cdk` the env-var mechanism is *endpoint-only*; S3 path style is unreachable. The resulting limitation on the loopback fallback is out of scope for v1 (see the S3 endpoint decision).
+
+lstk runs `cdk` as an external subprocess and cannot reach into CDK's Node SDK, so only the **environment-variable** mechanism is available to us — which means the endpoint is configurable but S3 addressing style is not. This is the central constraint that shapes the design: `lstk cdk` is fundamentally an environment-construction-plus-passthrough command (close to `lstk aws`), **not** a file-generation command like `lstk terraform`. There is no override file, no schema discovery, no HCL parsing, and no cleanup step.
+
+`cdklocal` reference behavior we carry over: invoke the real CDK CLI; default credentials to `test`/`test`; resolve the endpoint from a host/port (we resolve it ourselves instead of from `LOCALSTACK_HOSTNAME`/`EDGE_PORT`); strip conflicting AWS config so a stray profile can't redirect to real AWS; derive the S3 endpoint with an `s3.` host prefix.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `lstk cdk <args>` forwards all args to the real `cdk`, streaming stdin/stdout/stderr and propagating the exit code.
+- Auto-resolve the LocalStack endpoint from the running AWS emulator — no host/port env vars needed.
+- Build a clean, LocalStack-pointed AWS environment for the subprocess (`AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, mock creds, region) and strip ambient AWS config that could redirect CDK at real AWS.
+- Reuse the terraform command's `--region`/`--account` parsing, validation, precedence, and `DeactivateAccessKey` safeguard.
+- Gate AWS-contacting subcommands on a running AWS emulator (with the same AWS-specific "wrong emulator" messaging as terraform); run a fixed offline set without that requirement.
+- Fail fast and clearly when `cdk` is missing or older than 2.177.0.
+- Keep the architecture aligned with lstk conventions: cmd/ wiring only, domain logic in `internal/iac/cdk/cli/`, output via `output.Sink`, diagnostics via `log.Logger`, no direct stdout/stderr prints, no `config.Get()` in domain code.
+
+**Non-Goals:**
+- Depending on or shelling out to `cdklocal`/`aws-cdk-local`.
+- Reproducing `cdklocal`'s pre-2.177 in-process SDK monkey-patching (impossible for an external subprocess).
+- Supporting `cdklocal`-specific knobs like `LAMBDA_MOUNT_CODE`, `BUCKET_MARKER_LOCAL`, `AWS_ENVAR_ALLOWLIST`, `LOCALSTACK_HOSTNAME`, `EDGE_PORT` (lstk resolves the endpoint itself).
+- A spinner / progress UI around CDK output.
+- Managing `cdk bootstrap` for the user (bootstrap is just another proxied subcommand; lstk does not run it implicitly).
+- Pulling real credentials from the ambient AWS credential chain. Account is controlled only by `--account` / `AWS_ACCESS_KEY_ID`; `secret_key` is always `test`.
+
+## Decisions
+
+### Command wiring mirrors `lstk aws` / `lstk terraform`
+`cmd/cdk.go` defines a Cobra command with `Use: "cdk [args...]"`, `DisableFlagParsing: true`, and the standard `PreRunE` that calls `stripGlobalFlags` + `initConfig(nil)`. It reuses the terraform preamble: `runtime.NewDockerRuntime`, resolve the `config.EmulatorAWS` `ContainerConfig` (via the existing `resolveAWSContainer` helper in `cmd/terraform.go`), `rt.IsHealthy`, `container.ResolveRunningContainerName`, the non-AWS-emulator-running check (`runningNonAWSEmulator`), and `endpoint.ResolveHost`. It strips and validates `--region`/`--account` at the boundary, resolves the effective region/account, builds `http://host:port`, and hands off to a new domain entry point `cdkcli.Run(...)`.
+
+No CLI alias is added — `cdk` is already short and has no conventional shorthand (unlike terraform's `tf`).
+
+**Reuse, don't duplicate, the flag helpers.** `resolveRegion`, `resolveAccount`, `accountIDRe`, `DeactivateAccessKey`, the leading-flag stripper, `rejectPreSubcommandFlags`, and `emitValidationError` already exist for terraform. CDK needs the same `--region`/`--account` semantics, so these are shared. The terraform-specific `-chdir` handling is **not** carried over — CDK has no equivalent global directory flag, so the CDK stripper only needs to extract `--region`/`--account`. Where the existing terraform stripper is terraform-specific (it also reads `-chdir`), factor the `--region`/`--account` extraction into a form both commands call rather than copy-pasting.
+
+**Alternative considered:** generalize `lstk aws`/`terraform`/`cdk` into one shared proxy abstraction. Rejected for now (YAGNI) — the three differ in what they do with the endpoint (CLI flag vs. override file vs. env vars). We share the discrete helpers instead of the whole command body.
+
+### New domain package `internal/iac/cdk/cli/`
+Code lives under the existing `internal/iac/` umbrella (which already hosts `internal/iac/terraform/`), in the leaf package `internal/iac/cdk/cli` (Go `package cli`), imported at the single call site as `cdkcli`:
+```go
+import cdkcli "github.com/localstack/lstk/internal/iac/cdk/cli"
+```
+All business logic lives here. Suggested decomposition:
+- `exec.go` — `Run(ctx, endpointURL, region, account string, sink output.Sink, logger log.Logger, args []string) error`: locate the binary via `exec.LookPath(cdkCmd())`, verify the version (see below), build the environment, then run `cdk` via `exec.CommandContext` with `os.Stdin`/stdout/stderr wired through; non-zero exit wrapped as `output.NewSilentError` (same as `awscli.Exec`). Wrap in an OpenTelemetry span like `awscli.Exec`.
+- `env.go` — `cdkCmd()` reads `LSTK_CDK_CMD` (default `cdk`); `endpointURLOverride()` reads `AWS_ENDPOINT_URL`; `s3EndpointOverride()` reads `AWS_ENDPOINT_URL_S3`. `BuildEnv(base []string, endpointURL, s3Endpoint, region, account string) []string` produces the subprocess environment (set the LocalStack values, strip ambient AWS config — see "AWS environment construction").
+- `version.go` — `CheckVersion(ctx, cdkBin string) error`: run `<cdkBin> --version`, parse the leading `MAJOR.MINOR.PATCH`, and return an actionable error if it is below `2.177.0` or cannot be parsed.
+- `defaults.go` — the minimum supported version constant and the fixed offline-subcommand set, with an `IsOffline(args []string) bool` helper that finds the first non-flag token (the subcommand) and looks it up. This mirrors terraform's `IsUnproxied`/`subcommand`.
+
+### AWS environment construction (the core of the change)
+`BuildEnv` starts from `os.Environ()` and produces a subprocess environment that deterministically targets LocalStack. Following `cdklocal`'s >= 2.177 behavior, it both **sets** LocalStack values and **removes** ambient AWS configuration that could otherwise win:
+
+Set (overriding any existing value):
+- `AWS_ENDPOINT_URL` = resolved `http://host:port` (or `AWS_ENDPOINT_URL` override).
+- `AWS_ENDPOINT_URL_S3` = the S3 endpoint (or `AWS_ENDPOINT_URL_S3` override). Derived from the base endpoint with the same `s3.`-prefix logic terraform uses for virtual-host-capable hosts (see "S3 endpoint").
+- `AWS_ACCESS_KEY_ID` = resolved account (default `test`), `AWS_SECRET_ACCESS_KEY` = `test`.
+- `AWS_REGION` = `AWS_DEFAULT_REGION` = resolved region.
+
+Remove (so they cannot redirect CDK at real AWS or override our region):
+- `AWS_PROFILE`, `AWS_DEFAULT_PROFILE` — a named profile would pull real credentials/region from `~/.aws`.
+- `AWS_SESSION_TOKEN` — a stale real session token alongside our mock key would be rejected or, worse, route to real AWS.
+
+This is the safety-critical part of the design: the whole point of pinning the endpoint **and** clearing profile/session state is that a user with real AWS credentials configured cannot accidentally `lstk cdk deploy` into their real account. It directly mirrors why `cdklocal` strips AWS env vars before invoking `cdk`.
+
+`CDK_DISABLE_LEGACY_EXPORT_WARNING=1` is optionally set to quiet a noisy CDK warning, matching `cdklocal`; it has no correctness impact.
+
+**Alternative considered — pass an `--endpoint`-style flag instead of env vars.** Rejected: the CDK CLI has no global endpoint flag; environment variables are the only supported lever for >= 2.177, which is exactly why the version floor exists.
+
+### Minimum CDK version 2.177.0
+Because lstk only sets environment variables (it cannot patch CDK's in-process SDK the way `cdklocal` does for older versions), CDK must be a version that honors `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3` — i.e. **>= 2.177.0**. On an older CDK, those variables are ignored and `cdk deploy` would silently target **real AWS** with our mock credentials (best case: an auth failure; worst case, with real creds not fully stripped, a real deploy). That is unacceptable, so `Run` checks `cdk --version` up front and fails with an actionable error naming the minimum version before doing anything else.
+
+**Alternative considered — skip the check and document the requirement.** Rejected: the failure mode (silently hitting real AWS) is severe enough to justify a fast, explicit guard rather than relying on the user reading the help text. The check is one cheap subprocess invocation, only on proxied paths is the running emulator also required, but the version check runs for every invocation since even offline commands behave differently across versions and the floor is a hard product requirement.
+
+### S3 endpoint
+`AWS_ENDPOINT_URL_S3` is derived from the base endpoint exactly as terraform derives its `s3` endpoint key value (the `s3Addressing`/`virtualHostCapable` logic in [internal/iac/terraform/cli/override.go](../../../internal/iac/terraform/cli/override.go)):
+
+| Resolved host | `AWS_ENDPOINT_URL_S3` |
+|---|---|
+| virtual-host-capable `*.localstack.cloud` (e.g. `localhost.localstack.cloud`) | `http://s3.<host>:<port>` |
+| `127.0.0.1` / `localhost` | `http://<host>:<port>` (bare) |
+
+This matches `cdklocal`'s documented default (`https://s3.localhost.localstack.cloud:4566`) and the "must include `.s3.`" guidance for the virtual-host case.
+
+**Path-style on the `127.0.0.1` fallback — out of scope for v1.** When `endpoint.ResolveHost` falls back to `127.0.0.1` (DNS-rebind protection blocks `localhost.localstack.cloud`), CDK's S3 asset operations (`bootstrap`, asset-bearing `deploy`s) attempt virtual-host addressing and fail, because the bare CDK CLI exposes `forcePathStyle` only as a code-level client argument with no env/config lever a subprocess can set. Non-S3 services are unaffected. lstk surfaces the DNS fallback as a `SeverityWarning` (`dnsOK == false`); the supported path is ensuring `localhost.localstack.cloud` resolves. A self-sufficient fix is out of scope for v1.
+
+### Offline vs. AWS-contacting subcommands
+A fixed set of CDK subcommands never contacts AWS and therefore does not require a running emulator: `init`, `synth` (`synthesize`), `ls` (`list`), `version`, `doctor`, `acknowledge` (`ack`), `context`, `notices`. Everything else (`bootstrap`, `deploy`, `destroy`, `diff`, `import`, `watch`, `rollback`, `gc`, `migrate`, …) is treated as AWS-contacting and is gated on a running AWS emulator, emitting the same actionable error as `lstk terraform` (and the AWS-specific message when a non-AWS emulator is running). The set is fixed and intentionally not configurable, mirroring terraform's `unproxiedCommands`.
+
+The endpoint environment is built and applied for **every** invocation, including offline commands — it is harmless when no API call is made, and it means a `synth` that does perform a context lookup (e.g. `fromLookup`) still routes to LocalStack rather than real AWS. Only the *emulator-running gate* distinguishes offline from AWS-contacting commands. (`synth` can in principle trigger AWS context lookups; classifying it offline means lstk won't require the emulator for it. If a lookup does fire without a running emulator, CDK surfaces its own error — an acceptable, honest failure.)
+
+**Alternative considered — gate every subcommand on a running emulator (simpler).** Rejected: requiring a running LocalStack just to `cdk synth`/`cdk init`/`cdk ls` would be a poor experience for commands that demonstrably never touch AWS, and terraform already set the precedent of a fixed offline set.
+
+### No spinner; managed subprocess
+Per the same reasoning as terraform, no spinner wraps `cdk` and stdout/stderr are **not** routed through `StopOnWriteWriter` (unlike `aws.go`). `cdk deploy`/`bootstrap` stream progress that must remain intact, and CDK prompts interactively (e.g. `--require-approval`), so `os.Stdin` is wired straight through. We run `cdk` as a managed child (`exec.CommandContext`) rather than `syscall.Exec` for consistency with the other proxies and so the OpenTelemetry span closes cleanly; there is no cleanup step to protect (no files are generated), so process replacement would also be safe, but the managed child keeps the code uniform with `awscli`/`tfcli`.
+
+## Risks / Trade-offs
+
+- **Old CDK silently targeting real AWS** → Mitigated by the mandatory `cdk --version` >= 2.177.0 check that aborts before any command runs.
+- **Real credentials in the environment** → Mitigated by stripping `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`AWS_SESSION_TOKEN` and overriding the key/secret with mock values; the `DeactivateAccessKey` safeguard neutralizes a real `AWS_ACCESS_KEY_ID` used as the account source.
+- **S3 path style on the `127.0.0.1` fallback** → CDK S3 asset operations fail when DNS-rebind protection forces the loopback host (the bare CLI has no env/config lever for path style). Non-S3 services are unaffected. Mitigated by a warning pointing at the DNS fix; a self-sufficient fix is out of scope for v1 (see the S3 endpoint decision).
+- **Version-parsing fragility** → `cdk --version` output could change format. Mitigated by parsing only the leading `MAJOR.MINOR.PATCH` and failing safe (treat unparseable output as too old, with a clear error).
+- **Subcommand classification drift** → New CDK subcommands won't be in the offline set and will default to requiring the emulator (the safe direction — at worst an unnecessary "start LocalStack" prompt, never an accidental real-AWS call). The set is easy to extend.
+
+## Migration Plan
+
+Additive change — no migration for existing lstk users. Users currently using `cdklocal` can switch to `lstk cdk` once on aws-cdk >= 2.177.0; the supported environment variables and the version requirement are documented in the command help, `README.md`, and `CLAUDE.md`. No rollback concerns beyond not shipping the command.
+
+## Open Questions
+
+None — resolved during design.
+
+**Bootstrap UX (resolved).** `lstk cdk` does not detect a not-yet-bootstrapped environment or hint `lstk cdk bootstrap`; the not-bootstrapped error is left to CDK to surface. This keeps lstk a transparent passthrough and is consistent with the non-goal of not managing `cdk bootstrap` implicitly.

--- a/openspec/changes/add-cdk-proxy-command/proposal.md
+++ b/openspec/changes/add-cdk-proxy-command/proposal.md
@@ -9,15 +9,15 @@ Users running AWS CDK against LocalStack today must install LocalStack's separat
 - Resolve the LocalStack endpoint automatically via lstk's existing container discovery + `endpoint.ResolveHost`, instead of the `LOCALSTACK_HOSTNAME`/`EDGE_PORT` environment variables `cdklocal` relies on.
 - Invoke the **real `cdk` binary directly** (configurable via `LSTK_CDK_CMD`, default `cdk`) and reimplement `cdklocal`'s endpoint setup natively in Go — exactly as `lstk terraform` invokes `terraform` rather than `tflocal`. lstk does **not** depend on `cdklocal` or `aws-cdk-local`.
 - Require **AWS CDK >= 2.177.0**. From that version the CDK CLI honors `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3`, so the endpoint can be set entirely through environment variables. Earlier versions only worked via `cdklocal`'s in-process Node SDK monkey-patching, which a Go subprocess cannot reproduce; lstk fails fast with an actionable error rather than silently deploying to real AWS.
-- Support lstk-specific `--region <region>` and `--account <id>` flags (leading position, before the CDK action), reusing the same parsing/validation/precedence as `lstk terraform` (including the `AWS_ACCESS_KEY_ID` access-key deactivation safeguard).
+- Support an lstk-specific `--region <region>` flag (leading position, before the CDK action), reusing the same parsing/validation/precedence as `lstk terraform`. CDK does **not** support `--account`: it always operates against the default LocalStack account `000000000000`, and a leading `--account` is rejected with an actionable error (the indirect STS-derived account chain CDK requires cannot reliably honor it — see design.md "Why CDK has no --account").
 - Gate AWS-contacting subcommands (`bootstrap`, `deploy`, `destroy`, `diff`, `import`, `watch`, `rollback`, …) on a running AWS emulator, emitting the same actionable "not running" error as `lstk terraform`. A fixed set of offline subcommands (`init`, `synth`, `ls`, `version`, `doctor`, `acknowledge`/`ack`, `context`, `notices`) runs without requiring the emulator.
 - Stream `cdk`'s stdin/stdout/stderr through unobstructed and propagate its exit code. **No spinner**, no lifecycle-event capture — `cdk deploy`/`bootstrap` are long-running, streaming commands whose own output must remain intact (same decision as `lstk terraform`).
-- Support a small environment-variable surface: `LSTK_CDK_CMD`, `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`, and `AWS_ACCESS_KEY_ID`.
+- Support a small environment-variable surface: `LSTK_CDK_CMD`, `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, and `AWS_REGION`. `AWS_ACCESS_KEY_ID` is **not** read for account selection — it is always overridden with `test`.
 
 ## Capabilities
 
 ### New Capabilities
-- `cdk-proxy`: Running AWS CDK against a running LocalStack instance through `lstk`, including automatic endpoint resolution, a clean LocalStack-pointed AWS environment for the `cdk` subprocess, mock credentials with region/account selection, emulator-gating of AWS-contacting commands, and a defined set of supported environment variables.
+- `cdk-proxy`: Running AWS CDK against a running LocalStack instance through `lstk`, including automatic endpoint resolution, a clean LocalStack-pointed AWS environment for the `cdk` subprocess, mock credentials with region selection (account fixed to the default `000000000000`), emulator-gating of AWS-contacting commands, and a defined set of supported environment variables.
 
 ### Modified Capabilities
 <!-- None: no existing specs change. -->
@@ -26,6 +26,6 @@ Users running AWS CDK against LocalStack today must install LocalStack's separat
 
 - **New command wiring**: `cmd/cdk.go` (Cobra command), registered in the root command alongside `newAWSCmd`/`newTerraformCmd`.
 - **New domain package**: `internal/iac/cdk/cli/` (Go `package cli`, imported as `cdkcli`) for binary discovery, version checking, AWS-environment construction, and subprocess execution. Lives under the existing `internal/iac/` umbrella next to `internal/iac/terraform/`.
-- **Reused infrastructure**: `internal/container` (`ResolveRunningContainerName`, `RunningEmulators`), `internal/endpoint` (`ResolveHost`), `internal/runtime` (Docker health), `internal/output` (sink/events), `internal/config` (AWS emulator container resolution). The `--region`/`--account` parsing, validation, and `DeactivateAccessKey` safeguard from the terraform command are shared rather than duplicated.
+- **Reused infrastructure**: `internal/container` (`ResolveRunningContainerName`, `RunningEmulators`), `internal/endpoint` (`ResolveHost`), `internal/runtime` (Docker health), `internal/output` (sink/events), `internal/config` (AWS emulator container resolution). The `--region` parsing, validation, and leading-flag stripping from the terraform command are shared rather than duplicated. `--account` is rejected for CDK.
 - **External dependency**: requires the `cdk` binary (AWS CDK CLI >= 2.177.0) on `PATH`. No new Go module dependencies.
 - **Docs**: update `README.md` and `CLAUDE.md` to document the new command, its supported environment variables, and the CDK >= 2.177.0 requirement.

--- a/openspec/changes/add-cdk-proxy-command/proposal.md
+++ b/openspec/changes/add-cdk-proxy-command/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Users running AWS CDK against LocalStack today must install LocalStack's separate Node wrapper, `cdklocal` (the `aws-cdk-local` npm package), which depends on a matching `aws-cdk` install and points CDK's API calls at LocalStack. lstk already proxies the AWS CLI via `lstk aws` and Terraform via `lstk terraform`; extending the same pattern to CDK lets users run `lstk cdk` with no extra wrapper and with the LocalStack endpoint resolved automatically from the running emulator.
+
+## What Changes
+
+- Add a new `lstk cdk <args>` command that proxies all arguments to the real `cdk` binary, mirroring the passthrough behavior of `lstk aws`.
+- Before invoking `cdk`, build a clean AWS environment for the subprocess that points CDK at the running LocalStack instance: set `AWS_ENDPOINT_URL` (and an `.s3.`-prefixed `AWS_ENDPOINT_URL_S3`) to the resolved LocalStack endpoint, set mock credentials and region, and **strip ambient AWS configuration** (`AWS_PROFILE`, `AWS_DEFAULT_PROFILE`, `AWS_SESSION_TOKEN`, and any real `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`) so a stray profile cannot silently redirect a deploy at real AWS.
+- Resolve the LocalStack endpoint automatically via lstk's existing container discovery + `endpoint.ResolveHost`, instead of the `LOCALSTACK_HOSTNAME`/`EDGE_PORT` environment variables `cdklocal` relies on.
+- Invoke the **real `cdk` binary directly** (configurable via `LSTK_CDK_CMD`, default `cdk`) and reimplement `cdklocal`'s endpoint setup natively in Go — exactly as `lstk terraform` invokes `terraform` rather than `tflocal`. lstk does **not** depend on `cdklocal` or `aws-cdk-local`.
+- Require **AWS CDK >= 2.177.0**. From that version the CDK CLI honors `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3`, so the endpoint can be set entirely through environment variables. Earlier versions only worked via `cdklocal`'s in-process Node SDK monkey-patching, which a Go subprocess cannot reproduce; lstk fails fast with an actionable error rather than silently deploying to real AWS.
+- Support lstk-specific `--region <region>` and `--account <id>` flags (leading position, before the CDK action), reusing the same parsing/validation/precedence as `lstk terraform` (including the `AWS_ACCESS_KEY_ID` access-key deactivation safeguard).
+- Gate AWS-contacting subcommands (`bootstrap`, `deploy`, `destroy`, `diff`, `import`, `watch`, `rollback`, …) on a running AWS emulator, emitting the same actionable "not running" error as `lstk terraform`. A fixed set of offline subcommands (`init`, `synth`, `ls`, `version`, `doctor`, `acknowledge`/`ack`, `context`, `notices`) runs without requiring the emulator.
+- Stream `cdk`'s stdin/stdout/stderr through unobstructed and propagate its exit code. **No spinner**, no lifecycle-event capture — `cdk deploy`/`bootstrap` are long-running, streaming commands whose own output must remain intact (same decision as `lstk terraform`).
+- Support a small environment-variable surface: `LSTK_CDK_CMD`, `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`, and `AWS_ACCESS_KEY_ID`.
+
+## Capabilities
+
+### New Capabilities
+- `cdk-proxy`: Running AWS CDK against a running LocalStack instance through `lstk`, including automatic endpoint resolution, a clean LocalStack-pointed AWS environment for the `cdk` subprocess, mock credentials with region/account selection, emulator-gating of AWS-contacting commands, and a defined set of supported environment variables.
+
+### Modified Capabilities
+<!-- None: no existing specs change. -->
+
+## Impact
+
+- **New command wiring**: `cmd/cdk.go` (Cobra command), registered in the root command alongside `newAWSCmd`/`newTerraformCmd`.
+- **New domain package**: `internal/iac/cdk/cli/` (Go `package cli`, imported as `cdkcli`) for binary discovery, version checking, AWS-environment construction, and subprocess execution. Lives under the existing `internal/iac/` umbrella next to `internal/iac/terraform/`.
+- **Reused infrastructure**: `internal/container` (`ResolveRunningContainerName`, `RunningEmulators`), `internal/endpoint` (`ResolveHost`), `internal/runtime` (Docker health), `internal/output` (sink/events), `internal/config` (AWS emulator container resolution). The `--region`/`--account` parsing, validation, and `DeactivateAccessKey` safeguard from the terraform command are shared rather than duplicated.
+- **External dependency**: requires the `cdk` binary (AWS CDK CLI >= 2.177.0) on `PATH`. No new Go module dependencies.
+- **Docs**: update `README.md` and `CLAUDE.md` to document the new command, its supported environment variables, and the CDK >= 2.177.0 requirement.

--- a/openspec/changes/add-cdk-proxy-command/specs/cdk-proxy/spec.md
+++ b/openspec/changes/add-cdk-proxy-command/specs/cdk-proxy/spec.md
@@ -40,32 +40,34 @@ The system SHALL require AWS CDK CLI version 2.177.0 or newer, because lstk poin
 ### Requirement: Mock credentials and AWS environment isolation
 The system SHALL provide LocalStack-compatible mock credentials to the `cdk` subprocess and SHALL strip ambient AWS configuration that could redirect CDK to real AWS. lstk SHALL NOT require, read, or inject the LocalStack auth token for CDK-to-LocalStack API calls; the auth token only activates the emulator container.
 
+CDK always operates against the default LocalStack account `000000000000`; lstk SHALL set a fixed mock `AWS_ACCESS_KEY_ID=test` and SHALL NOT derive the account from a flag or from the ambient `AWS_ACCESS_KEY_ID`.
+
 #### Scenario: Provide mock credentials and region
 - **WHEN** lstk runs a CDK command
-- **THEN** the subprocess environment contains `AWS_ACCESS_KEY_ID` (the resolved account, default `test`), `AWS_SECRET_ACCESS_KEY=test`, and the resolved region in `AWS_REGION`/`AWS_DEFAULT_REGION`
+- **THEN** the subprocess environment contains `AWS_ACCESS_KEY_ID=test`, `AWS_SECRET_ACCESS_KEY=test`, and the resolved region in `AWS_REGION`/`AWS_DEFAULT_REGION`
 
 #### Scenario: Strip ambient AWS configuration
 - **WHEN** the user's environment contains `AWS_PROFILE`, `AWS_DEFAULT_PROFILE`, `AWS_SESSION_TOKEN`, or real `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` values
 - **THEN** lstk removes or overrides them in the subprocess environment so CDK cannot resolve credentials or a profile that point at real AWS
 
-#### Scenario: Neutralize a real access key supplied via environment
-- **WHEN** `AWS_ACCESS_KEY_ID` is used as the account source and its value looks like a real AWS key (begins with `A`, e.g. `AKIA…`/`ASIA…`)
-- **THEN** lstk deactivates it (rewrites the leading `A` to `L`) before placing it in the subprocess environment
+#### Scenario: A 12-digit AWS_ACCESS_KEY_ID does not change the account
+- **WHEN** the user's environment contains a 12-digit `AWS_ACCESS_KEY_ID` (an account id)
+- **THEN** lstk overrides it with `test` so CDK still operates against the default account `000000000000`
 
-### Requirement: Region and account selection
-The system SHALL accept lstk-specific `--region` and `--account` flags in leading position (before the CDK subcommand) and encode them into the subprocess environment, with the same parsing and precedence as `lstk terraform`.
+### Requirement: Region selection
+The system SHALL accept the lstk-specific `--region` flag in leading position (before the CDK subcommand) and encode it into the subprocess environment, with the same parsing and precedence as `lstk terraform`. The system SHALL NOT accept an `--account` flag for CDK.
 
 #### Scenario: Region precedence
 - **WHEN** `--region` is omitted
 - **THEN** lstk resolves the region from `AWS_REGION`, falling back to `us-east-1`
 
-#### Scenario: Account precedence and validation
-- **WHEN** `--account` is provided
-- **THEN** lstk validates it is exactly 12 digits, using it as `AWS_ACCESS_KEY_ID`; when omitted, lstk uses `AWS_ACCESS_KEY_ID` from the environment, falling back to `test`
+#### Scenario: Reject the --account flag
+- **WHEN** `--account` is provided to `lstk cdk` in leading position, with any value
+- **THEN** lstk fails at the command boundary with an error explaining that `--account` is not supported and that CDK always uses the default LocalStack account `000000000000`, and does not invoke `cdk`
 
 #### Scenario: Flags only in leading position
-- **WHEN** `--region`/`--account` appear after the CDK subcommand (e.g. `lstk cdk deploy --region us-west-2`)
-- **THEN** lstk forwards them to `cdk` unchanged rather than consuming them
+- **WHEN** `--region` appears after the CDK subcommand (e.g. `lstk cdk deploy --region us-west-2`)
+- **THEN** lstk forwards it to `cdk` unchanged rather than consuming it
 
 ### Requirement: Emulator gating for AWS-contacting commands
 The system SHALL require a running AWS emulator for CDK subcommands that contact AWS APIs and SHALL run a fixed set of offline subcommands without that requirement.

--- a/openspec/changes/add-cdk-proxy-command/specs/cdk-proxy/spec.md
+++ b/openspec/changes/add-cdk-proxy-command/specs/cdk-proxy/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: CDK CLI proxy command
+The system SHALL provide an `lstk cdk` command that forwards all of its arguments to the real AWS CDK CLI (`cdk`) and, before invoking it, configures the subprocess environment to target the running LocalStack instance.
+
+#### Scenario: Pass through CDK arguments
+- **WHEN** the user runs `lstk cdk deploy MyStack --require-approval never`
+- **THEN** lstk invokes the `cdk` binary with `deploy MyStack --require-approval never` intact and propagates its exit code
+
+#### Scenario: Inject LocalStack endpoint into the CDK environment
+- **WHEN** lstk runs a CDK command
+- **THEN** the `cdk` subprocess receives `AWS_ENDPOINT_URL` set to the resolved LocalStack endpoint and `AWS_ENDPOINT_URL_S3` set to the corresponding S3 endpoint (with an `s3.` host prefix when the host is virtual-host-capable)
+
+#### Scenario: Honor an explicit endpoint override
+- **WHEN** `AWS_ENDPOINT_URL` is already set in the environment
+- **THEN** lstk uses that value instead of the auto-resolved endpoint
+
+### Requirement: Direct cdk invocation with no cdklocal dependency
+The system SHALL invoke the real `cdk` binary directly and SHALL NOT require or invoke `cdklocal`/`aws-cdk-local`. The binary name SHALL be configurable via `LSTK_CDK_CMD`, defaulting to `cdk`.
+
+#### Scenario: Resolve the cdk binary from PATH
+- **WHEN** `lstk cdk` runs and `cdk` is on `PATH`
+- **THEN** lstk locates and executes it
+
+#### Scenario: Override the binary name
+- **WHEN** `LSTK_CDK_CMD` is set to an alternative binary name
+- **THEN** lstk invokes that binary instead of `cdk`
+
+#### Scenario: Missing CDK binary
+- **WHEN** the configured CDK binary is not found on `PATH`
+- **THEN** lstk emits an actionable error directing the user to install the AWS CDK CLI and does not attempt to run anything
+
+### Requirement: Minimum CDK version
+The system SHALL require AWS CDK CLI version 2.177.0 or newer, because lstk points CDK at LocalStack purely through environment variables (`AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3`), which older CDK versions do not honor.
+
+#### Scenario: CDK version is too old
+- **WHEN** the resolved `cdk` binary reports a version older than 2.177.0
+- **THEN** lstk fails with an actionable error explaining the minimum version, and does not run the command (so it cannot silently target real AWS)
+
+### Requirement: Mock credentials and AWS environment isolation
+The system SHALL provide LocalStack-compatible mock credentials to the `cdk` subprocess and SHALL strip ambient AWS configuration that could redirect CDK to real AWS. lstk SHALL NOT require, read, or inject the LocalStack auth token for CDK-to-LocalStack API calls; the auth token only activates the emulator container.
+
+#### Scenario: Provide mock credentials and region
+- **WHEN** lstk runs a CDK command
+- **THEN** the subprocess environment contains `AWS_ACCESS_KEY_ID` (the resolved account, default `test`), `AWS_SECRET_ACCESS_KEY=test`, and the resolved region in `AWS_REGION`/`AWS_DEFAULT_REGION`
+
+#### Scenario: Strip ambient AWS configuration
+- **WHEN** the user's environment contains `AWS_PROFILE`, `AWS_DEFAULT_PROFILE`, `AWS_SESSION_TOKEN`, or real `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` values
+- **THEN** lstk removes or overrides them in the subprocess environment so CDK cannot resolve credentials or a profile that point at real AWS
+
+#### Scenario: Neutralize a real access key supplied via environment
+- **WHEN** `AWS_ACCESS_KEY_ID` is used as the account source and its value looks like a real AWS key (begins with `A`, e.g. `AKIA…`/`ASIA…`)
+- **THEN** lstk deactivates it (rewrites the leading `A` to `L`) before placing it in the subprocess environment
+
+### Requirement: Region and account selection
+The system SHALL accept lstk-specific `--region` and `--account` flags in leading position (before the CDK subcommand) and encode them into the subprocess environment, with the same parsing and precedence as `lstk terraform`.
+
+#### Scenario: Region precedence
+- **WHEN** `--region` is omitted
+- **THEN** lstk resolves the region from `AWS_REGION`, falling back to `us-east-1`
+
+#### Scenario: Account precedence and validation
+- **WHEN** `--account` is provided
+- **THEN** lstk validates it is exactly 12 digits, using it as `AWS_ACCESS_KEY_ID`; when omitted, lstk uses `AWS_ACCESS_KEY_ID` from the environment, falling back to `test`
+
+#### Scenario: Flags only in leading position
+- **WHEN** `--region`/`--account` appear after the CDK subcommand (e.g. `lstk cdk deploy --region us-west-2`)
+- **THEN** lstk forwards them to `cdk` unchanged rather than consuming them
+
+### Requirement: Emulator gating for AWS-contacting commands
+The system SHALL require a running AWS emulator for CDK subcommands that contact AWS APIs and SHALL run a fixed set of offline subcommands without that requirement.
+
+#### Scenario: AWS-contacting command without a running emulator
+- **WHEN** the user runs an AWS-contacting subcommand (e.g. `lstk cdk deploy`) and the AWS emulator is not running
+- **THEN** lstk emits an actionable "LocalStack is not running" error (with a command to start it) and does not invoke `cdk`
+
+#### Scenario: A different emulator is running
+- **WHEN** an AWS-contacting CDK command is run while a non-AWS emulator (e.g. Snowflake or Azure) is running but the AWS emulator is not
+- **THEN** lstk fails with an AWS-specific error naming the running emulator rather than a misleading generic "not running" message
+
+#### Scenario: Offline command without a running emulator
+- **WHEN** the user runs an offline subcommand (e.g. `lstk cdk synth`, `lstk cdk ls`, `lstk cdk init`)
+- **THEN** lstk runs it without requiring a running emulator
+
+### Requirement: Streamed passthrough output
+The system SHALL stream the CDK subprocess's stdin, stdout, and stderr through unobstructed and SHALL NOT display a spinner or capture CDK output into lifecycle events.
+
+#### Scenario: Unobstructed streaming
+- **WHEN** a long-running CDK command (e.g. `lstk cdk deploy`) produces incremental output
+- **THEN** lstk streams that output directly to the terminal without a spinner or reformatting, and forwards interactive prompts via stdin
+
+#### Scenario: Propagate failure
+- **WHEN** the CDK command exits non-zero
+- **THEN** lstk returns a silent error carrying that exit status so the top-level handler does not reprint it

--- a/openspec/changes/add-cdk-proxy-command/tasks.md
+++ b/openspec/changes/add-cdk-proxy-command/tasks.md
@@ -1,0 +1,64 @@
+## 1. Domain package scaffolding
+
+- [x] 1.1 Create `internal/iac/cdk/cli/` package (Go `package cli`, imported as `cdkcli`) with a `Run(ctx context.Context, endpointURL, region, account string, sink output.Sink, logger log.Logger, args []string) error` entry-point signature
+- [x] 1.2 Add `defaults.go`: the minimum-supported-version constant (`2.177.0`) and the fixed offline-subcommand set (`init`, `synth`/`synthesize`, `ls`/`list`, `version`, `doctor`, `acknowledge`/`ack`, `context`, `notices`) with an `IsOffline(args []string) bool` helper that resolves the first non-flag token (mirror terraform's `IsUnproxied`/`subcommand`). The set is fixed, not env-configurable
+- [x] 1.3 Add `env.go` with package-scoped env helpers: `cdkCmd()` (`LSTK_CDK_CMD`, default `cdk`), `endpointURLOverride()` (`AWS_ENDPOINT_URL`), and `s3EndpointOverride()` (`AWS_ENDPOINT_URL_S3`). Do NOT read `LOCALSTACK_HOSTNAME`/`EDGE_PORT`/`AWS_DEFAULT_REGION`
+
+## 2. AWS environment construction
+
+- [x] 2.1 Implement `BuildEnv(base []string, endpointURL, s3Endpoint, region, account string) []string`: start from `base` (`os.Environ()`), then SET `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID` (account), `AWS_SECRET_ACCESS_KEY=test`, `AWS_REGION`, and `AWS_DEFAULT_REGION` (overriding any existing values), and optionally `CDK_DISABLE_LEGACY_EXPORT_WARNING=1`
+- [x] 2.2 In `BuildEnv`, REMOVE ambient AWS config that could redirect CDK at real AWS: `AWS_PROFILE`, `AWS_DEFAULT_PROFILE`, `AWS_SESSION_TOKEN` (and ensure the mock key/secret override any real `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`)
+- [x] 2.3 Derive the S3 endpoint: reuse/extract terraform's `s3Addressing`/`virtualHostCapable` logic so a virtual-host-capable `*.localstack.cloud` host gets an `s3.`-prefixed endpoint and `127.0.0.1`/`localhost` gets the bare endpoint; let `AWS_ENDPOINT_URL_S3` override the derivation. Factor the shared helper into a location both `tfcli` and `cdkcli` can use rather than duplicating it
+- [x] 2.4 Unit-test `BuildEnv`: LocalStack values are set; `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`AWS_SESSION_TOKEN` are stripped; a real `AWS_ACCESS_KEY_ID` in `base` is overridden; the `s3.` prefix appears for virtual-host hosts and not for `127.0.0.1`/`localhost`; `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3` overrides win
+
+## 3. Version checking
+
+- [x] 3.1 Implement `version.go` `CheckVersion(ctx context.Context, cdkBin string) error`: run `<cdkBin> --version`, parse the leading `MAJOR.MINOR.PATCH`, and return an actionable error when the version is below `2.177.0`
+- [x] 3.2 Fail safe on unparseable `--version` output (treat as too old) with a clear error mentioning the minimum version
+- [x] 3.3 Unit-test the version parse/compare: `2.177.0` and newer pass; `2.176.x` and older fail; malformed output fails
+
+## 4. Execution orchestration
+
+- [x] 4.1 In `exec.go`, resolve the binary via `exec.LookPath(cdkCmd())`; on failure return a clear "install the AWS CDK CLI" error
+- [x] 4.2 Call `CheckVersion` before running; abort with the actionable error when it fails (so an old CDK can never silently target real AWS)
+- [x] 4.3 Build the subprocess environment via `BuildEnv` and run `cdk` via `exec.CommandContext` with `os.Stdin` and the passed stdout/stderr writers; wrap non-zero exit as `output.NewSilentError`; do NOT wrap output in a spinner writer
+- [x] 4.4 Add an OpenTelemetry span around execution (mirror `internal/awscli/exec.go`), recording the args and exit code
+
+## 5. Region/account flag handling (shared with terraform)
+
+- [x] 5.1 Extract the `--region`/`--account` leading-flag parsing, validation (`accountIDRe`, 12-digit), precedence (`resolveRegion`/`resolveAccount`), `DeactivateAccessKey`, `rejectPreSubcommandFlags`, and `emitValidationError` from `cmd/terraform.go` into a form both `terraform` and `cdk` call (do NOT duplicate). The CDK stripper extracts only `--region`/`--account` (no `-chdir`)
+- [x] 5.2 Resolve effective region (`--region` → `AWS_REGION` → `us-east-1`) and account (`--account` → `AWS_ACCESS_KEY_ID` → `test`, run through `DeactivateAccessKey`) at the cmd boundary and pass into `cdkcli.Run`
+- [x] 5.3 Unit-test the shared parser still behaves for terraform (regression) and for cdk: both flag forms, missing value, invalid account, env fallback, leading-only behavior (flags after the subcommand forwarded verbatim)
+
+## 6. Command wiring
+
+- [x] 6.1 Add `cmd/cdk.go` with `newCDKCmd(cfg *env.Env, logger log.Logger)`: `Use: "cdk [args...]"`, `DisableFlagParsing: true`, `PreRunE` = `stripGlobalFlags` + `initConfig(nil)`, and `Long` help documenting `--region`/`--account`, the supported env vars, the CDK >= 2.177.0 requirement, and that LocalStack must be running for AWS-contacting commands
+- [x] 6.2 In `RunE`: reject pre-subcommand `--region`/`--account`, strip+resolve the flags, then for offline subcommands (`IsOffline`) call `cdkcli.Run` with an empty endpoint and no emulator gating
+- [x] 6.3 For AWS-contacting subcommands, reuse the terraform preamble (`runtime.NewDockerRuntime`, `resolveAWSContainer`, `rt.IsHealthy`/`EmitUnhealthyError`, `container.ResolveRunningContainerName`, the `runningNonAWSEmulator` AWS-specific error, `endpoint.ResolveHost`), then call `cdkcli.Run` with `http://host:port`
+- [x] 6.4 When `endpoint.ResolveHost` returns the `127.0.0.1` DNS-rebind fallback, emit a `SeverityWarning` note that CDK S3 asset operations may not work on the loopback host and suggest ensuring `localhost.localstack.cloud` resolves (or setting `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3`)
+- [x] 6.5 Register the command in the root command alongside `newAWSCmd`/`newTerraformCmd`
+
+## 7. Tests
+
+- [x] 7.1 Integration test: `lstk cdk <args>` forwards args and propagates exit code, using a stub `cdk` binary on `PATH` (that also answers `--version` with a >= 2.177.0 string) and an isolated `$HOME` via `testEnvWithHome`
+- [x] 7.2 Integration test: the stub `cdk` records its environment; assert `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3`/`AWS_REGION`/mock creds are set and `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`AWS_SESSION_TOKEN` are stripped
+- [x] 7.3 Integration test: an AWS-contacting command (e.g. `deploy`) fails with the "not running" error and does not invoke `cdk` when no emulator is running; and fails with the AWS-specific message when a non-AWS emulator is running
+- [x] 7.4 Integration test: offline commands (`init`/`synth`/`ls`/`version`/`doctor`) run without requiring a running emulator (including with leading `--region`/`--account` present, which are stripped)
+- [x] 7.5 Integration test: a stub `cdk` reporting a version below 2.177.0 causes a clear failure before the command runs; a missing `cdk` binary yields the install error
+- [x] 7.6 Integration test: leading `--region`/`--account` are stripped and reflected in the subprocess env; invalid `--account` fails before `cdk` is invoked; `--region`/`--account` after the subcommand are forwarded to `cdk` unchanged; `lstk --account … cdk` (before the subcommand) is rejected
+- [x] 7.7 Integration test: `LSTK_CDK_CMD` causes lstk to invoke the alternative binary stub instead of `cdk`
+
+## 8. End-to-end (real cdk + LocalStack)
+
+- [x] 8.1 Harness: a Docker+token+cdk-gated helper that brings up a real LocalStack via `lstk start` (named so name-based discovery finds it, 4566 on 127.0.0.1) and a readable sample CDK app under `test/integration/test-samples/iac/cdk/<name>/`, copied into a temp dir per test (gitignore the CDK `cdk.out`/asset artifacts). Skip when Docker, a real `cdk` (>= 2.177.0), or the auth token is absent
+- [x] 8.2 E2E: `lstk cdk bootstrap` succeeds against LocalStack
+- [x] 8.3 E2E: `lstk cdk deploy --require-approval never` of a minimal stack (e.g. a single S3 bucket or SSM parameter) succeeds against LocalStack and `lstk cdk destroy --force` tears it down
+- [x] 8.4 E2E: `lstk cdk synth` of the sample app succeeds without a running emulator (offline path)
+- [x] 8.5 CI: install the AWS CDK CLI (>= 2.177.0) on the Linux integration shards; skip on shards where it is unavailable. Raise the integration timeout if the CDK bootstrap/deploy + image pull pushes the suite past the current budget
+- [x] 8.6 New sample `test/integration/test-samples/iac/cdk/lambda-asset/`: a stack with a `lambda.Function` whose code is `lambda.Code.fromAsset("lambda")` pointing at a real `lambda/index.js` Node handler. It MUST use `fromAsset`, not `fromInline` (inline embeds the code in the template and never produces an S3 asset, defeating the purpose). Reuses the existing `copyCDKSample`/`npmInstall` helpers and gitignores `cdk.out`/`node_modules`/asset artifacts like `single-bucket`. Validated with `cdk synth`: the synthesized `AWS::Lambda::Function` references `S3Bucket: cdk-hnb659fds-assets-…` + `S3Key: <hash>.zip` (confirming a real S3 asset, not inline code)
+- [x] 8.7 E2E (separate test case `TestCDKE2ELambdaAssetDeployDestroy`, distinct from the bucket deploy): full Lambda round-trip against LocalStack — `lstk cdk bootstrap`, `lstk cdk deploy --require-approval never`, then `lstk cdk destroy --force`. Unlike the bucket-only stack (whose small template may be passed inline to CloudFormation), a `fromAsset` Lambda guarantees a real `PutObject` across `AWS_ENDPOINT_URL_S3` at deploy time, so deploy success is itself the assertion that the asset path routed through LocalStack — hardening that guarantee from "probably" to "definitely". When the real `aws` CLI is on `PATH` (e.g. GitHub-hosted runners) the test additionally invokes the function via `lstk aws lambda invoke` and asserts the handler output, proving end-to-end provisioning from the uploaded asset; that step is skipped (deploy still runs) where `aws` is absent, since the suite does not otherwise depend on the real CLI and there is no `aws-sdk-go` dependency. Gated identically (Docker + real `cdk` + npm + token) and serialized with the other container e2e tests via `cleanup()` (no `t.Parallel()`); the Lambda runtime image pull makes the raised timeout in 8.5 non-optional. The test comment is precise that it is the CLI's asset *publish* that exercises lstk's injected S3 endpoint, not LocalStack's internal read of the asset
+
+## 9. Documentation
+
+- [x] 9.1 Command `Long` help: document `--region`/`--account`, the supported env vars (`LSTK_CDK_CMD`, `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`), the CDK >= 2.177.0 requirement, and that LocalStack must be running for AWS-contacting commands. Write `Short`/`Long` as unbroken paragraphs per the CLI help-text convention
+- [x] 9.2 Add a "CDK Integration" section to `README.md` (mirroring the Terraform section) and note the new command + IaC umbrella in `CLAUDE.md`

--- a/openspec/changes/add-cdk-proxy-command/tasks.md
+++ b/openspec/changes/add-cdk-proxy-command/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Domain package scaffolding
 
-- [x] 1.1 Create `internal/iac/cdk/cli/` package (Go `package cli`, imported as `cdkcli`) with a `Run(ctx context.Context, endpointURL, region, account string, sink output.Sink, logger log.Logger, args []string) error` entry-point signature
+- [x] 1.1 Create `internal/iac/cdk/cli/` package (Go `package cli`, imported as `cdkcli`) with a `Run(ctx context.Context, endpointURL, region string, sink output.Sink, logger log.Logger, args []string) error` entry-point signature (no `account` parameter — CDK always uses the default account)
 - [x] 1.2 Add `defaults.go`: the minimum-supported-version constant (`2.177.0`) and the fixed offline-subcommand set (`init`, `synth`/`synthesize`, `ls`/`list`, `version`, `doctor`, `acknowledge`/`ack`, `context`, `notices`) with an `IsOffline(args []string) bool` helper that resolves the first non-flag token (mirror terraform's `IsUnproxied`/`subcommand`). The set is fixed, not env-configurable
 - [x] 1.3 Add `env.go` with package-scoped env helpers: `cdkCmd()` (`LSTK_CDK_CMD`, default `cdk`), `endpointURLOverride()` (`AWS_ENDPOINT_URL`), and `s3EndpointOverride()` (`AWS_ENDPOINT_URL_S3`). Do NOT read `LOCALSTACK_HOSTNAME`/`EDGE_PORT`/`AWS_DEFAULT_REGION`
 
 ## 2. AWS environment construction
 
-- [x] 2.1 Implement `BuildEnv(base []string, endpointURL, s3Endpoint, region, account string) []string`: start from `base` (`os.Environ()`), then SET `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID` (account), `AWS_SECRET_ACCESS_KEY=test`, `AWS_REGION`, and `AWS_DEFAULT_REGION` (overriding any existing values), and optionally `CDK_DISABLE_LEGACY_EXPORT_WARNING=1`
+- [x] 2.1 Implement `BuildEnv(base []string, endpointURL, s3Endpoint, region string) []string`: start from `base` (`os.Environ()`), then SET `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID=test` (fixed — never an account), `AWS_SECRET_ACCESS_KEY=test`, `AWS_REGION`, and `AWS_DEFAULT_REGION` (overriding any existing values), and optionally `CDK_DISABLE_LEGACY_EXPORT_WARNING=1`
 - [x] 2.2 In `BuildEnv`, REMOVE ambient AWS config that could redirect CDK at real AWS: `AWS_PROFILE`, `AWS_DEFAULT_PROFILE`, `AWS_SESSION_TOKEN` (and ensure the mock key/secret override any real `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`)
 - [x] 2.3 Derive the S3 endpoint: reuse/extract terraform's `s3Addressing`/`virtualHostCapable` logic so a virtual-host-capable `*.localstack.cloud` host gets an `s3.`-prefixed endpoint and `127.0.0.1`/`localhost` gets the bare endpoint; let `AWS_ENDPOINT_URL_S3` override the derivation. Factor the shared helper into a location both `tfcli` and `cdkcli` can use rather than duplicating it
-- [x] 2.4 Unit-test `BuildEnv`: LocalStack values are set; `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`AWS_SESSION_TOKEN` are stripped; a real `AWS_ACCESS_KEY_ID` in `base` is overridden; the `s3.` prefix appears for virtual-host hosts and not for `127.0.0.1`/`localhost`; `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3` overrides win
+- [x] 2.4 Unit-test `BuildEnv`: LocalStack values are set; `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`AWS_SESSION_TOKEN` are stripped; `AWS_ACCESS_KEY_ID` is always `test` even when `base` contains a real key or a 12-digit account id (proving no account can be selected via env); the `s3.` prefix appears for virtual-host hosts and not for `127.0.0.1`/`localhost`; `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3` overrides win
 
 ## 3. Version checking
 
@@ -24,16 +24,16 @@
 - [x] 4.3 Build the subprocess environment via `BuildEnv` and run `cdk` via `exec.CommandContext` with `os.Stdin` and the passed stdout/stderr writers; wrap non-zero exit as `output.NewSilentError`; do NOT wrap output in a spinner writer
 - [x] 4.4 Add an OpenTelemetry span around execution (mirror `internal/awscli/exec.go`), recording the args and exit code
 
-## 5. Region/account flag handling (shared with terraform)
+## 5. Region flag handling (shared with terraform)
 
-- [x] 5.1 Extract the `--region`/`--account` leading-flag parsing, validation (`accountIDRe`, 12-digit), precedence (`resolveRegion`/`resolveAccount`), `DeactivateAccessKey`, `rejectPreSubcommandFlags`, and `emitValidationError` from `cmd/terraform.go` into a form both `terraform` and `cdk` call (do NOT duplicate). The CDK stripper extracts only `--region`/`--account` (no `-chdir`)
-- [x] 5.2 Resolve effective region (`--region` → `AWS_REGION` → `us-east-1`) and account (`--account` → `AWS_ACCESS_KEY_ID` → `test`, run through `DeactivateAccessKey`) at the cmd boundary and pass into `cdkcli.Run`
-- [x] 5.3 Unit-test the shared parser still behaves for terraform (regression) and for cdk: both flag forms, missing value, invalid account, env fallback, leading-only behavior (flags after the subcommand forwarded verbatim)
+- [x] 5.1 Extract the `--region`/`--account` leading-flag parsing, `rejectPreSubcommandFlags`, and `emitValidationError` from `cmd/terraform.go` into a form both `terraform` and `cdk` call (do NOT duplicate). The shared stripper still consumes a leading `--account` so it cannot leak into the forwarded cdk args; `resolveAccount`/`accountIDRe`/`DeactivateAccessKey` stay terraform-only. The CDK stripper handles no `-chdir`
+- [x] 5.2 Resolve effective region (`--region` → `AWS_REGION` → `us-east-1`) at the cmd boundary and pass into `cdkcli.Run`. Do NOT resolve an account; reject a non-empty `--account` (see 6.2)
+- [x] 5.3 Unit-test the shared parser still behaves for terraform (regression — account precedence/validation intact) and for cdk: `--region` both flag forms, missing value, env fallback, leading-only behavior (flags after the subcommand forwarded verbatim)
 
 ## 6. Command wiring
 
-- [x] 6.1 Add `cmd/cdk.go` with `newCDKCmd(cfg *env.Env, logger log.Logger)`: `Use: "cdk [args...]"`, `DisableFlagParsing: true`, `PreRunE` = `stripGlobalFlags` + `initConfig(nil)`, and `Long` help documenting `--region`/`--account`, the supported env vars, the CDK >= 2.177.0 requirement, and that LocalStack must be running for AWS-contacting commands
-- [x] 6.2 In `RunE`: reject pre-subcommand `--region`/`--account`, strip+resolve the flags, then for offline subcommands (`IsOffline`) call `cdkcli.Run` with an empty endpoint and no emulator gating
+- [x] 6.1 Add `cmd/cdk.go` with `newCDKCmd(cfg *env.Env, logger log.Logger)`: `Use: "cdk [args...]"`, `DisableFlagParsing: true`, `PreRunE` = `stripGlobalFlags` + `initConfig(nil)`, and `Long` help documenting `--region` (and that CDK always uses the default account `000000000000`, with no `--account` flag), the supported env vars, the CDK >= 2.177.0 requirement, and that LocalStack must be running for AWS-contacting commands
+- [x] 6.2 In `RunE`: reject pre-subcommand `--region`/`--account`, strip the leading flags, reject a non-empty `--account` with an actionable "not supported; CDK always uses 000000000000" error, resolve the region, then for offline subcommands (`IsOffline`) call `cdkcli.Run` with an empty endpoint and no emulator gating
 - [x] 6.3 For AWS-contacting subcommands, reuse the terraform preamble (`runtime.NewDockerRuntime`, `resolveAWSContainer`, `rt.IsHealthy`/`EmitUnhealthyError`, `container.ResolveRunningContainerName`, the `runningNonAWSEmulator` AWS-specific error, `endpoint.ResolveHost`), then call `cdkcli.Run` with `http://host:port`
 - [x] 6.4 When `endpoint.ResolveHost` returns the `127.0.0.1` DNS-rebind fallback, emit a `SeverityWarning` note that CDK S3 asset operations may not work on the loopback host and suggest ensuring `localhost.localstack.cloud` resolves (or setting `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3`)
 - [x] 6.5 Register the command in the root command alongside `newAWSCmd`/`newTerraformCmd`
@@ -43,9 +43,9 @@
 - [x] 7.1 Integration test: `lstk cdk <args>` forwards args and propagates exit code, using a stub `cdk` binary on `PATH` (that also answers `--version` with a >= 2.177.0 string) and an isolated `$HOME` via `testEnvWithHome`
 - [x] 7.2 Integration test: the stub `cdk` records its environment; assert `AWS_ENDPOINT_URL`/`AWS_ENDPOINT_URL_S3`/`AWS_REGION`/mock creds are set and `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`AWS_SESSION_TOKEN` are stripped
 - [x] 7.3 Integration test: an AWS-contacting command (e.g. `deploy`) fails with the "not running" error and does not invoke `cdk` when no emulator is running; and fails with the AWS-specific message when a non-AWS emulator is running
-- [x] 7.4 Integration test: offline commands (`init`/`synth`/`ls`/`version`/`doctor`) run without requiring a running emulator (including with leading `--region`/`--account` present, which are stripped)
+- [x] 7.4 Integration test: offline commands (`init`/`synth`/`ls`/`version`/`doctor`) run without requiring a running emulator (including with a leading `--region` present, which is stripped)
 - [x] 7.5 Integration test: a stub `cdk` reporting a version below 2.177.0 causes a clear failure before the command runs; a missing `cdk` binary yields the install error
-- [x] 7.6 Integration test: leading `--region`/`--account` are stripped and reflected in the subprocess env; invalid `--account` fails before `cdk` is invoked; `--region`/`--account` after the subcommand are forwarded to `cdk` unchanged; `lstk --account … cdk` (before the subcommand) is rejected
+- [x] 7.6 Integration test: leading `--region` is stripped and reflected in the subprocess env (with `AWS_ACCESS_KEY_ID=test`); a leading `--account` (any value, including a valid 12-digit one) is rejected before `cdk` is invoked with the "not supported" message; a 12-digit `AWS_ACCESS_KEY_ID` in the environment still yields `AWS_ACCESS_KEY_ID=test` (account stays default); `--region` after the subcommand is forwarded to `cdk` unchanged; `lstk --account … cdk` (before the subcommand) is rejected
 - [x] 7.7 Integration test: `LSTK_CDK_CMD` causes lstk to invoke the alternative binary stub instead of `cdk`
 
 ## 8. End-to-end (real cdk + LocalStack)
@@ -60,5 +60,5 @@
 
 ## 9. Documentation
 
-- [x] 9.1 Command `Long` help: document `--region`/`--account`, the supported env vars (`LSTK_CDK_CMD`, `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`), the CDK >= 2.177.0 requirement, and that LocalStack must be running for AWS-contacting commands. Write `Short`/`Long` as unbroken paragraphs per the CLI help-text convention
+- [x] 9.1 Command `Long` help: document `--region` (and that CDK always uses the default account `000000000000` — no `--account`), the supported env vars (`LSTK_CDK_CMD`, `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`), the CDK >= 2.177.0 requirement, and that LocalStack must be running for AWS-contacting commands. Write `Short`/`Long` as unbroken paragraphs per the CLI help-text convention
 - [x] 9.2 Add a "CDK Integration" section to `README.md` (mirroring the Terraform section) and note the new command + IaC umbrella in `CLAUDE.md`

--- a/test/integration/cdk_cmd_test.go
+++ b/test/integration/cdk_cmd_test.go
@@ -1,0 +1,246 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFakeCDK creates a stub `cdk` that answers `--version` with the given
+// version string and, for any other invocation, echoes its args and the AWS
+// environment it was given so tests can assert what lstk injected/stripped.
+func writeFakeCDK(t *testing.T, version string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cdk script not supported on Windows")
+	}
+	dir := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "%s"
+  exit 0
+fi
+echo "ARGS:$*"
+echo "ENV_AWS_ENDPOINT_URL=$AWS_ENDPOINT_URL"
+echo "ENV_AWS_ENDPOINT_URL_S3=$AWS_ENDPOINT_URL_S3"
+echo "ENV_AWS_REGION=$AWS_REGION"
+echo "ENV_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+echo "ENV_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+echo "ENV_AWS_PROFILE=${AWS_PROFILE:-<unset>}"
+echo "ENV_AWS_DEFAULT_PROFILE=${AWS_DEFAULT_PROFILE:-<unset>}"
+echo "ENV_AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-<unset>}"
+`, version)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cdk"), []byte(script), 0755))
+	return dir
+}
+
+// writeFakeCDKExit creates a stub `cdk` reporting a supported version but exiting
+// with the given code for any real subcommand.
+func writeFakeCDKExit(t *testing.T, code int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cdk script not supported on Windows")
+	}
+	dir := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--version" ]; then echo "2.177.0"; exit 0; fi
+echo "cdk: simulated failure" >&2
+exit %d
+`, code)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cdk"), []byte(script), 0755))
+	return dir
+}
+
+// 7.1 — forwards args. `synth` is offline, so no emulator/Docker is required.
+func TestCDKForwardsArgs(t *testing.T) {
+	t.Parallel()
+	fakeDir := writeFakeCDK(t, "2.177.0 (build abc123)")
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "cdk", "synth")
+	require.NoError(t, err, "stderr: %s", stderr)
+	assert.Contains(t, stdout, "ARGS:synth")
+}
+
+// 7.1 — propagates the cdk exit code.
+func TestCDKPropagatesExitCode(t *testing.T) {
+	t.Parallel()
+	fakeDir := writeFakeCDKExit(t, 7)
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+	_, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "cdk", "synth")
+	require.Error(t, err)
+	assert.Contains(t, stderr, "simulated failure")
+	requireExitCode(t, 7, err)
+}
+
+// 7.2 — the subprocess gets the LocalStack-pointing env, and ambient AWS config
+// that could redirect at real AWS is stripped.
+func TestCDKInjectsCleanAWSEnv(t *testing.T) {
+	t.Parallel()
+	fakeDir := writeFakeCDK(t, "2.177.0")
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir()).
+		With(env.Key("AWS_PROFILE"), "my-real-profile").
+		With(env.Key("AWS_DEFAULT_PROFILE"), "other").
+		With(env.Key("AWS_SESSION_TOKEN"), "realtoken").
+		With(env.Key("AWS_ACCESS_KEY_ID"), "AKIAREALKEY")
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
+		"cdk", "--region", "eu-west-1", "--account", "123456789012", "synth")
+	require.NoError(t, err, "stderr: %s", stderr)
+
+	assert.Contains(t, stdout, "ENV_AWS_ENDPOINT_URL=http")
+	assert.Contains(t, stdout, ":4566")
+	assert.Contains(t, stdout, "ENV_AWS_ENDPOINT_URL_S3=http")
+	assert.Contains(t, stdout, "ENV_AWS_REGION=eu-west-1")
+	assert.Contains(t, stdout, "ENV_AWS_ACCESS_KEY_ID=123456789012")
+	assert.Contains(t, stdout, "ENV_AWS_SECRET_ACCESS_KEY=test")
+	// Ambient AWS config is stripped.
+	assert.Contains(t, stdout, "ENV_AWS_PROFILE=<unset>")
+	assert.Contains(t, stdout, "ENV_AWS_DEFAULT_PROFILE=<unset>")
+	assert.Contains(t, stdout, "ENV_AWS_SESSION_TOKEN=<unset>")
+}
+
+// 7.4 — offline subcommands run without a running emulator, even with leading
+// --region/--account present (which are stripped from the forwarded args).
+func TestCDKOfflineCommandsNoEmulator(t *testing.T) {
+	t.Parallel()
+	for _, sub := range []string{"init", "synth", "ls", "version", "doctor"} {
+		sub := sub
+		t.Run(sub, func(t *testing.T) {
+			t.Parallel()
+			fakeDir := writeFakeCDK(t, "2.177.0")
+			e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+			stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
+				"cdk", "--region", "us-west-2", "--account", "111111111111", sub)
+			require.NoError(t, err, "stderr: %s", stderr)
+
+			assert.Contains(t, stdout, "ARGS:"+sub)
+			assert.NotContains(t, stdout, "--region")
+			assert.NotContains(t, stdout, "--account")
+		})
+	}
+}
+
+// 7.5 — a too-old cdk fails before the command runs.
+func TestCDKVersionTooOld(t *testing.T) {
+	t.Parallel()
+	fakeDir := writeFakeCDK(t, "2.176.0 (build old)")
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "cdk", "synth")
+	require.Error(t, err)
+	assert.Contains(t, stderr+stdout, "2.177.0")
+	// cdk was never run for real.
+	assert.NotContains(t, stdout, "ARGS:synth")
+}
+
+// 7.5 — a missing cdk binary yields the install error.
+func TestCDKMissingBinary(t *testing.T) {
+	t.Parallel()
+	e := env.With(env.DisableEvents, "1").With("PATH", t.TempDir()).With(env.Home, t.TempDir())
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "cdk", "synth")
+	require.Error(t, err)
+	assert.Contains(t, stderr+stdout, "not found in PATH")
+}
+
+// 7.6 — invalid --account fails at the command boundary before cdk is invoked.
+func TestCDKInvalidAccountRejected(t *testing.T) {
+	t.Parallel()
+	fakeDir := writeFakeCDK(t, "2.177.0")
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
+		"cdk", "--account", "12345", "synth")
+	require.Error(t, err)
+	assert.Contains(t, stderr+stdout, "12-digit")
+	assert.NotContains(t, stdout, "ARGS:synth")
+}
+
+// 7.6 — flags after the subcommand are forwarded to cdk unchanged.
+func TestCDKFlagsAfterActionAreForwarded(t *testing.T) {
+	t.Parallel()
+	fakeDir := writeFakeCDK(t, "2.177.0")
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
+		"cdk", "synth", "--region", "us-west-2")
+	require.NoError(t, err, "stderr: %s", stderr)
+	assert.Contains(t, stdout, "ARGS:synth --region us-west-2")
+}
+
+// 7.6 — a flag before the subcommand is rejected with a clear message.
+func TestCDKFlagBeforeSubcommandRejected(t *testing.T) {
+	t.Parallel()
+	fakeDir := writeFakeCDK(t, "2.177.0")
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
+		"--account", "111111111111", "cdk", "synth")
+	require.Error(t, err)
+	assert.Contains(t, stderr+stdout, "must appear after the cdk subcommand")
+}
+
+// 7.7 — LSTK_CDK_CMD selects the binary to invoke.
+func TestCDKHonorsLstkCdkCmd(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cdk script not supported on Windows")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mycdk"),
+		[]byte("#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo \"2.177.0\"; exit 0; fi\necho \"MYCDK:$*\"\n"), 0755))
+	e := env.With(env.DisableEvents, "1").With("PATH", dir).With(env.Home, t.TempDir()).
+		With(env.Key("LSTK_CDK_CMD"), "mycdk")
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "cdk", "synth")
+	require.NoError(t, err, "stderr: %s", stderr)
+	assert.Contains(t, stdout, "MYCDK:synth")
+}
+
+// 7.3 — an AWS-contacting command with no running emulator fails with "not
+// running" and does not invoke cdk.
+func TestCDKFailsWhenEmulatorNotRunning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	fakeDir := writeFakeCDK(t, "2.177.0")
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+	stdout, _, err := runLstk(t, testContext(t), t.TempDir(), e, "cdk", "deploy")
+	require.Error(t, err)
+	assert.Contains(t, stdout, "is not running")
+	assert.Contains(t, stdout, "Start LocalStack:")
+	assert.NotContains(t, stdout, "ARGS:deploy")
+}
+
+// 7.3 — an AWS-contacting command fails with an AWS-specific error naming the
+// running non-AWS emulator, and does not invoke cdk.
+func TestCDKRequiresAWSEmulator(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	cleanupSnowflake()
+	t.Cleanup(cleanup)
+	t.Cleanup(cleanupSnowflake)
+
+	ctx := testContext(t)
+	startTestSnowflakeContainer(t, ctx)
+
+	fakeDir := writeFakeCDK(t, "2.177.0")
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+
+	stdout, _, err := runLstk(t, ctx, t.TempDir(), e, "cdk", "deploy")
+	require.Error(t, err)
+	assert.Contains(t, stdout, "requires the")
+	assert.Contains(t, stdout, "Snowflake")
+	assert.NotContains(t, stdout, "ARGS:deploy")
+}

--- a/test/integration/cdk_cmd_test.go
+++ b/test/integration/cdk_cmd_test.go
@@ -85,21 +85,24 @@ func TestCDKPropagatesExitCode(t *testing.T) {
 func TestCDKInjectsCleanAWSEnv(t *testing.T) {
 	t.Parallel()
 	fakeDir := writeFakeCDK(t, "2.177.0")
+	// A 12-digit AWS_ACCESS_KEY_ID would make LocalStack resolve a custom
+	// account; lstk must override it with "test" so CDK always uses the default
+	// account 000000000000.
 	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir()).
 		With(env.Key("AWS_PROFILE"), "my-real-profile").
 		With(env.Key("AWS_DEFAULT_PROFILE"), "other").
 		With(env.Key("AWS_SESSION_TOKEN"), "realtoken").
-		With(env.Key("AWS_ACCESS_KEY_ID"), "AKIAREALKEY")
+		With(env.Key("AWS_ACCESS_KEY_ID"), "999999999999")
 
 	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
-		"cdk", "--region", "eu-west-1", "--account", "123456789012", "synth")
+		"cdk", "--region", "eu-west-1", "synth")
 	require.NoError(t, err, "stderr: %s", stderr)
 
 	assert.Contains(t, stdout, "ENV_AWS_ENDPOINT_URL=http")
 	assert.Contains(t, stdout, ":4566")
 	assert.Contains(t, stdout, "ENV_AWS_ENDPOINT_URL_S3=http")
 	assert.Contains(t, stdout, "ENV_AWS_REGION=eu-west-1")
-	assert.Contains(t, stdout, "ENV_AWS_ACCESS_KEY_ID=123456789012")
+	assert.Contains(t, stdout, "ENV_AWS_ACCESS_KEY_ID=test")
 	assert.Contains(t, stdout, "ENV_AWS_SECRET_ACCESS_KEY=test")
 	// Ambient AWS config is stripped.
 	assert.Contains(t, stdout, "ENV_AWS_PROFILE=<unset>")
@@ -107,8 +110,8 @@ func TestCDKInjectsCleanAWSEnv(t *testing.T) {
 	assert.Contains(t, stdout, "ENV_AWS_SESSION_TOKEN=<unset>")
 }
 
-// 7.4 — offline subcommands run without a running emulator, even with leading
-// --region/--account present (which are stripped from the forwarded args).
+// 7.4 — offline subcommands run without a running emulator, even with a leading
+// --region present (which is stripped from the forwarded args).
 func TestCDKOfflineCommandsNoEmulator(t *testing.T) {
 	t.Parallel()
 	for _, sub := range []string{"init", "synth", "ls", "version", "doctor"} {
@@ -119,12 +122,11 @@ func TestCDKOfflineCommandsNoEmulator(t *testing.T) {
 			e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
 
 			stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
-				"cdk", "--region", "us-west-2", "--account", "111111111111", sub)
+				"cdk", "--region", "us-west-2", sub)
 			require.NoError(t, err, "stderr: %s", stderr)
 
 			assert.Contains(t, stdout, "ARGS:"+sub)
 			assert.NotContains(t, stdout, "--region")
-			assert.NotContains(t, stdout, "--account")
 		})
 	}
 }
@@ -152,17 +154,24 @@ func TestCDKMissingBinary(t *testing.T) {
 	assert.Contains(t, stderr+stdout, "not found in PATH")
 }
 
-// 7.6 — invalid --account fails at the command boundary before cdk is invoked.
-func TestCDKInvalidAccountRejected(t *testing.T) {
+// 7.6 — --account is not supported for cdk and is rejected at the command
+// boundary (with any value, including a valid 12-digit one) before cdk runs.
+func TestCDKAccountRejected(t *testing.T) {
 	t.Parallel()
-	fakeDir := writeFakeCDK(t, "2.177.0")
-	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
+	for _, value := range []string{"123456789012", "12345"} {
+		value := value
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+			fakeDir := writeFakeCDK(t, "2.177.0")
+			e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).With(env.Home, t.TempDir())
 
-	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
-		"cdk", "--account", "12345", "synth")
-	require.Error(t, err)
-	assert.Contains(t, stderr+stdout, "12-digit")
-	assert.NotContains(t, stdout, "ARGS:synth")
+			stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
+				"cdk", "--account", value, "synth")
+			require.Error(t, err)
+			assert.Contains(t, stderr+stdout, "not supported")
+			assert.NotContains(t, stdout, "ARGS:synth")
+		})
+	}
 }
 
 // 7.6 — flags after the subcommand are forwarded to cdk unchanged.

--- a/test/integration/cdk_e2e_test.go
+++ b/test/integration/cdk_e2e_test.go
@@ -1,0 +1,192 @@
+package integration_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/require"
+)
+
+// End-to-end tests for `lstk cdk` that exercise the real AWS CDK CLI against a
+// real LocalStack container (see localstack_test.go for the shared bring-up
+// helpers) — unlike cdk_cmd_test.go, which uses a stub cdk and an alpine
+// stand-in. They are gated on Docker + a real cdk binary + npm + an auth token
+// (CI installs cdk on the Linux shards and provides the token; otherwise they
+// skip).
+//
+// A successful `cdk deploy` against LocalStack proves the full path: lstk
+// injected AWS_ENDPOINT_URL/AWS_ENDPOINT_URL_S3 + mock creds, CDK routed
+// CloudFormation and the S3 asset staging through them, and LocalStack served
+// the calls. The S3 staging in particular validates the virtual-host S3
+// endpoint (s3.localhost.localstack.cloud) lstk derives.
+
+func requireCDK(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("cdk"); err != nil {
+		t.Skip("cdk binary not found on PATH")
+	}
+}
+
+func requireNpm(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("npm"); err != nil {
+		t.Skip("npm not found on PATH")
+	}
+}
+
+// copyCDKSample copies a CDK sample project from test-samples/iac/cdk into a
+// fresh temp dir. Tests run there so node_modules/cdk.out never touch the
+// tracked tree.
+func copyCDKSample(t *testing.T, name string) string {
+	t.Helper()
+	work := t.TempDir()
+	src := filepath.Join("test-samples", "iac", "cdk", name)
+	require.NoError(t, os.CopyFS(work, os.DirFS(src)))
+	return work
+}
+
+// npmInstall installs the sample's dependencies (aws-cdk-lib, constructs) into
+// the copied work dir so the CDK app can synthesize. The sample pins
+// aws-cdk-lib to an older exact version on purpose: a CDK CLI can read cloud
+// assemblies from its own and older aws-cdk-lib schema versions but not newer
+// ones, so pinning the library below the minimum supported CLI (2.177) keeps
+// synth/deploy working against any CLI >= 2.177, including the latest CI installs.
+func npmInstall(t *testing.T, ctx context.Context, work string, e env.Environ) {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, "npm", "install", "--no-audit", "--no-fund", "--loglevel=error")
+	cmd.Dir = work
+	cmd.Env = e
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("npm install failed: %v\n%s", err, out)
+	}
+}
+
+// runCDK runs `lstk cdk <args>` and returns stdout, stderr, err. Wrapping
+// runLstk lets the e2e tests read in cdk terms.
+func runCDK(t *testing.T, ctx context.Context, work string, e env.Environ, args ...string) (string, string, error) {
+	t.Helper()
+	return runLstk(t, ctx, work, e, append([]string{"cdk"}, args...)...)
+}
+
+// cdkE2EEnv inherits the real PATH (so the real cdk/node are found) with an
+// isolated HOME.
+func cdkE2EEnv(t *testing.T) env.Environ {
+	t.Helper()
+	return env.With(env.DisableEvents, "1").With(env.Home, t.TempDir())
+}
+
+// 8.4 — `cdk synth` succeeds offline (no running emulator required).
+func TestCDKE2ESynthOffline(t *testing.T) {
+	requireCDK(t)
+	requireNpm(t)
+
+	ctx := testContext(t)
+	work := copyCDKSample(t, "single-bucket")
+	e := cdkE2EEnv(t)
+	npmInstall(t, ctx, work, e)
+
+	_, stderr, err := runCDK(t, ctx, work, e, "synth")
+	require.NoError(t, err, "cdk synth stderr: %s", stderr)
+}
+
+// 8.1 + 8.2 — `cdk bootstrap` succeeds against a real LocalStack (also
+// exercises the bring-up harness).
+func TestCDKE2EBootstrap(t *testing.T) {
+	requireDocker(t)
+	requireCDK(t)
+	requireNpm(t)
+	token := requireAuthToken(t)
+	cleanup()
+	t.Cleanup(cleanup)
+	ctx := testContext(t)
+	startRealLocalStack(t, ctx, token)
+
+	work := copyCDKSample(t, "single-bucket")
+	e := cdkE2EEnv(t)
+	npmInstall(t, ctx, work, e)
+
+	_, stderr, err := runCDK(t, ctx, work, e, "bootstrap")
+	require.NoError(t, err, "cdk bootstrap stderr: %s", stderr)
+}
+
+// 8.3 — `cdk deploy` of a single bucket succeeds against LocalStack, and
+// `cdk destroy` tears it down. Deploy requires a prior bootstrap.
+func TestCDKE2EDeployDestroy(t *testing.T) {
+	requireDocker(t)
+	requireCDK(t)
+	requireNpm(t)
+	token := requireAuthToken(t)
+	cleanup()
+	t.Cleanup(cleanup)
+	ctx := testContext(t)
+	startRealLocalStack(t, ctx, token)
+
+	work := copyCDKSample(t, "single-bucket")
+	e := cdkE2EEnv(t)
+	npmInstall(t, ctx, work, e)
+
+	_, stderr, err := runCDK(t, ctx, work, e, "bootstrap")
+	require.NoError(t, err, "cdk bootstrap stderr: %s", stderr)
+
+	_, stderr, err = runCDK(t, ctx, work, e, "deploy", "--require-approval", "never")
+	require.NoError(t, err, "cdk deploy stderr: %s", stderr)
+
+	_, stderr, err = runCDK(t, ctx, work, e, "destroy", "--force")
+	require.NoError(t, err, "cdk destroy stderr: %s", stderr)
+}
+
+// 8.6 + 8.7 — full Lambda round-trip against LocalStack. Unlike the single-bucket
+// stack (whose small template may be passed inline to CloudFormation and so might
+// never touch S3), the lambda-asset stack loads its code with Code.fromAsset,
+// which forces CDK to zip the lambda/ dir and PutObject it to the bootstrap
+// staging bucket at deploy time. That upload uses the S3 client configured from
+// the AWS_ENDPOINT_URL_S3 value lstk injects, so a successful deploy proves the
+// asset path routed through LocalStack — this is where AWS_ENDPOINT_URL_S3 is
+// fully exercised. When the real aws CLI is present we additionally invoke the
+// deployed function and assert its output, proving LocalStack provisioned it from
+// the uploaded asset end-to-end. (LocalStack's own read of the asset is internal
+// and does not use lstk's endpoint; the publish step is the part that does.)
+func TestCDKE2ELambdaAssetDeployDestroy(t *testing.T) {
+	requireDocker(t)
+	requireCDK(t)
+	requireNpm(t)
+	token := requireAuthToken(t)
+	cleanup()
+	t.Cleanup(cleanup)
+	ctx := testContext(t)
+	startRealLocalStack(t, ctx, token)
+
+	work := copyCDKSample(t, "lambda-asset")
+	e := cdkE2EEnv(t)
+	npmInstall(t, ctx, work, e)
+
+	_, stderr, err := runCDK(t, ctx, work, e, "bootstrap")
+	require.NoError(t, err, "cdk bootstrap stderr: %s", stderr)
+
+	_, stderr, err = runCDK(t, ctx, work, e, "deploy", "--require-approval", "never")
+	require.NoError(t, err, "cdk deploy stderr: %s", stderr)
+
+	// Strongest proof when available: invoke the function (provisioned from the
+	// uploaded asset) and assert the handler's response. lstk aws shells out to
+	// the real aws CLI, so only run this when it is installed; the deploy above
+	// already proves the asset was published across AWS_ENDPOINT_URL_S3.
+	if _, lookErr := exec.LookPath("aws"); lookErr == nil {
+		outFile := filepath.Join(work, "invoke-out.json")
+		_, stderr, err = runLstk(t, ctx, work, e, "aws", "lambda", "invoke",
+			"--function-name", "lstk-cdk-e2e-fn", outFile)
+		require.NoError(t, err, "lstk aws lambda invoke stderr: %s", stderr)
+
+		out, readErr := os.ReadFile(outFile)
+		require.NoError(t, readErr)
+		require.Contains(t, string(out), "ok from lstk cdk lambda", "lambda response: %s", out)
+	} else {
+		t.Log("aws CLI not on PATH; skipping lambda invoke verification (deploy already exercised the S3 asset path)")
+	}
+
+	_, stderr, err = runCDK(t, ctx, work, e, "destroy", "--force")
+	require.NoError(t, err, "cdk destroy stderr: %s", stderr)
+}

--- a/test/integration/test-samples/iac/cdk/lambda-asset/.gitignore
+++ b/test/integration/test-samples/iac/cdk/lambda-asset/.gitignore
@@ -1,0 +1,7 @@
+# Artifacts produced when the e2e tests run cdk in a temp copy of this sample.
+# The sample itself is just app.js/lambda/index.js/cdk.json/package.json; these
+# are never tracked.
+node_modules/
+package-lock.json
+cdk.out/
+cdk.context.json

--- a/test/integration/test-samples/iac/cdk/lambda-asset/app.js
+++ b/test/integration/test-samples/iac/cdk/lambda-asset/app.js
@@ -1,0 +1,21 @@
+// CDK app used by the lstk cdk end-to-end tests to exercise S3 asset publishing:
+// a single Lambda function whose code is loaded with Code.fromAsset, which forces
+// CDK to zip the lambda/ directory and upload it to the bootstrap staging bucket
+// at deploy time. That upload is a PutObject against the S3 endpoint lstk injects
+// via AWS_ENDPOINT_URL_S3, so a successful deploy proves the asset path routed
+// through LocalStack. (Code.fromInline would embed the code in the template and
+// never touch S3 — fromAsset is deliberate.)
+const path = require("path");
+const { App, Stack, CfnOutput } = require("aws-cdk-lib");
+const { Function, Runtime, Code } = require("aws-cdk-lib/aws-lambda");
+
+const app = new App();
+const stack = new Stack(app, "LstkCdkLambdaE2eStack");
+const fn = new Function(stack, "Handler", {
+  functionName: "lstk-cdk-e2e-fn",
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromAsset(path.join(__dirname, "lambda")),
+});
+new CfnOutput(stack, "FunctionName", { value: fn.functionName });
+app.synth();

--- a/test/integration/test-samples/iac/cdk/lambda-asset/cdk.json
+++ b/test/integration/test-samples/iac/cdk/lambda-asset/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node app.js"
+}

--- a/test/integration/test-samples/iac/cdk/lambda-asset/lambda/index.js
+++ b/test/integration/test-samples/iac/cdk/lambda-asset/lambda/index.js
@@ -1,0 +1,3 @@
+// Trivial handler whose code lives in a real file (not inline) so CDK zips and
+// uploads it to the asset bucket. The e2e test invokes it and asserts this body.
+exports.handler = async () => ({ statusCode: 200, body: "ok from lstk cdk lambda" });

--- a/test/integration/test-samples/iac/cdk/lambda-asset/package.json
+++ b/test/integration/test-samples/iac/cdk/lambda-asset/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "lstk-cdk-lambda-asset-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "aws-cdk-lib": "2.177.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/test/integration/test-samples/iac/cdk/single-bucket/.gitignore
+++ b/test/integration/test-samples/iac/cdk/single-bucket/.gitignore
@@ -1,0 +1,6 @@
+# Artifacts produced when the e2e tests run cdk in a temp copy of this sample.
+# The sample itself is just app.js/cdk.json/package.json; these are never tracked.
+node_modules/
+package-lock.json
+cdk.out/
+cdk.context.json

--- a/test/integration/test-samples/iac/cdk/single-bucket/app.js
+++ b/test/integration/test-samples/iac/cdk/single-bucket/app.js
@@ -1,0 +1,10 @@
+// Minimal CDK app used by the lstk cdk end-to-end tests: a single S3 bucket in
+// one stack. Deploying it against LocalStack proves lstk routed CloudFormation
+// and the S3 asset staging through the injected LocalStack endpoint.
+const { App, Stack } = require("aws-cdk-lib");
+const { Bucket } = require("aws-cdk-lib/aws-s3");
+
+const app = new App();
+const stack = new Stack(app, "LstkCdkE2eStack");
+new Bucket(stack, "Bucket", { bucketName: "lstk-cdk-e2e-bucket" });
+app.synth();

--- a/test/integration/test-samples/iac/cdk/single-bucket/cdk.json
+++ b/test/integration/test-samples/iac/cdk/single-bucket/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node app.js"
+}

--- a/test/integration/test-samples/iac/cdk/single-bucket/package.json
+++ b/test/integration/test-samples/iac/cdk/single-bucket/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "lstk-cdk-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "aws-cdk-lib": "2.177.0",
+    "constructs": "^10.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `lstk cdk`, a proxy that runs the real AWS CDK CLI against a running LocalStack emulator — mirroring `lstk aws` / `lstk terraform`. This replaces the existing `cdklocal` command, with the one caveat that using and endpoint of `http://127.0.01:4566` or `http://localhost:4566` will _NOT_ work correctly in some cases. A future solution is still required for this edge case.

## Implementation

- Most of this implementation was a direct copy from the existing `cdklocal` tool. See `openspec/changes/add-cdk-proxy-command/` for the full proposal, design, and spec.

- **Endpoint via env vars** (`internal/iac/cdk/cli/`): `BuildEnv` sets `AWS_ENDPOINT_URL`, the derived `AWS_ENDPOINT_URL_S3`, mock creds, and region on the cdk subprocess.
- **Safety — strip ambient AWS config**: `AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`AWS_SESSION_TOKEN` are removed so a user's real credentials can't redirect a deploy at real AWS. This is the safety-critical core, mirroring `cdklocal`.
- **Version floor 2.177.0**: older CDK ignores the endpoint env vars and would silently hit real AWS, so `Run` checks `cdk --version` up front and fails with an actionable error. The caveat is that users wanting to use an older version of CDK must resort to `cdklocal` instead.
- **S3 endpoint addressing** (`internal/endpoint`): shared `S3Addressing` derives the `s3.`-prefixed virtual-host endpoint for `*.localstack.cloud` hosts. Path-style on the `127.0.0.1` DNS-rebind fallback is a known limitation (CDK exposes `forcePathStyle` only as a code-level arg, unreachable from a subprocess); lstk warns and the fix is out of scope for v1.
- **Shared IaC helpers → `cmd/iac.go`**: the command-boundary helpers (`--region`/`--account` parsing, `requireRunningAWSEmulator`, `resolveAWSContainer`, validation) moved out of `cmd/terraform.go` into a neutral file so cdk and terraform share them without one looking terraform-owned.

## Testing

- **`cdk_cmd_test.go`** — stub-`cdk` integration tests: arg/exit-code passthrough, env construction, emulator gating, version floor, flag handling, `LSTK_CDK_CMD`.
- **`cdk_e2e_test.go`** — real cdk + real LocalStack running in Docker.

Resolves [DPX-505](https://linear.app/localstack/issue/DPX-505/aws-cdk-cli-proxy-command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)