### PR TITLE
Replace code owners with @localstack/devx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @carole-lavillonniere @silv-io @anisaoshafi
+* @localstack/devx


### PR DESCRIPTION
Replaces the individual code owners with the @localstack/devx team, [per relevant discussion](https://app.notion.com/p/localstack/Weekly-DevX-Sync-386fc2a234318014a11bc435877c3277?v=87ca1be49bae49098e2c51d10daffda0&source=copy_link#386fc2a23431800d9a1bef4025bd77b4).

- Single team owner keeps ownership managed in one place instead of a hand-maintained list of individuals.
- Carole and Silvio can be re-added individually whenever a review need comes up.

Note: `@localstack/devx` needs write access to this repo for the entry to take effect.

Thanks @carole-lavillonniere for discussing this! 🙏 