### PR TITLE
Include LocalStack version in already-running note

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -238,7 +238,10 @@ func runPostStartSetups(ctx context.Context, rt runtime.Runtime, sink output.Sin
 func emitAlreadyRunning(ctx context.Context, sink output.Sink, c runtime.ContainerConfig, localStackHost, webAppURL string, persist bool) {
 	name := c.EmulatorType.DisplayName()
 	if info, err := fetchLocalStackInfo(ctx, c.Port); err == nil && info.Version != "" {
-		name = fmt.Sprintf("%s %s", name, info.Version)
+		// /_localstack/info may report a build suffix (e.g. "2026.5.3:04ddfd3a0");
+		// keep only the version number.
+		version, _, _ := strings.Cut(info.Version, ":")
+		name = fmt.Sprintf("%s %s", name, version)
 	}
 	sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: fmt.Sprintf("%s is already running", name)})
 	resolvedHost, dnsOK := endpoint.ResolveHost(ctx, c.Port, localStackHost)

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -236,7 +236,11 @@ func runPostStartSetups(ctx context.Context, rt runtime.Runtime, sink output.Sin
 }
 
 func emitAlreadyRunning(ctx context.Context, sink output.Sink, c runtime.ContainerConfig, localStackHost, webAppURL string, persist bool) {
-	sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: fmt.Sprintf("%s is already running", c.EmulatorType.DisplayName())})
+	name := c.EmulatorType.DisplayName()
+	if info, err := fetchLocalStackInfo(ctx, c.Port); err == nil && info.Version != "" {
+		name = fmt.Sprintf("%s %s", name, info.Version)
+	}
+	sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: fmt.Sprintf("%s is already running", name)})
 	resolvedHost, dnsOK := endpoint.ResolveHost(ctx, c.Port, localStackHost)
 	if !dnsOK {
 		sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: endpoint.DNSRebindNote})

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 
@@ -104,6 +106,45 @@ func TestRunPostStartSetups_OmitsPersistenceWhenContainerEnvLacksFlag(t *testing
 	require.NoError(t, err)
 
 	assert.NotContains(t, out.String(), "• Persistence:")
+}
+
+func TestEmitAlreadyRunning_IncludesRunningVersion(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_localstack/info" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"3.4.0","edition":"pro"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	emitAlreadyRunning(context.Background(), sink, runtime.ContainerConfig{EmulatorType: config.EmulatorAWS, Port: port}, "", "", false)
+
+	assert.Contains(t, out.String(), "3.4.0 is already running")
+}
+
+func TestEmitAlreadyRunning_FallsBackWhenVersionUnavailable(t *testing.T) {
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	// Nothing is listening on this port, so the version lookup fails and we
+	// fall back to the bare note.
+	emitAlreadyRunning(context.Background(), sink, runtime.ContainerConfig{EmulatorType: config.EmulatorAWS, Port: "0"}, "", "", false)
+
+	got := out.String()
+	assert.Contains(t, got, "is already running")
+	assert.Contains(t, got, config.EmulatorAWS.DisplayName())
 }
 
 func TestEmitPostStartPointers_Snowflake_ReplacesEndpointWithSnowflakeEndpoint(t *testing.T) {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -114,7 +114,7 @@ func TestEmitAlreadyRunning_IncludesRunningVersion(t *testing.T) {
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/_localstack/info" {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"version":"3.4.0","edition":"pro"}`))
+			_, _ = w.Write([]byte(`{"version":"2026.5.3:04ddfd3a0","edition":"pro"}`))
 			return
 		}
 		http.NotFound(w, r)
@@ -131,7 +131,9 @@ func TestEmitAlreadyRunning_IncludesRunningVersion(t *testing.T) {
 
 	emitAlreadyRunning(context.Background(), sink, runtime.ContainerConfig{EmulatorType: config.EmulatorAWS, Port: port}, "", "", false)
 
-	assert.Contains(t, out.String(), "3.4.0 is already running")
+	got := out.String()
+	assert.Contains(t, got, "2026.5.3 is already running")
+	assert.NotContains(t, got, "04ddfd3a0", "build suffix should be stripped from the version")
 }
 
 func TestEmitAlreadyRunning_FallsBackWhenVersionUnavailable(t *testing.T) {


### PR DESCRIPTION
When `lstk start` detects an already-running emulator, the note now includes the running version. The version is fetched from `/_localstack/info` (and any build suffix is stripped); if the lookup fails, we fall back to the previous bare note.

Before:

`> Note: LocalStack AWS Emulator is already running`

After:

`> Note: LocalStack AWS Emulator 2026.5.3 is already running`

The change is in `emitAlreadyRunning`, which covers both detection paths (named container via `IsRunning` and externally-managed containers found via `FindRunningByImage`).

Added unit tests covering the version-bearing note and the fallback when the version is unavailable.