### PR TITLE
Improve error when loading pod that doesn't exist

### DIFF
--- a/internal/emulator/aws/client.go
+++ b/internal/emulator/aws/client.go
@@ -239,6 +239,14 @@ func isInvalidSnapshotFileMsg(msg string) bool {
 	return strings.Contains(m, "not a valid zip archive") || strings.Contains(m, "invalid pod file")
 }
 
+// isPodNotFoundMsg reports whether an emulator error message indicates the
+// requested cloud snapshot does not exist. The emulator reports an unknown pod
+// with this generic version-lookup message rather than a distinct not-found
+// error, so we translate it into snapshot.ErrPodNotFound.
+func isPodNotFoundMsg(msg string) bool {
+	return strings.Contains(strings.ToLower(msg), "failed to get version information from platform")
+}
+
 func (c *Client) LoadPodSnapshot(ctx context.Context, host, podName, authToken, strategy string) ([]string, error) {
 	url := fmt.Sprintf("http://%s/_localstack/pods/%s", host, podName)
 	if strategy != "" {
@@ -299,6 +307,9 @@ func (c *Client) LoadPodSnapshot(ctx context.Context, host, podName, authToken, 
 			if event.Status != "ok" {
 				if isInvalidSnapshotFileMsg(event.Message) {
 					return nil, snapshot.ErrInvalidSnapshotFile
+				}
+				if isPodNotFoundMsg(event.Message) {
+					return nil, snapshot.ErrPodNotFound
 				}
 				return nil, fmt.Errorf("pod load failed: %s", event.Message)
 			}

--- a/internal/snapshot/load.go
+++ b/internal/snapshot/load.go
@@ -109,6 +109,16 @@ func load(ctx context.Context, rt runtime.Runtime, containers []config.Container
 		})
 		return output.NewSilentError(err)
 	}
+	if errors.Is(err, ErrPodNotFound) {
+		sink.Emit(output.ErrorEvent{
+			Title:   "Could not load snapshot",
+			Summary: "Snapshot was not found on the LocalStack platform",
+			Actions: []output.ErrorAction{
+				{Label: "List your snapshots:", Value: "lstk snapshot list"},
+			},
+		})
+		return output.NewSilentError(err)
+	}
 	return err
 }
 

--- a/test/integration/snapshot_load_test.go
+++ b/test/integration/snapshot_load_test.go
@@ -78,6 +78,24 @@ func mockPodLoadServer(t *testing.T, respondOK bool) *httptest.Server {
 	return srv
 }
 
+// mockPodNotFoundServer mimics the emulator response when the requested cloud
+// snapshot does not exist: the platform version lookup fails, so the load
+// completes with the generic "Failed to get version information" diagnostic.
+func mockPodNotFoundServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/_localstack/pods/") && r.Method == http.MethodPut {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"event":"completion","status":"error","message":"Failed to get version information from platform.. aborting"}` + "\n"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
 // writeTestSnapFile creates a small file usable as a local snapshot source.
 func writeTestSnapFile(t *testing.T, dir, name string) string {
 	t.Helper()
@@ -292,6 +310,32 @@ func TestSnapshotLoadPodServerError(t *testing.T) {
 	)
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stderr, "platform unavailable")
+}
+
+// TestSnapshotLoadPodNotFound covers a non-existent cloud snapshot. The emulator
+// cannot fetch version information for an unknown pod and reports the generic
+// platform diagnostic; lstk must translate it into a clear "not found" message
+// rather than leaking "Failed to get version information from platform".
+func TestSnapshotLoadPodNotFound(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+	srv := mockPodNotFoundServer(t)
+
+	stdout, stderr, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.LocalStackHost, lsHost(srv)).
+			With(env.AuthToken, "test-token"),
+		"--non-interactive", "snapshot", "load", "pod:does-not-exist",
+	)
+	requireExitCode(t, 1, err)
+	// The user-facing error is emitted through the sink (stdout); the raw
+	// platform diagnostic must not leak to the user.
+	assert.Contains(t, stdout, "not found on the LocalStack platform")
+	assert.NotContains(t, strings.ToLower(stdout+stderr), "version information")
 }
 
 func TestSnapshotLoadTelemetryEmitted(t *testing.T) {


### PR DESCRIPTION
The error when loading a pod that doesn't exist is misleading.
Change it to a more accurate and actionable error: 

| Before  | After |
| ------------- | ------------- |
| <img width="695" height="54" alt="image" src="https://github.com/user-attachments/assets/ce8cbc1c-7fe5-4f76-bef5-6186118e1c48" />  | <img width="957" height="105" alt="image" src="https://github.com/user-attachments/assets/b706e972-3805-4e0b-aae6-88f5e92c7211" /> |



### Source
The emulator can't distinguish "pod doesn't exist" (404) from a real platform failure, and reports the generic version-lookup error in both cases.

The proper fix belongs upstream in localstack-pro's CloudPodsRemotePlatform.get_max_version (treat 404 as "not found" → return None). Since that isn't available right now, this PR fixes it on the lstk side: detect the platform version-lookup diagnostic at the emulator boundary and translate it into a clear "snapshot not found" error.