### PR TITLE
Show a consistent error when the proxy CLI is missing

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -53,6 +53,16 @@ Examples:
 			return initConfig(nil)(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			sink := output.NewPlainSink(os.Stdout)
+
+			if err := awscli.CheckInstalled(); err != nil {
+				sink.Emit(output.ErrorEvent{
+					Title:   "aws CLI not found in PATH",
+					Actions: []output.ErrorAction{{Label: "Install AWS CLI:", Value: awscli.InstallURL}},
+				})
+				return output.NewSilentError(err)
+			}
+
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
@@ -70,8 +80,6 @@ Examples:
 					break
 				}
 			}
-
-			sink := output.NewPlainSink(os.Stdout)
 
 			if err := rt.IsHealthy(cmd.Context()); err != nil {
 				rt.EmitUnhealthyError(sink, err)

--- a/cmd/az.go
+++ b/cmd/az.go
@@ -34,6 +34,8 @@ Examples:
 		DisableFlagParsing: true,
 		PreRunE:            initConfig(nil),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			sink := output.NewPlainSink(os.Stdout)
+
 			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
 			if err != nil {
 				return err
@@ -52,8 +54,6 @@ Examples:
 				}
 			}
 
-			sink := output.NewPlainSink(os.Stdout)
-
 			configDir, err := config.ConfigDir()
 			if err != nil {
 				return fmt.Errorf("failed to resolve config directory: %w", err)
@@ -67,6 +67,14 @@ Examples:
 					},
 				})
 				return output.NewSilentError(fmt.Errorf("azure CLI integration not set up"))
