### PR TITLE
Allow snapshot commands for snowflake and azure with warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ lstk proxies third-party IaC tools at the AWS emulator so they run against Local
 
 # Snapshots
 
-`lstk snapshot` captures and restores the running emulator's state (AWS emulator only). Domain logic lives in `internal/snapshot/`; `cmd/snapshot.go` is wiring + output-mode selection.
+`lstk snapshot` captures and restores the running emulator's state. For Snowflake and Azure, snapshot support is still maturing, so these commands surface a friendly heads-up that results may be incomplete. Domain logic lives in `internal/snapshot/`; `cmd/snapshot.go` is wiring + output-mode selection.
 
 - `lstk snapshot save [destination]` — export state to a local `.snapshot` file or a named cloud snapshot.
 - `lstk snapshot load REF` — restore state, starting the emulator first if needed; `--merge` controls how snapshot state combines with running state (`account-region-merge` (default), `overwrite`, `service-merge`).

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -217,25 +217,27 @@ func resolveSnapshotDeps(ctx context.Context, cfg *env.Env) (rt runtime.Runtime,
 		return nil, nil, "", nil, nil, fmt.Errorf("failed to get config: %w", err)
 	}
 
-	var awsContainer config.ContainerConfig
-	var found bool
-	for _, c := range appConfig.Containers {
-		if c.Type == config.EmulatorAWS {
-			awsContainer = c
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil, nil, "", nil, nil, fmt.Errorf("snapshot is only supported for the AWS emulator")
+	if len(appConfig.Containers) == 0 {
+		return nil, nil, "", nil, nil, fmt.Errorf("no emulator is configured")
 	}
 
 	rt, err = runtime.NewDockerRuntime(cfg.DockerHost)
 	if err != nil {
 		return nil, nil, "", nil, nil, err
 	}
-	host, _ = endpoint.ResolveHost(ctx, awsContainer.Port, cfg.LocalStackHost)
-	return rt, aws.NewClient(), host, []config.ContainerConfig{awsContainer}, appConfig, nil
+
+	// Target the first running emulator when one is up, otherwise fall back to the
+	// first configured emulator (the load command relies on this to auto-start it).
+	// RunningEmulators preserves config order, so "first running" is deterministic
+	// when several emulators are configured. Running-detection errors are ignored
+	// here so the downstream save/load flows surface them with proper messaging.
+	target := appConfig.Containers[0]
+	if running, rerr := container.RunningEmulators(ctx, rt, appConfig.Containers); rerr == nil && len(running) > 0 {
+		target = running[0]
+	}
+
+	host, _ = endpoint.ResolveHost(ctx, target.Port, cfg.LocalStackHost)
+	return rt, aws.NewClient(), host, []config.ContainerConfig{target}, appConfig, nil
 }
 
 func newSnapshotListCmd(cfg *env.Env, logger log.Logger) *cobra.Command {

--- a/internal/snapshot/experimental.go
+++ b/internal/snapshot/experimental.go
@@ -1,0 +1,23 @@
+package snapshot
+
+import (
+	"fmt"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/output"
+)
+
+// emitExperimentalWarning warns the user when a snapshot operation targets a
+// non-AWS emulator, whose snapshot support is not yet fully tested. The AWS
+// emulator is the well-tested path and produces no warning.
+func emitExperimentalWarning(containers []config.ContainerConfig, sink output.Sink) {
+	for _, c := range containers {
+		if c.Type == config.EmulatorAWS {
+			continue
+		}
+		sink.Emit(output.MessageEvent{
+			Severity: output.SeverityWarning,
+			Text:     fmt.Sprintf("Snapshot support for the %s emulator is experimental and not fully tested.", c.Type.ShortName()),
+		})
+	}
+}

--- a/internal/snapshot/load.go
+++ b/internal/snapshot/load.go
@@ -65,6 +65,8 @@ func load(ctx context.Context, rt runtime.Runtime, containers []config.Container
 		return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
 	}
 
+	emitExperimentalWarning(containers, sink)
+
 	runningContainers, err := container.RunningEmulators(ctx, rt, containers)
 	if err != nil {
 		return fmt.Errorf("checking emulator status: %w", err)

--- a/internal/snapshot/save.go
+++ b/internal/snapshot/save.go
@@ -52,6 +52,8 @@ func save(ctx context.Context, rt runtime.Runtime, containers []config.Container
 		return output.NewSilentError(fmt.Errorf("LocalStack is not running"))
 	}
 
+	emitExperimentalWarning(containers, sink)
+
 	sink.Emit(output.SpinnerStart(spinnerText))
 	defer func() {
 		sink.Emit(output.SpinnerStop())

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -20,10 +20,10 @@ import (
 	"net/netip"
 
 	"github.com/creack/pty"
+	"github.com/localstack/lstk/test/integration/env"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
-	"github.com/localstack/lstk/test/integration/env"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/go-keyring"
 )
@@ -236,6 +236,18 @@ func startExternalContainer(t *testing.T, ctx context.Context, imgName, name, ho
 
 func startTestSnowflakeContainer(t *testing.T, ctx context.Context) {
 	t.Helper()
+	startNamedTestContainer(t, ctx, snowflakeContainerName, "snowflake")
+}
+
+func startTestAzureContainer(t *testing.T, ctx context.Context) {
+	t.Helper()
+	startNamedTestContainer(t, ctx, azureContainerName, "azure")
+}
+
+// startNamedTestContainer starts a placeholder container (sleep infinity) under
+// the given name so emulator running-detection matches it by image and port.
+func startNamedTestContainer(t *testing.T, ctx context.Context, name, label string) {
+	t.Helper()
 
 	reader, err := dockerClient.ImagePull(ctx, testImage, client.ImagePullOptions{})
 	require.NoError(t, err, "failed to pull test image")
@@ -247,11 +259,11 @@ func startTestSnowflakeContainer(t *testing.T, ctx context.Context) {
 			Image: testImage,
 			Cmd:   []string{"sleep", "infinity"},
 		},
-		Name: snowflakeContainerName,
+		Name: name,
 	})
-	require.NoError(t, err, "failed to create snowflake test container")
+	require.NoError(t, err, "failed to create %s test container", label)
 	_, err = dockerClient.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{})
-	require.NoError(t, err, "failed to start snowflake test container")
+	require.NoError(t, err, "failed to start %s test container", label)
 }
 
 func testContext(t *testing.T) context.Context {

--- a/test/integration/snapshot_experimental_test.go
+++ b/test/integration/snapshot_experimental_test.go
@@ -1,0 +1,143 @@
+package integration_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// save/load work for Snowflake and Azure but emit an experimental warning.
+// These tests pin that warning (and its absence for AWS).
+
+const experimentalWarningFragment = "experimental and not fully tested"
+
+// nonAWSEmulator describes a non-AWS emulator under test: its config writer, its
+// container starter/cleanup, and the emulator name expected in the warning.
+type nonAWSEmulator struct {
+	name           string // ShortName as it appears in the warning, e.g. "Snowflake"
+	writeConfig    func(t *testing.T, hostPort string) string
+	startContainer func(t *testing.T, ctx context.Context)
+	cleanup        func()
+}
+
+func nonAWSEmulators() []nonAWSEmulator {
+	return []nonAWSEmulator{
+		{
+			name:           "Snowflake",
+			writeConfig:    writeSnowflakeConfig,
+			startContainer: startTestSnowflakeContainer,
+			cleanup:        cleanupSnowflake,
+		},
+		{
+			name:           "Azure",
+			writeConfig:    writeAzureConfig,
+			startContainer: startTestAzureContainer,
+			cleanup:        cleanupAzure,
+		},
+	}
+}
+
+// snapshotOp describes one snapshot operation (save/load, local/pod) under test.
+// setup builds the mock LocalStack server and the snapshot subcommand args for a
+// run whose working directory is dir; withAuth selects whether an auth token is
+// supplied (pod operations are cloud-only and require it).
+type snapshotOp struct {
+	name        string
+	successText string
+	withAuth    bool
+	setup       func(t *testing.T, dir string) (srv *httptest.Server, subArgs []string)
+}
+
+func snapshotOps() []snapshotOp {
+	return []snapshotOp{
+		{
+			name:        "Save",
+			successText: "Snapshot saved",
+			setup: func(t *testing.T, dir string) (*httptest.Server, []string) {
+				return mockStateServer(t), []string{"snapshot", "save"}
+			},
+		},
+		{
+			name:        "SavePod",
+			successText: "Snapshot saved",
+			withAuth:    true,
+			setup: func(t *testing.T, dir string) (*httptest.Server, []string) {
+				return mockPodSaveServer(t, true), []string{"snapshot", "save", "pod:my-baseline"}
+			},
+		},
+		{
+			name:        "Load",
+			successText: "Snapshot loaded",
+			setup: func(t *testing.T, dir string) (*httptest.Server, []string) {
+				srv, _ := mockLocalLoadServer(t)
+				snapPath := writeTestSnapFile(t, dir, "snap.snapshot")
+				return srv, []string{"snapshot", "load", snapPath}
+			},
+		},
+		{
+			name:        "LoadPod",
+			successText: "Snapshot loaded",
+			withAuth:    true,
+			setup: func(t *testing.T, dir string) (*httptest.Server, []string) {
+				return mockPodLoadServer(t, true), []string{"snapshot", "load", "pod:my-baseline"}
+			},
+		},
+	}
+}
+
+func TestSnapshotNonAWSShowsExperimentalWarning(t *testing.T) {
+	requireDocker(t)
+
+	for _, op := range snapshotOps() {
+		for _, em := range nonAWSEmulators() {
+			t.Run(op.name+"/"+em.name, func(t *testing.T) {
+				cleanup()
+				em.cleanup()
+				t.Cleanup(cleanup)
+				t.Cleanup(em.cleanup)
+
+				ctx := testContext(t)
+				em.startContainer(t, ctx)
+				dir := t.TempDir()
+				srv, subArgs := op.setup(t, dir)
+
+				environ := env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.LocalStackHost, lsHost(srv))
+				if op.withAuth {
+					environ = environ.With(env.AuthToken, "test-token")
+				}
+
+				args := append([]string{"--config", em.writeConfig(t, "4566"), "--non-interactive"}, subArgs...)
+				stdout, stderr, err := runLstk(t, ctx, dir, environ, args...)
+				require.NoError(t, err, "lstk snapshot %s failed: %s", op.name, stderr)
+				assert.Contains(t, stdout, op.successText)
+				assert.Contains(t, stdout, experimentalWarningFragment)
+				assert.Contains(t, stdout, em.name)
+			})
+		}
+	}
+}
+
+// TestSnapshotSaveAWSNoExperimentalWarning guards the well-tested AWS path: it
+// must not emit the experimental warning.
+func TestSnapshotSaveAWSNoExperimentalWarning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+	srv := mockStateServer(t)
+	dir := t.TempDir()
+
+	stdout, stderr, err := runLstk(t, ctx, dir,
+		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.LocalStackHost, lsHost(srv)),
+		"--non-interactive", "snapshot", "save",
+	)
+	require.NoError(t, err, "lstk snapshot save failed: %s", stderr)
+	assert.Contains(t, stdout, "Snapshot saved")
+	assert.NotContains(t, stdout, experimentalWarningFragment)
+}


### PR DESCRIPTION
Allow snapshot commands for Snowflake and Azure, but emphasize that they are not properly tested.
<img width="844" height="74" alt="image" src="https://github.com/user-attachments/assets/11a3b49f-c708-497f-8a74-5e4c6965d1ea" />
