### PR TITLE
Fix success message style for snapshot load

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -299,7 +299,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.addLine(styledLine{text: style.Render(text)})
 		a.addLine(blank)
 		return a, nil
-	case output.InstanceInfoEvent, output.PodSnapshotSavedEvent:
+	case output.InstanceInfoEvent, output.PodSnapshotSavedEvent, output.SnapshotLoadedEvent:
 		if line, ok := output.FormatEventLine(msg.(output.Event)); ok {
 			a.addSuccessLines(line)
 		}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -219,6 +219,30 @@ func TestAppMessageEventRendering(t *testing.T) {
 	}
 }
 
+func TestAppSnapshotLoadedEventRendersGreen(t *testing.T) {
+	// Mutates the global lipgloss color profile, so it must not run in parallel.
+	original := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(original) })
+
+	app := NewApp("dev", "", "", nil)
+
+	model, _ := app.Update(output.SnapshotLoadedEvent{Source: "pod:my-baseline"})
+	app = model.(App)
+
+	if len(app.lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(app.lines))
+	}
+
+	wantMarker := styles.Success.Render(output.SuccessMarker())
+	if !strings.Contains(app.lines[0].text, wantMarker) {
+		t.Fatalf("expected green success marker %q in rendered line, got: %q", wantMarker, app.lines[0].text)
+	}
+	if !strings.Contains(app.lines[0].text, "Snapshot loaded from pod:my-baseline") {
+		t.Fatalf("expected loaded message text, got: %q", app.lines[0].text)
+	}
+}
+
 func TestAppMessageEventWrapsOnVisibleWidth(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When you run lstk snapshot load in interactive mode, the confirmation line "Snapshot loaded from …" appears in the default terminal color instead of colored. This PR fixes this inconsistency.

| Before  | After |
|----|-----|
|<img width="549" height="69" alt="image" src="https://github.com/user-attachments/assets/0f18f6b2-9a07-4428-b035-83d5af62e60d" /> | <img width="905" height="68" alt="image" src="https://github.com/user-attachments/assets/271d3c88-f0bd-4d55-bc09-17da801fe781" /> |