+			}
+
+			if err := azurecli.CheckInstalled(); err != nil {
+				sink.Emit(output.ErrorEvent{
+					Title:   "az CLI not found in PATH",
+					Actions: []output.ErrorAction{{Label: "Install Azure CLI:", Value: azurecli.InstallURL}},
+				})
+				return output.NewSilentError(err)
 			}
 
 			if err := rt.IsHealthy(cmd.Context()); err != nil {

--- a/internal/awscli/exec.go
+++ b/internal/awscli/exec.go
@@ -3,7 +3,6 @@ package awscli
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -17,6 +16,17 @@ import (
 	"github.com/localstack/lstk/internal/output"
 )
 
+const InstallURL = "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+
+var ErrNotInstalled = errors.New("aws CLI not found in PATH")
+
+func CheckInstalled() error {
+	if _, err := exec.LookPath("aws"); err != nil {
+		return ErrNotInstalled
+	}
+	return nil
+}
+
 func Exec(ctx context.Context, endpointURL string, useProfile bool, stdout, stderr io.Writer, args []string) error {
 	ctx, span := otel.Tracer("github.com/localstack/lstk/internal/awscli").Start(ctx, "aws cli")
 	defer span.End()
@@ -25,7 +35,7 @@ func Exec(ctx context.Context, endpointURL string, useProfile bool, stdout, stde
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		return fmt.Errorf("aws CLI not found in PATH — install it from https://aws.amazon.com/cli/")
+		return ErrNotInstalled
 	}
 
 	capacity := len(args) + 2

--- a/internal/azurecli/exec.go
+++ b/internal/azurecli/exec.go
@@ -14,8 +14,10 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
+const InstallURL = "https://learn.microsoft.com/en-us/cli/azure/"
+
 // ErrNotInstalled is returned when the `az` binary cannot be found on PATH.
-var ErrNotInstalled = errors.New("az CLI not found in PATH — install it from https://learn.microsoft.com/cli/azure/install-azure-cli")
+var ErrNotInstalled = fmt.Errorf("az CLI not found in PATH — install it from %s", InstallURL)
 
 // CheckInstalled returns ErrNotInstalled if the `az` binary is not on PATH.
 // Callers should use this before performing setup work to avoid leaving partial state.

--- a/internal/iac/terraform/cli/exec.go
+++ b/internal/iac/terraform/cli/exec.go
@@ -38,13 +38,13 @@ func Run(ctx context.Context, endpointURL, region, account, chdir string, sink o
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		installURL := "https://developer.hashicorp.com/terraform/install"
+		installLabel, installURL := "Install Terraform CLI:", "https://developer.hashicorp.com/terraform/cli"
 		if tfCmd() == "tofu" {
-			installURL = "https://opentofu.org/docs/intro/install/"
+			installLabel, installURL = "Install OpenTofu CLI:", "https://opentofu.org/docs/intro/install/"
 		}
 		sink.Emit(output.ErrorEvent{
 			Title:   fmt.Sprintf("%s not found in PATH", tfCmd()),
-			Actions: []output.ErrorAction{{Label: "Install it and ensure it is on your PATH:", Value: installURL}},
+			Actions: []output.ErrorAction{{Label: installLabel, Value: installURL}},
 		})
 		return output.NewSilentError(fmt.Errorf("%s not found in PATH", tfCmd()))
 	}

--- a/test/integration/aws_cmd_test.go
+++ b/test/integration/aws_cmd_test.go
@@ -159,17 +159,14 @@ func TestAWSCommandUsesProfileWhenAvailable(t *testing.T) {
 }
 
 func TestAWSCommandFailsWhenAWSCLINotInstalled(t *testing.T) {
-	requireDocker(t)
-	cleanup()
-	t.Cleanup(cleanup)
-	ctx := testContext(t)
-	startTestContainer(t, ctx)
+	t.Parallel()
+	e := env.With(env.DisableEvents, "1").With("PATH", t.TempDir()).With(env.Home, t.TempDir())
 
-	e := env.With(env.DisableEvents, "1").With("PATH", t.TempDir())
-
-	_, stderr, err := runLstk(t, ctx, t.TempDir(), e, "aws", "s3", "ls")
+	stdout, _, err := runLstk(t, testContext(t), t.TempDir(), e, "aws", "s3", "ls")
 	require.Error(t, err)
-	assert.Contains(t, stderr, "aws CLI not found")
+	assert.Contains(t, stdout, "aws CLI not found in PATH")
+	assert.Contains(t, stdout, "Install AWS CLI:")
+	assert.Contains(t, stdout, "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html")
 }
 
 func TestAWSCommandUsesDefaultPortWithoutConfig(t *testing.T) {

--- a/test/integration/az_cmd_test.go
+++ b/test/integration/az_cmd_test.go
@@ -1,0 +1,23 @@
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzCommandFailsWhenAzureCLINotInstalled(t *testing.T) {
+	t.Parallel()
+	workDir := azureWorkDir(t)
+	writeAzureSetupMarker(t, workDir)
+
+	e := env.With(env.DisableEvents, "1").With("PATH", t.TempDir()).With(env.Home, t.TempDir())
+
+	stdout, _, err := runLstk(t, testContext(t), workDir, e, "az", "group", "list")
+	require.Error(t, err)
+	assert.Contains(t, stdout, "az CLI not found in PATH")
+	assert.Contains(t, stdout, "Install Azure CLI:")
+	assert.Contains(t, stdout, "https://learn.microsoft.com/en-us/cli/azure/")
+}

--- a/test/integration/setup_azure_test.go
+++ b/test/integration/setup_azure_test.go
@@ -96,6 +96,7 @@ func TestSetupAzureReportsMissingAzCLIOnce(t *testing.T) {
 
 func TestAzCommandErrorsWhenEmulatorNotRunning(t *testing.T) {
 	requireDocker(t)
+	requireAzCLI(t)
 	cleanup()
 	cleanupAzure()
 	t.Cleanup(cleanup)

--- a/test/integration/terraform_cmd_test.go
+++ b/test/integration/terraform_cmd_test.go
@@ -135,7 +135,10 @@ func TestTerraformMissingBinary(t *testing.T) {
 
 	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "terraform", "version")
 	require.Error(t, err)
-	assert.Contains(t, stderr+stdout, "not found in PATH")
+	combined := stderr + stdout
+	assert.Contains(t, combined, "not found in PATH")
+	assert.Contains(t, combined, "Install Terraform CLI:")
+	assert.Contains(t, combined, "https://developer.hashicorp.com/terraform/cli")
 }
 
 // 7.3 — fmt/validate/version/init run without generating an override and without


### PR DESCRIPTION
## Summary

When a proxied CLI binary was missing, `lstk` reported it inconsistently: `lstk terraform` emitted a styled two-line error (title + actionable install link), while `lstk aws` and `lstk az` returned a plain `fmt.Errorf` that fell through to the generic unstyled `Error: %v` one-liner.

This makes all of them render the same styled error, with refreshed install URLs and tool-specific action labels.

## BEFORE / AFTER

**AWS** — `lstk aws ...`
```diff
- Error: aws CLI not found in PATH — install it from https://aws.amazon.com/cli/
+ Error: aws CLI not found in PATH
+   ==> Install AWS CLI: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
```

**Azure** — `lstk az ...`
```diff
- Error: az CLI not found in PATH — install it from https://learn.microsoft.com/cli/azure/install-azure-cli
+ Error: az CLI not found in PATH
+   ==> Install Azure CLI: https://learn.microsoft.com/en-us/cli/azure/
```

**Terraform** — `lstk terraform ...`
```diff
  Error: terraform not found in PATH
-   ==> Install it and ensure it is on your PATH: https://developer.hashicorp.com/terraform/install
+   ==> Install Terraform CLI: https://developer.hashicorp.com/terraform/cli
```

**OpenTofu** — `lstk terraform ...`
```diff
  Error: tofu not found in PATH
-   ==> Install it and ensure it is on your PATH: https://opentofu.org/docs/intro/install/
+   ==> Install OpenTofu CLI: https://opentofu.org/docs/intro/install/
```