### PR TITLE
Fix duplicate config section when writing a second key

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,8 +162,13 @@ func setInFile(path, key string, value any) error {
 	content := string(data)
 
 	re := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(field) + `\s*=.*$`)
+	secRe := regexp.MustCompile(`(?m)^\[` + regexp.QuoteMeta(section) + `\][^\n]*$`)
 	if re.MatchString(content) {
 		content = re.ReplaceAllString(content, assignment)
+	} else if secRe.MatchString(content) {
+		content = secRe.ReplaceAllStringFunc(content, func(header string) string {
+			return header + "\n" + assignment
+		})
 	} else {
 		content = strings.TrimRight(content, "\n") + "\n\n[" + section + "]\n" + assignment + "\n"
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,6 +60,36 @@ update_skipped_version = "v1.0.0"
 	require.NoError(t, toml.Unmarshal(got, &parsed))
 }
 
+func TestSetInFileAddsSecondFieldToExistingSection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	original := `# Keep this
+[[containers]]
+type = "aws"
+
+[cli]
+update_skipped_version = "v1.0.0"
+`
+	require.NoError(t, os.WriteFile(path, []byte(original), 0644))
+
+	require.NoError(t, setInFile(path, "cli.notify_cadence", "minor"))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	result := string(got)
+
+	var parsed struct {
+		CLI struct {
+			UpdateSkippedVersion string `toml:"update_skipped_version"`
+			NotifyCadence        string `toml:"notify_cadence"`
+		} `toml:"cli"`
+	}
+	require.NoError(t, toml.Unmarshal(got, &parsed))
+	assert.Equal(t, "v1.0.0", parsed.CLI.UpdateSkippedVersion)
+	assert.Equal(t, "minor", parsed.CLI.NotifyCadence)
+
+	assert.Equal(t, 1, strings.Count(result, "[cli]"), "expected a single [cli] section header")
+}
+
 func TestSetInFilePreservesCommentsAndFormatting(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	original := `# lstk configuration file


### PR DESCRIPTION
## Summary

`config.Set` persists individual keys to `config.toml` through `setInFile`, which edits the file surgically to preserve user comments and formatting. It had a latent corruption bug: when the target field was **absent**, it always appended a brand-new `[section]` header — even when that section already existed. Writing a **second, distinct** key to an existing section produced a **duplicate TOML table**, which the parser rejects, so every subsequent config load failed.

On a field-match miss, `setInFile` unconditionally appended a new section:

```go
content = strings.TrimRight(content, "\n") + "\n\n[" + section + "]\n" + assignment + "\n"
```

Today only `cli.update_skipped_version` is ever written, so the duplicate-header path is never hit — the bug is **latent**. But as soon as a second `[cli]` key is introduced (e.g. an update-notification cadence setting), the sequence becomes:

1. lstk writes `cli.update_skipped_version` → appends `[cli]` (first time, fine).
2. lstk later writes `cli.notify_cadence` → field absent → appends a **second** `[cli]` header.
3. Next startup: `viper.ReadInConfig` / `toml.Unmarshal` fails with `toml: table cli already exists`.

The user's `config.toml` is now unparseable and **every command fails** until the file is hand-repaired.

**Before (corrupted output):**

```toml
[cli]
update_skipped_version = "v1.0.0"

[cli]
notify_cadence = 'minor'
```

**After (fixed):**

```toml
[cli]
notify_cadence = 'minor'
update_skipped_version = "v1.0.0"
```

When the field is absent but the `[section]` header already exists, insert the new field **under the existing header** instead of appending a duplicate table. A fresh `[section]` is appended only when the section does not yet exist. Behavior for existing single-field configs is unchanged; only the previously-broken "second field in an existing section" path differs.
