### PR TITLE
Stop integration tests from sending telemetry to production

### DIFF
--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -22,6 +22,14 @@ const (
 	OtelEndpoint      Key = "OTEL_EXPORTER_OTLP_ENDPOINT"
 )
 
+// UnreachableAnalyticsEndpoint is a closed local port used as the default
+// analytics endpoint for every test environment, so the binary under test never
+// reports telemetry to the production analytics backend (which would pollute it,
+// e.g. with "start" events tagged as coming from CI or an AI agent). Tests that
+// exercise telemetry override it with a mock server URL via With(AnalyticsEndpoint, ...);
+// the explicit value wins because exec dedups duplicate keys to the last value.
+const UnreachableAnalyticsEndpoint = "http://127.0.0.1:1"
+
 func Get(key Key) string {
 	return os.Getenv(string(key))
 }
@@ -38,11 +46,11 @@ func Require(t testing.TB, key Key) string {
 type Environ []string
 
 func Without(keys ...Key) Environ {
-	return Environ(os.Environ()).Without(keys...)
+	return Environ(os.Environ()).With(AnalyticsEndpoint, UnreachableAnalyticsEndpoint).Without(keys...)
 }
 
 func With(key Key, value string) Environ {
-	return Environ(os.Environ()).With(key, value)
+	return Environ(os.Environ()).With(AnalyticsEndpoint, UnreachableAnalyticsEndpoint).With(key, value)
 }
 
 func (e Environ) Without(keys ...Key) Environ {

--- a/test/integration/env/env_test.go
+++ b/test/integration/env/env_test.go
@@ -1,0 +1,49 @@
+package env
+
+import (
+	"strings"
+	"testing"
+)
+
+// resolve returns the effective value of key in e, mirroring how os/exec
+// dedups duplicate keys: the last occurrence wins.
+func resolve(e Environ, key Key) (string, bool) {
+	value, found := "", false
+	prefix := string(key) + "="
+	for _, entry := range e {
+		if strings.HasPrefix(entry, prefix) {
+			value, found = strings.TrimPrefix(entry, prefix), true
+		}
+	}
+	return value, found
+}
+
+// Guards against telemetry from integration tests reaching the production
+// analytics backend: the base env helpers must default the analytics endpoint
+// to an unreachable address unless a test explicitly overrides it.
+func TestBaseEnvDefaultsAnalyticsEndpointToUnreachable(t *testing.T) {
+	cases := map[string]Environ{
+		"With":    With("SOME_VAR", "value"),
+		"Without": Without(AuthToken),
+	}
+	for name, e := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, found := resolve(e, AnalyticsEndpoint)
+			if !found {
+				t.Fatalf("%s did not set %s", name, AnalyticsEndpoint)
+			}
+			if got != UnreachableAnalyticsEndpoint {
+				t.Fatalf("%s analytics endpoint = %q, want %q", name, got, UnreachableAnalyticsEndpoint)
+			}
+		})
+	}
+}
+
+func TestExplicitAnalyticsEndpointOverridesDefault(t *testing.T) {
+	const mock = "http://127.0.0.1:54321"
+	e := With(APIEndpoint, "http://example").With(AnalyticsEndpoint, mock)
+	got, _ := resolve(e, AnalyticsEndpoint)
+	if got != mock {
+		t.Fatalf("analytics endpoint = %q, want %q (explicit override must win over default)", got, mock)
+	}
+}


### PR DESCRIPTION
## Motivation

Integration tests run the real `lstk` binary, whose analytics endpoint defaults to production (`https://analytics.localstack.cloud`). Aany test that doesn't explicitly redirect analytics to a mock sends real `lstk_command`/`lstk_lifecycle` events to the production backend, polluting analytics.

## Changes

- Default `LSTK_ANALYTICS_ENDPOINT` to an unreachable local address (`http://127.0.0.1:1`) in the integration test env helpers (`env.With` / `env.Without`), so the binary under test can never reach production.
- Tests that exercise telemetry are unaffected: they redirect to a mock server, and the explicit value wins because `exec` dedups duplicate env keys to the last value.

Closes DEVX-928