### PR TITLE
CI: Enforce `docs` label in `lstk` Repository

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -12,4 +12,3 @@ jobs:
           mode: exactly
           count: 1
           labels: "docs: needed, docs: skip"
-          token: ${{ secrets.PRO_ACCESS_TOKEN }}

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,15 @@
+name: Enforce Labels
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, opened, synchronize]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "docs: needed, docs: skip"
+          token: ${{ secrets.PRO_ACCESS_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,15 @@
+name: Sync Labels
+
+on:
+  schedule:
+    # once a day at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync-labels:
+    uses: localstack/meta/.github/workflows/sync-labels.yml@83b4ff2ee4169d58eeb35bfa6dcddf9f35388212 # main
+    with:
+      categories: docs
+    secrets:
+      github-token: ${{ secrets.PRO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Changes + Motivation
- Adds and enforces the `docs` label in the `lstk` repository.
- You can also migrate the existing `check-release-label.yml` workflow to this new `enforce-labels.yml` workflow as well as update the `sync-labels.yml` to sync up the `semver` labels from the `localstack/meta` repository.

```
# enforce-labels.yml

...
  semver:
    runs-on: ubuntu-latest
    steps:
      - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
        with:
          mode: exactly
          count: 1
          labels: "semver: patch, semver: minor, semver: major"

          # not required, just matches old messaging
          message: "PR must have a release label: 'semver: patch', 'semver: minor', or 'semver: major'"
          add_comment: true
```

- Opted not to for now since I saw there is some repository level protection rules which requires this exact check (didn't want to break anything) 


**_Feel free to merge this if it's ready!_** 