### PR TITLE
Set SF_S3_ENDPOINT from Snowflake emulator port config

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -108,6 +108,15 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			"LOCALSTACK_HOST="+endpoint.Hostname+":"+c.Port,
 		)
 
+		// The Python Snowflake emulator routes all S3 access through a single
+		// SF_S3_ENDPOINT (defaulting to port 4566), so on a custom port internal
+		// stages (e.g. COPY INTO) fail. Set it to match the configured port unless
+		// the user already provided their own value. AWS + Snowflake multi-emulator
+		// setups are not supported by this flow yet.
+		if c.Type == config.EmulatorSnowflake && !envHasKey(resolvedEnv, "SF_S3_ENDPOINT") {
+			env = append(env, "SF_S3_ENDPOINT="+snowflake.S3Endpoint(c.Port))
+		}
+
 		env = append(env, hostEnv...)
 		env = append(env, agentEnvVars...)
 
@@ -692,6 +701,16 @@ func filterHostEnv(envList []string) []string {
 		}
 	}
 	return out
+}
+
+func envHasKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func agentEnv(cl caller.Classification) []string {

--- a/internal/emulator/snowflake/snowflake.go
+++ b/internal/emulator/snowflake/snowflake.go
@@ -1,6 +1,19 @@
 package snowflake
 
-import "net"
+import (
+	"net"
+
+	"github.com/localstack/lstk/internal/endpoint"
+)
+
+// S3Endpoint returns the value for the Snowflake emulator's SF_S3_ENDPOINT
+// variable for the given host port. The Python Snowflake emulator funnels all
+// S3 access (including internal stages, e.g. COPY INTO) through this single
+// endpoint, so it must match the port the emulator is exposed on; otherwise it
+// defaults to 4566 and S3 access fails when the emulator runs on a custom port.
+func S3Endpoint(port string) string {
+	return "s3." + endpoint.Hostname + ":" + port
+}
 
 func Hostname(resolvedHost string) string {
 	host, _, err := net.SplitHostPort(resolvedHost)

--- a/internal/emulator/snowflake/snowflake_test.go
+++ b/internal/emulator/snowflake/snowflake_test.go
@@ -2,6 +2,24 @@ package snowflake
 
 import "testing"
 
+func TestS3Endpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		port string
+		want string
+	}{
+		{"default port", "4566", "s3.localhost.localstack.cloud:4566"},
+		{"custom port", "4567", "s3.localhost.localstack.cloud:4567"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := S3Endpoint(tt.port); got != tt.want {
+				t.Errorf("S3Endpoint(%q) = %q, want %q", tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHostname(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -703,6 +703,33 @@ func TestStartCommandSucceedsForSnowflake(t *testing.T) {
 		"snowflake start should print a tip line like AWS does")
 }
 
+func TestStartCommandSetsSnowflakeS3EndpointFromPort(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	cleanupSnowflake()
+	t.Cleanup(cleanup)
+	t.Cleanup(cleanupSnowflake)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	const hostPort = "4599"
+	configFile := writeSnowflakeConfig(t, hostPort)
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, snowflakeContainerName, client.ContainerInspectOptions{})
+	require.NoError(t, err, "failed to inspect snowflake container")
+	envVars := containerEnvToMap(inspect.Container.Config.Env)
+	assert.Equal(t, "s3.localhost.localstack.cloud:"+hostPort, envVars["SF_S3_ENDPOINT"],
+		"SF_S3_ENDPOINT should match the configured Snowflake port")
+}
+
 const azureContainerName = "localstack-azure"
 
 func cleanupAzure() {


### PR DESCRIPTION
The Python Snowflake emulator funnels all S3 access through a single `SF_S3_ENDPOINT` that defaults to port `4566`. When the Snowflake emulator runs on a custom port, internal-stage operations like `COPY INTO` fail because S3 access still targets `4566`.

This sets `SF_S3_ENDPOINT` on startup to match the configured Snowflake port (`s3.localhost.localstack.cloud:<port>`), unless the user already provided their own value via an env profile. AWS + Snowflake multi-emulator setups remain unsupported in this flow for now — users who need both should use a single container image.

Tests: a unit test for `snowflake.S3Endpoint` and an integration test asserting `SF_S3_ENDPOINT` matches a custom configured port.