### PR TITLE
chore(ci): add "docs: skip" label to automated dependency PRs

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -3,7 +3,7 @@ name: create-pr
 description: Create a GitHub pull request following lstk conventions with proper title, description, and ticket references.
 argument-hint: [base-branch]
 disable-model-invocation: true
-allowed-tools: Bash(git log *), Bash(git diff *), Bash(git branch *), Bash(git push -u origin HEAD), Bash(gh pr create *), mcp__plugin_linear_linear__get_issue
+allowed-tools: Bash(git log *), Bash(git diff *), Bash(git branch *), Bash(git push -u origin HEAD), Bash(gh pr create *), Bash(gh label list *), mcp__plugin_linear_linear__get_issue
 ---
 
 # Create Pull Request
@@ -69,15 +69,29 @@ Rules:
 - Omit Todo section if there are no follow-up items
 - Don't over-explain; the diff speaks for itself
 
-## Step 5: Commit and push
+## Step 5: Choose labels
+
+Always apply two labels, based on the size and nature of the change:
+
+1. A semver label reflecting the impact of the change:
+   - `semver: patch` — bug fixes, dependency/toolchain bumps, internal refactors, and other backward-compatible changes with no new user-facing behavior.
+   - `semver: minor` — new backward-compatible functionality (e.g. a new command or flag).
+   - `semver: major` — breaking changes to existing behavior or interfaces.
+2. A docs label reflecting whether documentation needs updating:
+   - `docs: skip` — no user-facing documentation change is required (most dependency/toolchain upgrades, internal refactors).
+   - `docs: needed` — the change adds or alters user-facing behavior that requires documentation updates.
+
+This applies to automated PRs too (dependency and toolchain upgrades), which are almost always `semver: patch` + `docs: skip`.
+
+## Step 6: Commit and push
 
 If there are uncommitted changes, commit them with a concise message. Do NOT add `Co-Authored-By: Claude` unless the user explicitly asks for it.
 
-Then push and create the PR:
+Then push and create the PR with the chosen labels:
 
 ```
 git push -u origin HEAD
-gh pr create --draft --title "<title>" --body "<body>" --base <base-branch>
+gh pr create --draft --title "<title>" --body "<body>" --base <base-branch> --label "<semver-label>" --label "<docs-label>"
 ```
 
 Return the PR URL when done.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "semver: patch"
+      - "docs: skip"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,3 +20,4 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "semver: patch"
+      - "docs: skip"

--- a/.github/workflows/weekly-go-upgrade.yml
+++ b/.github/workflows/weekly-go-upgrade.yml
@@ -47,4 +47,5 @@ jobs:
           labels: |
             dependencies
             semver: patch
+            docs: skip
           token: ${{ secrets.PRO_ACCESS_TOKEN }}


### PR DESCRIPTION
After https://github.com/localstack/lstk/pull/307 was merged, automated PRs (e.g. https://github.com/localstack/lstk/pull/316) started failing because now docs tag is a required check, unless manually tagged.


Took advantage to add another step for users that rely on /create-pr skill so Claude can determine and set the labels on its own, so users don't have to manually set them  https://github.com/localstack/lstk/pull/323/commits/b6586d1d6df81c7da8718d7370977161bdeba191.