### PR TITLE
Style snapshot list output to match status

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -540,6 +540,10 @@ func (a App) DeferredOutput() string {
 }
 
 func styleDeferredEvent(inner output.Event) (string, bool) {
+	if msg, ok := inner.(output.MessageEvent); ok && msg.Severity == output.SeverityNote {
+		return components.RenderMessage(msg), true
+	}
+
 	line, ok := output.FormatEventLine(inner)
 	if !ok {
 		return "", false
@@ -549,19 +553,17 @@ func styleDeferredEvent(inner output.Event) (string, bool) {
 		if p == "" {
 			continue
 		}
-		switch e := inner.(type) {
+		switch inner.(type) {
 		case output.TableEvent:
 			if i == 0 {
 				parts[i] = styles.SecondaryMessage.Render(p)
 			}
 		case output.MessageEvent:
-			if e.Severity != output.SeverityNote {
-				parts[i] = styles.Highlight.Render(p)
-			}
+			parts[i] = styles.Highlight.Render(p)
 		}
 	}
 	styled := strings.Join(parts, "\n")
-	if msg, isMsg := inner.(output.MessageEvent); isMsg && msg.Severity != output.SeverityNote {
+	if _, isMsg := inner.(output.MessageEvent); isMsg {
 		styled = "\n" + styled
 	}
 	return styled, true

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -305,11 +305,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 	case output.DeferredEvent:
-		if line, ok := output.FormatEventLine(msg); ok {
+		if styled, ok := styleDeferredEvent(msg.Inner); ok {
 			if a.deferredOutput != "" {
 				a.deferredOutput += "\n"
 			}
-			a.deferredOutput += line
+			a.deferredOutput += styled
 		}
 		return a, nil
 	default:
@@ -537,4 +537,32 @@ func (a App) Err() error {
 
 func (a App) DeferredOutput() string {
 	return a.deferredOutput
+}
+
+func styleDeferredEvent(inner output.Event) (string, bool) {
+	line, ok := output.FormatEventLine(inner)
+	if !ok {
+		return "", false
+	}
+	parts := strings.Split(line, "\n")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		switch e := inner.(type) {
+		case output.TableEvent:
+			if i == 0 {
+				parts[i] = styles.SecondaryMessage.Render(p)
+			}
+		case output.MessageEvent:
+			if e.Severity != output.SeverityNote {
+				parts[i] = styles.Highlight.Render(p)
+			}
+		}
+	}
+	styled := strings.Join(parts, "\n")
+	if msg, isMsg := inner.(output.MessageEvent); isMsg && msg.Severity != output.SeverityNote {
+		styled = "\n" + styled
+	}
+	return styled, true
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/ui/styles"
 	"github.com/muesli/termenv"
 )
 
@@ -239,6 +240,54 @@ func TestAppMessageEventWrapsOnVisibleWidth(t *testing.T) {
 	}
 	if strings.Contains(view, "backg\nround") {
 		t.Fatalf("expected message to wrap at word boundary, got: %q", view)
+	}
+}
+
+func TestAppDeferredEventStyling(t *testing.T) {
+	// Mutates the global lipgloss color profile, so it must not run in parallel.
+	original := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(original) })
+
+	app := NewApp("dev", "", "", nil)
+
+	summary := output.MessageEvent{Severity: output.SeveritySecondary, Text: "~ 2 snapshots\n"}
+	table := output.TableEvent{
+		Headers: []string{"Name", "Version", "Last Changed"},
+		Rows: [][]string{
+			{"baseline-q2", "3", "2026-04-15 14:32 UTC"},
+			{"infra-2026-04", "1", "-"},
+		},
+	}
+
+	model, _ := app.Update(output.DeferredEvent{Inner: summary})
+	app = model.(App)
+	model, _ = app.Update(output.DeferredEvent{Inner: table})
+	app = model.(App)
+
+	out := app.DeferredOutput()
+
+	if !strings.HasPrefix(out, "\n") {
+		t.Fatalf("expected a blank line above the summary, got: %q", out)
+	}
+
+	wantSummary := styles.Highlight.Render("~ 2 snapshots")
+	if !strings.Contains(out, wantSummary) {
+		t.Fatalf("expected highlighted summary %q in deferred output, got: %q", wantSummary, out)
+	}
+
+	tableLine, ok := output.FormatEventLine(table)
+	if !ok {
+		t.Fatal("expected table to format")
+	}
+	header := strings.Split(tableLine, "\n")[0]
+	wantHeader := styles.SecondaryMessage.Render(header)
+	if !strings.Contains(out, wantHeader) {
+		t.Fatalf("expected gray header %q in deferred output, got: %q", wantHeader, out)
+	}
+
+	if strings.Contains(out, styles.Highlight.Render("baseline-q2")) {
+		t.Fatal("data rows should not be highlighted")
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/ui/components"
 	"github.com/localstack/lstk/internal/ui/styles"
 	"github.com/muesli/termenv"
 )
@@ -288,6 +289,27 @@ func TestAppDeferredEventStyling(t *testing.T) {
 
 	if strings.Contains(out, styles.Highlight.Render("baseline-q2")) {
 		t.Fatal("data rows should not be highlighted")
+	}
+}
+
+func TestAppDeferredNoteStyledLikeStatus(t *testing.T) {
+	// Mutates the global lipgloss color profile, so it must not run in parallel.
+	original := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(original) })
+
+	app := NewApp("dev", "", "", nil)
+	note := output.MessageEvent{Severity: output.SeverityNote, Text: "No snapshots found"}
+
+	model, _ := app.Update(output.DeferredEvent{Inner: note})
+	app = model.(App)
+
+	out := app.DeferredOutput()
+	if want := components.RenderMessage(note); out != want {
+		t.Fatalf("deferred note should render like status's inline note %q, got %q", want, out)
+	}
+	if strings.HasPrefix(out, "\n") {
+		t.Fatalf("note should not be padded with a leading blank line, got %q", out)
 	}
 }
 


### PR DESCRIPTION
Applies the same styling as `lstk status` to the `lstk snapshot list` output: highlighted `~ N snapshots` summary (with a blank line above) and a muted table header. Interactive TUI only; plain/non-TTY output is unchanged.

Follow up from https://github.com/localstack/lstk/pull/294. Cc @anisaoshafi @carole-lavillonniere 

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="290" alt="Screenshot 2026-06-15 at 15 10 33" src="https://github.com/user-attachments/assets/747e8038-7754-4501-aee3-663949d2c4ad" /> | <img width="669" height="290" alt="Screenshot 2026-06-15 at 15 10 20" src="https://github.com/user-attachments/assets/0dd016c4-11e0-4f76-8dee-1383bfa15ceb" /> | 
| <img width="669" height="165" alt="Screenshot 2026-06-15 at 15 16 37" src="https://github.com/user-attachments/assets/0ed6adf0-beca-488d-907f-3a16eb787d7e" /> | <img width="669" height="165" alt="Screenshot 2026-06-15 at 15 16 35" src="https://github.com/user-attachments/assets/279bda08-a671-438d-a191-3aa8fd1499a6" /> |