### PR TITLE
feat: degrade gracefully in offline / enterprise environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,8 @@ Each `[[containers]]` block may set an optional `image` to override the default 
 There is no `--offline` flag. Instead `container.Start` degrades gracefully when internet requests fail (the common enterprise blockers: Docker Hub unreachable, proxy/TLS interception, license server unreachable):
 
 - **Image pull**: if `rt.PullImage` fails but `rt.ImageExists` reports the image is already present locally, lstk warns and uses the local image instead of failing.
-- **License pre-flight**: `validateLicense` distinguishes a definitive server rejection (`*api.LicenseError`, e.g. HTTP 403/400 — still fatal) from a transport-level failure (any other error — offline/proxy/cert). On a transport failure it skips the pre-flight check and lets the container validate its own bundled license at startup.
+- **License pre-flight (image already local)**: when a pinned image is already present locally — so `pullImages` won't pull it — `tryPrePullLicenseValidation` skips the pre-flight check entirely (gated on `rt.ImageExists`), since the redundant network round-trip would otherwise block a fully-offline start; the container validates its own bundled license at startup. This is symmetric with the skip-pull behaviour above.
+- **License pre-flight (server unreachable)**: when a check does run, `validateLicense` distinguishes a definitive server rejection (`*api.LicenseError`, e.g. HTTP 403/400 — still fatal) from a transport-level failure (any other error — offline/proxy/cert). On a transport failure it skips the pre-flight check and lets the container validate its own bundled license at startup.
 - **Telemetry/update checks** are already best-effort and fail silently when offline.
 
 `runtime.PullImage` always closes its `progress` channel (even when `ImagePull` fails early) so the local-image fallback path doesn't leak the progress goroutine. Pair this with a custom `image` in the config to point at a locally loaded image or an internal-registry mirror.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,16 @@ Created automatically on first run with defaults. Supports emulator types: `aws`
 
 Each `[[containers]]` block may set an optional `image` to override the default Docker Hub image (e.g. an internal registry mirror or a locally loaded offline image). `ContainerConfig.Image()` returns `image` as-is when it already carries a tag (so the separately-configured `tag` is dropped in that case), otherwise it appends `tag` (or `latest`); the default `localstack/<product>:<tag>` is used when `image` is unset.
 
+# Offline / Enterprise Environments
+
+There is no `--offline` flag. Instead `container.Start` degrades gracefully when internet requests fail (the common enterprise blockers: Docker Hub unreachable, proxy/TLS interception, license server unreachable):
+
+- **Image pull**: if `rt.PullImage` fails but `rt.ImageExists` reports the image is already present locally, lstk warns and uses the local image instead of failing.
+- **License pre-flight**: `validateLicense` distinguishes a definitive server rejection (`*api.LicenseError`, e.g. HTTP 403/400 — still fatal) from a transport-level failure (any other error — offline/proxy/cert). On a transport failure it skips the pre-flight check and lets the container validate its own bundled license at startup.
+- **Telemetry/update checks** are already best-effort and fail silently when offline.
+
+`runtime.PullImage` always closes its `progress` channel (even when `ImagePull` fails early) so the local-image fallback path doesn't leak the progress goroutine. Pair this with a custom `image` in the config to point at a locally loaded image or an internal-registry mirror.
+
 # Emulator Setup Commands
 
 Use `lstk setup <emulator>` to set up CLI integration for an emulator type:

--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ EAGER_SERVICE_LOADING = "1"
 
 Host environment variables prefixed with `LOCALSTACK_` are also forwarded to the emulator.
 
+### Offline / enterprise environments
+
+`lstk start` degrades gracefully when the common enterprise blockers (Docker Hub unreachable, a forward proxy, TLS interception, or an unreachable license server) make a network request fail:
+
+- If the image cannot be pulled but is already present locally, `lstk` warns and starts the local image instead of failing.
+- If the license server cannot be reached, `lstk` skips its pre-flight check and lets the emulator validate its own bundled license at startup. A definitive rejection from the server (e.g. an invalid token) stays fatal.
+
+Pair this with a custom `image` in the config to point at a locally loaded image or an internal-registry mirror.
+
 ## Interactive And Non-Interactive Mode
 
 `lstk` uses the TUI in an interactive terminal and plain output elsewhere. Use `--non-interactive` to force plain output even in a TTY:

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -338,6 +338,13 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *
 		}()
 		if err := rt.PullImage(ctx, c.Image, progress); err != nil {
 			sink.Emit(output.SpinnerStop())
+			// The registry may be unreachable (offline, proxy, or TLS interception in
+			// enterprise networks). If the image is already available locally, fall back
+			// to it instead of failing — the image carries its own license.
+			if exists, existsErr := rt.ImageExists(ctx, c.Image); existsErr == nil && exists {
+				sink.Emit(output.MessageEvent{Severity: output.SeverityWarning, Text: fmt.Sprintf("Could not pull %s; using the local image", c.Image)})
+				continue
+			}
 			sink.Emit(output.ErrorEvent{
 				Title:   fmt.Sprintf("Failed to pull %s", c.Image),
 				Summary: err.Error(),
@@ -612,14 +619,27 @@ func validateLicense(ctx context.Context, sink output.Sink, opts StartOptions, c
 	licenseResp, err := opts.PlatformClient.GetLicense(ctx, licenseReq)
 	if err != nil {
 		sink.Emit(output.SpinnerStop())
+		// A cancelled caller context (e.g. Ctrl+C) is not an offline condition —
+		// propagate it instead of degrading. The client's own request timeout is
+		// distinct from ctx and still falls through to the offline fallback below.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		var licErr *api.LicenseError
-		if errors.As(err, &licErr) {
-			if licErr.Detail != "" {
-				opts.Logger.Error("license server response (HTTP %d): %s", licErr.Status, licErr.Detail)
-			}
-			if licErr.IsUnsupportedTag {
-				err = errors.New(config.UnsupportedTagMessage())
-			}
+		if !errors.As(err, &licErr) {
+			// The license server responded with no definitive verdict — the request
+			// itself failed (offline, proxy, or TLS interception in enterprise
+			// networks). Skip the pre-flight check and let the container validate its
+			// own bundled license at startup instead of blocking the start.
+			opts.Logger.Info("license server unreachable, continuing with the image's bundled license: %v", err)
+			sink.Emit(output.MessageEvent{Severity: output.SeverityWarning, Text: "Could not reach the license server; continuing with the image's bundled license"})
+			return nil
+		}
+		if licErr.Detail != "" {
+			opts.Logger.Error("license server response (HTTP %d): %s", licErr.Status, licErr.Detail)
+		}
+		if licErr.IsUnsupportedTag {
+			err = errors.New(config.UnsupportedTagMessage())
 		}
 		opts.Telemetry.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
 			EventType: telemetry.LifecycleStartError,

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -338,6 +338,12 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *
 		}()
 		if err := rt.PullImage(ctx, c.Image, progress); err != nil {
 			sink.Emit(output.SpinnerStop())
+			// A cancelled caller context (e.g. Ctrl+C) is not an offline condition —
+			// propagate it instead of probing for a local image or reporting a pull
+			// failure, which would also emit a spurious start-error telemetry event.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			// The registry may be unreachable (offline, proxy, or TLS interception in
 			// enterprise networks). If the image is already available locally, fall back
 			// to it instead of failing — the image carries its own license.
@@ -635,6 +641,10 @@ func validateLicense(ctx context.Context, sink output.Sink, opts StartOptions, c
 			sink.Emit(output.MessageEvent{Severity: output.SeverityWarning, Text: "Could not reach the license server; continuing with the image's bundled license"})
 			return nil
 		}
+		// Known limitation: any *api.LicenseError — i.e. any non-200 HTTP response,
+		// including a 5xx or a 407 from a corporate proxy — is treated as a definitive
+		// verdict and stays fatal here; only connection-level failures (handled above)
+		// degrade. Gating this on licErr.Status is tracked as follow-up.
 		if licErr.Detail != "" {
 			opts.Logger.Error("license server response (HTTP %d): %s", licErr.Status, licErr.Detail)
 		}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -372,7 +372,8 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *
 	return pulled, nil
 }
 
-// Validates licenses before pulling for containers with pinned tags.
+// Validates licenses before pulling for containers with pinned tags, except those
+// whose image is already present locally (not pulled, so the check is skipped too).
 // "latest" and empty tags are deferred to post-pull validation via image inspection.
 func tryPrePullLicenseValidation(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, containers []runtime.ContainerConfig, token, licenseFilePath string) ([]runtime.ContainerConfig, error) {
 	var needsPostPull []runtime.ContainerConfig

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -167,9 +167,10 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 		return "", fmt.Errorf("failed to determine license file path: %w", err)
 	}
 
-	// Validate licenses before pulling. Pinned tags are validated immediately;
-	// "latest" tags are deferred to post-pull validation via image inspection.
-	postPullContainers, err := tryPrePullLicenseValidation(ctx, sink, opts, containers, token, licenseFilePath)
+	// Validate licenses before pulling. Pinned tags are validated immediately —
+	// unless the image is already present locally, in which case both the pull and
+	// the pre-flight check are skipped. "latest" tags defer to post-pull validation.
+	postPullContainers, err := tryPrePullLicenseValidation(ctx, rt, sink, opts, containers, token, licenseFilePath)
 	if err != nil {
 		return "", err
 	}
@@ -373,7 +374,7 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *
 
 // Validates licenses before pulling for containers with pinned tags.
 // "latest" and empty tags are deferred to post-pull validation via image inspection.
-func tryPrePullLicenseValidation(ctx context.Context, sink output.Sink, opts StartOptions, containers []runtime.ContainerConfig, token, licenseFilePath string) ([]runtime.ContainerConfig, error) {
+func tryPrePullLicenseValidation(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts StartOptions, containers []runtime.ContainerConfig, token, licenseFilePath string) ([]runtime.ContainerConfig, error) {
 	var needsPostPull []runtime.ContainerConfig
 	for _, c := range containers {
 		if c.EmulatorType.SelfValidatesLicense() {
@@ -381,6 +382,14 @@ func tryPrePullLicenseValidation(ctx context.Context, sink output.Sink, opts Sta
 		}
 
 		if c.Tag != "" && c.Tag != "latest" {
+			// A pinned image already present locally is not pulled (see pullImages),
+			// so skip the license pre-flight too: the check is redundant — and a hard
+			// blocker in offline/enterprise environments — when no network round-trip
+			// happens at all and the container validates its own bundled license at
+			// startup. A probe error is non-fatal here; fall through to the check.
+			if exists, err := rt.ImageExists(ctx, c.Image); err == nil && exists {
+				continue
+			}
 			if err := validateLicense(ctx, sink, opts, c, token, licenseFilePath); err != nil {
 				return nil, err
 			}

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/localstack/lstk/internal/api"
@@ -555,6 +556,73 @@ func TestValidateLicense_PropagatesContextCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	assert.NotContains(t, out.String(), "Could not reach the license server",
 		"a cancellation must not be reported as an unreachable license server")
+}
+
+func TestTryPrePullLicenseValidation_SkipsCheckWhenImageIsLocal(t *testing.T) {
+	// A pinned image already present locally is not pulled (see pullImages), so the
+	// CLI must not run a license pre-flight either — the container validates its own
+	// bundled license at startup. This keeps the local-image start fully offline.
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+
+	c := runtime.ContainerConfig{
+		Image:        "my-registry.internal/localstack-pro:2026.4",
+		Name:         "localstack-aws",
+		EmulatorType: config.EmulatorAWS,
+		ProductName:  "localstack-pro",
+		Tag:          "2026.4",
+	}
+	mockRT.EXPECT().ImageExists(gomock.Any(), c.Image).Return(true, nil)
+
+	var licenseHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&licenseHits, 1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	opts := StartOptions{
+		PlatformClient: api.NewPlatformClient(srv.URL, log.Nop()),
+		Logger:         log.Nop(),
+		Telemetry:      telemetry.New("", true),
+	}
+
+	postPull, err := tryPrePullLicenseValidation(context.Background(), mockRT, output.NewPlainSink(io.Discard), opts, []runtime.ContainerConfig{c}, "tok", filepath.Join(t.TempDir(), "license.json"))
+
+	require.NoError(t, err)
+	assert.Empty(t, postPull, "a pinned local image needs no post-pull validation")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&licenseHits), "the license server must not be contacted for a local image")
+}
+
+func TestTryPrePullLicenseValidation_ChecksWhenImageMissing(t *testing.T) {
+	// The pre-flight check still runs (and stays fatal on rejection) when the pinned
+	// image is not present locally — a pull will happen, so failing fast is correct.
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+
+	c := runtime.ContainerConfig{
+		Image:        "localstack/localstack-pro:2026.4",
+		Name:         "localstack-aws",
+		EmulatorType: config.EmulatorAWS,
+		ProductName:  "localstack-pro",
+		Tag:          "2026.4",
+	}
+	mockRT.EXPECT().ImageExists(gomock.Any(), c.Image).Return(false, nil)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	opts := StartOptions{
+		PlatformClient: api.NewPlatformClient(srv.URL, log.Nop()),
+		Logger:         log.Nop(),
+		Telemetry:      telemetry.New("", true),
+	}
+
+	_, err := tryPrePullLicenseValidation(context.Background(), mockRT, output.NewPlainSink(io.Discard), opts, []runtime.ContainerConfig{c}, "tok", filepath.Join(t.TempDir(), "license.json"))
+
+	require.Error(t, err, "a missing local image must still fail fast on a server rejection")
 }
 
 func TestStartContainers_SnowflakeLicenseError(t *testing.T) {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -443,6 +443,43 @@ func TestPullImages_FailsWhenPullFailsAndImageMissing(t *testing.T) {
 	assert.Contains(t, out.String(), "Failed to pull localstack/localstack-pro:latest")
 }
 
+func TestPullImages_PropagatesContextCancellation(t *testing.T) {
+	// A cancelled caller context (Ctrl+C) during a pull must surface as
+	// cancellation — not be reported as a pull failure nor probed as a local-image
+	// fallback (which would also emit a spurious start-error telemetry event).
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+
+	c := runtime.ContainerConfig{
+		Image:        "localstack/localstack-pro:latest",
+		Name:         "localstack-aws",
+		EmulatorType: config.EmulatorAWS,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mockRT.EXPECT().Remove(gomock.Any(), c.Name).Return(nil)
+	mockRT.EXPECT().PullImage(gomock.Any(), c.Image, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, progress chan<- runtime.PullProgress) error {
+			cancel() // the user interrupts mid-pull
+			close(progress)
+			return context.Canceled
+		})
+	// ImageExists must NOT be called once the context is cancelled; gomock fails
+	// the test if it is (no EXPECT registered).
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+	tel := telemetry.New("", true)
+
+	_, err := pullImages(ctx, mockRT, sink, tel, []runtime.ContainerConfig{c})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, output.IsSilent(err), "a user cancel is not a silent start error")
+	assert.NotContains(t, out.String(), "Failed to pull", "a cancel must not be reported as a pull failure")
+	assert.NotContains(t, out.String(), "using the local image")
+}
+
 func TestValidateLicense_ContinuesWhenServerUnreachable(t *testing.T) {
 	// A closed port yields a transport-level failure (not an *api.LicenseError),
 	// which models an offline/proxy environment that cannot reach the license server.

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -8,9 +8,11 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strconv"
 	"testing"
 
+	"github.com/localstack/lstk/internal/api"
 	"github.com/localstack/lstk/internal/caller"
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/log"
@@ -381,6 +383,141 @@ func TestAgentEnv(t *testing.T) {
 	assert.Equal(t, []string{"AI_AGENT=claude-code"},
 		agentEnv(caller.Classification{AgentIdentity: "claude-code", CIIdentity: "github-actions"}),
 		"an agent running inside CI still forwards its AI_AGENT identity")
+}
+
+func TestPullImages_FallsBackToLocalImageWhenPullFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+
+	c := runtime.ContainerConfig{
+		Image:        "my-registry.internal/localstack-pro:latest",
+		Name:         "localstack-aws",
+		EmulatorType: config.EmulatorAWS,
+	}
+
+	mockRT.EXPECT().Remove(gomock.Any(), c.Name).Return(nil)
+	mockRT.EXPECT().PullImage(gomock.Any(), c.Image, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, progress chan<- runtime.PullProgress) error {
+			close(progress)
+			return errors.New("tls: failed to verify certificate")
+		})
+	mockRT.EXPECT().ImageExists(gomock.Any(), c.Image).Return(true, nil)
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+	tel := telemetry.New("", true)
+
+	pulled, err := pullImages(context.Background(), mockRT, sink, tel, []runtime.ContainerConfig{c})
+
+	require.NoError(t, err, "a pull failure must not be fatal when the image is available locally")
+	assert.False(t, pulled[c.Name], "the image was not pulled, only found locally")
+	assert.Contains(t, out.String(), "using the local image")
+}
+
+func TestPullImages_FailsWhenPullFailsAndImageMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+
+	c := runtime.ContainerConfig{
+		Image:        "localstack/localstack-pro:latest",
+		Name:         "localstack-aws",
+		EmulatorType: config.EmulatorAWS,
+	}
+
+	mockRT.EXPECT().Remove(gomock.Any(), c.Name).Return(nil)
+	mockRT.EXPECT().PullImage(gomock.Any(), c.Image, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, progress chan<- runtime.PullProgress) error {
+			close(progress)
+			return errors.New("tls: failed to verify certificate")
+		})
+	mockRT.EXPECT().ImageExists(gomock.Any(), c.Image).Return(false, nil)
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+	tel := telemetry.New("", true)
+
+	_, err := pullImages(context.Background(), mockRT, sink, tel, []runtime.ContainerConfig{c})
+
+	require.Error(t, err)
+	assert.True(t, output.IsSilent(err), "error should be silent since an ErrorEvent was emitted")
+	assert.Contains(t, out.String(), "Failed to pull localstack/localstack-pro:latest")
+}
+
+func TestValidateLicense_ContinuesWhenServerUnreachable(t *testing.T) {
+	// A closed port yields a transport-level failure (not an *api.LicenseError),
+	// which models an offline/proxy environment that cannot reach the license server.
+	opts := StartOptions{
+		PlatformClient: api.NewPlatformClient("http://127.0.0.1:1", log.Nop()),
+		Logger:         log.Nop(),
+		Telemetry:      telemetry.New("", true),
+	}
+	c := runtime.ContainerConfig{
+		EmulatorType: config.EmulatorAWS,
+		ProductName:  "localstack-pro",
+		Tag:          "2026.4",
+		Image:        "localstack/localstack-pro:2026.4",
+	}
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	err := validateLicense(context.Background(), sink, opts, c, "tok", filepath.Join(t.TempDir(), "license.json"))
+
+	require.NoError(t, err, "an unreachable license server must not block the start")
+	assert.Contains(t, out.String(), "Could not reach the license server")
+}
+
+func TestValidateLicense_FailsOnServerRejection(t *testing.T) {
+	// A definitive rejection (HTTP 403 -> *api.LicenseError) must remain fatal.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	opts := StartOptions{
+		PlatformClient: api.NewPlatformClient(srv.URL, log.Nop()),
+		Logger:         log.Nop(),
+		Telemetry:      telemetry.New("", true),
+	}
+	c := runtime.ContainerConfig{
+		EmulatorType: config.EmulatorAWS,
+		ProductName:  "localstack-pro",
+		Tag:          "2026.4",
+		Image:        "localstack/localstack-pro:2026.4",
+	}
+
+	err := validateLicense(context.Background(), output.NewPlainSink(io.Discard), opts, c, "tok", filepath.Join(t.TempDir(), "license.json"))
+
+	require.Error(t, err, "a server rejection must remain fatal")
+	assert.Contains(t, err.Error(), "license validation failed")
+}
+
+func TestValidateLicense_PropagatesContextCancellation(t *testing.T) {
+	// A cancelled caller context (Ctrl+C) must surface as cancellation, not be
+	// mistaken for an offline license server.
+	opts := StartOptions{
+		PlatformClient: api.NewPlatformClient("http://127.0.0.1:1", log.Nop()),
+		Logger:         log.Nop(),
+		Telemetry:      telemetry.New("", true),
+	}
+	c := runtime.ContainerConfig{
+		EmulatorType: config.EmulatorAWS,
+		ProductName:  "localstack-pro",
+		Tag:          "2026.4",
+		Image:        "localstack/localstack-pro:2026.4",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	err := validateLicense(ctx, sink, opts, c, "tok", filepath.Join(t.TempDir(), "license.json"))
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotContains(t, out.String(), "Could not reach the license server",
+		"a cancellation must not be reported as an unreachable license server")
 }
 
 func TestStartContainers_SnowflakeLicenseError(t *testing.T) {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -181,6 +181,12 @@ func windowsDockerStartCommand(getenv func(string) string, lookPath func(string)
 }
 
 func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progress chan<- PullProgress) error {
+	// Close progress on every return path, including when ImagePull itself fails
+	// (e.g. the registry is unreachable), so callers ranging over it never block.
+	if progress != nil {
+		defer close(progress)
+	}
+
 	reader, err := d.client.ImagePull(ctx, imageName, client.ImagePullOptions{})
 	if err != nil {
 		return err
@@ -190,10 +196,6 @@ func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progres
 			log.Printf("failed to close image pull reader: %v", err)
 		}
 	}()
-
-	if progress != nil {
-		defer close(progress)
-	}
 
 	decoder := json.NewDecoder(reader)
 	for {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -795,83 +795,97 @@ func TestStartContinuesWhenLicenseServerUnreachable(t *testing.T) {
 	assert.True(t, inspect.Container.State.Running, "container should be running")
 }
 
-// TestStartSkipsPullAndLicenseCheckWhenImageIsLocal verifies the offline-friendly
-// success path from the #325 review: when a pinned image is configured and already
-// present locally, lstk pulls nothing and never contacts the license server — the
-// container validates its own bundled license at startup. Covers all four bullets:
-// image set in config, found locally and started, no pull, no CLI license check.
+// TestStartUsesLocalCustomImageWithoutPullOrLicenseCheck verifies the offline
+// success path from the #325 review: when a custom image is configured with a
+// pinned tag and is already present locally, lstk starts it with no pull and no
+// CLI license check at all. Covers all four points: image set in config, found
+// locally and started, no image pulled, no license call from the CLI.
 //
-// A real LocalStack image is tagged under a custom, pinned reference that no registry
-// can serve (so any pull would fail loudly), and the license endpoint points at a
-// server that fails the test if it is ever contacted.
-func TestStartSkipsPullAndLicenseCheckWhenImageIsLocal(t *testing.T) {
+// This is intentionally a small, token-free test: the custom image is a
+// lightweight stand-in tagged locally (so it exits right after it is created),
+// which lets us assert the pull/license decisions and that the container lstk
+// created uses the local image — without a real auth token or a reachable
+// registry/license server. A real container reaching a healthy state from a
+// local image is already covered by TestStartFallsBackToLocalImageWhenPullFails.
+func TestStartUsesLocalCustomImageWithoutPullOrLicenseCheck(t *testing.T) {
 	requireDocker(t)
-	authToken := env.Require(t, env.AuthToken)
-
 	cleanup()
 	t.Cleanup(cleanup)
 
 	ctx := testContext(t)
 
-	const sourceImage = "localstack/localstack-pro:latest"
-	const localImage = "lstk-local-only-test"
+	const customImage = "lstk-offline-only-image"
 	const pinnedTag = "1.0.0"
+	const fullRef = customImage + ":" + pinnedTag
 	// A pinned tag names the container "localstack-aws-<tag>", not the bare
 	// "localstack-aws" that the shared cleanup() removes.
 	const wantContainer = "localstack-aws-" + pinnedTag
-	reader, err := dockerClient.ImagePull(ctx, sourceImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull source image")
+
+	// Make the custom image present locally without a registry by tagging the
+	// lightweight test image under it.
+	reader, err := dockerClient.ImagePull(ctx, testImage, client.ImagePullOptions{})
+	require.NoError(t, err, "failed to pull test image")
 	_, _ = io.Copy(io.Discard, reader)
 	_ = reader.Close()
-
-	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: sourceImage, Target: localImage + ":" + pinnedTag})
-	require.NoError(t, err, "failed to tag local image")
+	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: testImage, Target: fullRef})
+	require.NoError(t, err)
 	t.Cleanup(func() {
-		_, _ = dockerClient.ImageRemove(context.Background(), localImage+":"+pinnedTag, client.ImageRemoveOptions{Force: true})
+		_, _ = dockerClient.ImageRemove(context.Background(), fullRef, client.ImageRemoveOptions{Force: true})
 	})
 
-	// Remove the pinned-tag container explicitly: cleanup() only knows the bare
-	// "localstack-aws" name, so without this the started container leaks and holds
-	// port 4566 for every test that follows on this shard.
+	// The pinned-tag container isn't the bare "localstack-aws" that cleanup()
+	// removes, so remove it explicitly to avoid leaking it onto port 4566.
 	removeContainer := func() {
 		_, _ = dockerClient.ContainerRemove(context.Background(), wantContainer, client.ContainerRemoveOptions{Force: true})
 	}
 	removeContainer()
 	t.Cleanup(removeContainer)
 
+	// Any request to the license server fails the test: a local pinned image must
+	// not trigger a CLI license check.
 	var licenseHits int32
 	licenseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		atomic.AddInt32(&licenseHits, 1)
-		w.WriteHeader(http.StatusForbidden) // would make a pre-flight check fatal
+		w.WriteHeader(http.StatusForbidden)
 	}))
 	defer licenseServer.Close()
 
+	home := t.TempDir()
+	configFile := filepath.Join(home, "config.toml")
 	configContent := fmt.Sprintf(`
 [[containers]]
 type = "aws"
 tag = %q
 port = "4566"
 image = %q
-`, pinnedTag, localImage)
-	configFile := filepath.Join(t.TempDir(), "config.toml")
+`, pinnedTag, customImage)
 	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
-	// Real (inherited) HOME like the other fresh-start container tests: the started
-	// container writes root-owned files into $HOME/.cache/lstk/volume. Config is
-	// isolated via --config below.
-	e := env.With(env.APIEndpoint, licenseServer.URL).With(env.AuthToken, authToken)
-	stdout, stderr, err := runLstk(t, ctx, "", e, "--config", configFile, "--non-interactive", "start")
-	require.NoError(t, err, "lstk start should use the local image without a license check: %s", stderr)
-	requireExitCode(t, 0, err)
-
+	// A dummy token satisfies the up-front auth check; it is never validated
+	// because the license pre-flight is skipped for a local image.
+	e := env.Environ(testEnvWithHome(home, "")).
+		With(env.APIEndpoint, licenseServer.URL).
+		With(env.AuthToken, "dummy-token")
+	stdout, stderr, _ := runLstk(t, ctx, "", e, "--config", configFile, "--non-interactive", "start")
 	combined := stdout + stderr
-	assert.Contains(t, combined, "Using local image", "the local pinned image must be reused, not pulled")
-	assert.NotContains(t, combined, "Pulling", "no image should be pulled when it is present locally")
-	assert.Equal(t, int32(0), atomic.LoadInt32(&licenseHits), "the license server must never be contacted for a local image")
 
+	// Found locally and used — nothing is pulled.
+	assert.Contains(t, combined, "Using local image "+fullRef,
+		"the configured custom image, present locally, should be reused: %s", combined)
+	assert.NotContains(t, combined, "Pulling",
+		"lstk must not pull when the configured custom image is already present locally")
+
+	// No license check from the CLI for a local image.
+	assert.Equal(t, int32(0), atomic.LoadInt32(&licenseHits),
+		"the CLI must not contact the license server for a local image")
+	assert.NotContains(t, combined, "Checking license",
+		"lstk must not run a pre-flight license check for a local image")
+
+	// Started from the configured local image: lstk created the container using it.
 	inspect, err := dockerClient.ContainerInspect(ctx, wantContainer, client.ContainerInspectOptions{})
-	require.NoError(t, err, "failed to inspect container")
-	assert.True(t, inspect.Container.State.Running, "container should be running from the local image")
+	require.NoError(t, err, "lstk should have created a container from the custom image")
+	assert.Equal(t, fullRef, inspect.Container.Config.Image,
+		"the container should be created from the configured custom image")
 }
 
 func cleanup() {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -725,25 +725,30 @@ func TestStartFallsBackToLocalImageWhenPullFails(t *testing.T) {
 		_, _ = dockerClient.ImageRemove(context.Background(), localImage+":latest", client.ImageRemoveOptions{Force: true})
 	})
 
+	// The started container writes root-owned files into its volume dir; keep that
+	// dir outside t.TempDir (whose cleanup runs as the unprivileged test user and
+	// would fail on root-owned files) so HOME can stay fully isolated below.
+	volumeDir, err := os.MkdirTemp("", "lstk-volume")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(volumeDir) }) // best-effort; root-owned files may remain
+
+	home := t.TempDir()
 	configContent := fmt.Sprintf(`
 [[containers]]
 type = "aws"
 tag = "latest"
 port = "4566"
 image = %q
-`, localImage)
-	configFile := filepath.Join(t.TempDir(), "config.toml")
+volume = %q
+`, localImage, volumeDir)
+	configFile := filepath.Join(home, "config.toml")
 	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
 	mockServer := createMockLicenseServer(true)
 	defer mockServer.Close()
 
-	// Use the real (inherited) HOME like the other fresh-start container tests
-	// (TestStartCommandSucceedsWithValidToken et al.): a started container writes
-	// root-owned files into $HOME/.cache/lstk/volume that t.TempDir's cleanup —
-	// running as the unprivileged test user — cannot unlink. Config is still
-	// isolated via --config below.
-	e := env.With(env.APIEndpoint, mockServer.URL).
+	e := env.Environ(testEnvWithHome(home, "")).
+		With(env.APIEndpoint, mockServer.URL).
 		With(env.AuthToken, authToken)
 	stdout, stderr, err := runLstk(t, ctx, "", e, "--config", configFile, "--non-interactive", "start")
 	require.NoError(t, err, "lstk start should fall back to the local image: %s", stderr)
@@ -779,12 +784,28 @@ func TestStartContinuesWhenLicenseServerUnreachable(t *testing.T) {
 	unreachableURL := unreachable.URL
 	unreachable.Close()
 
-	// Use the real (inherited) HOME like the other fresh-start container tests: a
-	// started container writes root-owned files into $HOME/.cache/lstk/volume that
-	// t.TempDir's cleanup — running as the unprivileged test user — cannot unlink.
-	e := env.With(env.APIEndpoint, unreachableURL).
+	// The started container writes root-owned files into its volume dir; keep that
+	// dir outside t.TempDir (whose cleanup runs as the unprivileged test user and
+	// would fail on root-owned files) so HOME can stay fully isolated below.
+	volumeDir, err := os.MkdirTemp("", "lstk-volume")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(volumeDir) }) // best-effort; root-owned files may remain
+
+	home := t.TempDir()
+	configContent := fmt.Sprintf(`
+[[containers]]
+type = "aws"
+tag = "latest"
+port = "4566"
+volume = %q
+`, volumeDir)
+	configFile := filepath.Join(home, "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	e := env.Environ(testEnvWithHome(home, "")).
+		With(env.APIEndpoint, unreachableURL).
 		With(env.AuthToken, authToken)
-	stdout, stderr, err := runLstk(t, ctx, "", e, "--non-interactive", "start")
+	stdout, stderr, err := runLstk(t, ctx, "", e, "--config", configFile, "--non-interactive", "start")
 	require.NoError(t, err, "lstk start should continue when the license server is unreachable: %s", stderr)
 	requireExitCode(t, 0, err)
 

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -737,8 +738,12 @@ image = %q
 	mockServer := createMockLicenseServer(true)
 	defer mockServer.Close()
 
-	e := env.Environ(testEnvWithHome(t.TempDir(), "")).
-		With(env.APIEndpoint, mockServer.URL).
+	// Use the real (inherited) HOME like the other fresh-start container tests
+	// (TestStartCommandSucceedsWithValidToken et al.): a started container writes
+	// root-owned files into $HOME/.cache/lstk/volume that t.TempDir's cleanup —
+	// running as the unprivileged test user — cannot unlink. Config is still
+	// isolated via --config below.
+	e := env.With(env.APIEndpoint, mockServer.URL).
 		With(env.AuthToken, authToken)
 	stdout, stderr, err := runLstk(t, ctx, "", e, "--config", configFile, "--non-interactive", "start")
 	require.NoError(t, err, "lstk start should fall back to the local image: %s", stderr)
@@ -774,8 +779,10 @@ func TestStartContinuesWhenLicenseServerUnreachable(t *testing.T) {
 	unreachableURL := unreachable.URL
 	unreachable.Close()
 
-	e := env.Environ(testEnvWithHome(t.TempDir(), "")).
-		With(env.APIEndpoint, unreachableURL).
+	// Use the real (inherited) HOME like the other fresh-start container tests: a
+	// started container writes root-owned files into $HOME/.cache/lstk/volume that
+	// t.TempDir's cleanup — running as the unprivileged test user — cannot unlink.
+	e := env.With(env.APIEndpoint, unreachableURL).
 		With(env.AuthToken, authToken)
 	stdout, stderr, err := runLstk(t, ctx, "", e, "--non-interactive", "start")
 	require.NoError(t, err, "lstk start should continue when the license server is unreachable: %s", stderr)
@@ -786,6 +793,73 @@ func TestStartContinuesWhenLicenseServerUnreachable(t *testing.T) {
 	inspect, err := dockerClient.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
 	require.NoError(t, err, "failed to inspect container")
 	assert.True(t, inspect.Container.State.Running, "container should be running")
+}
+
+// TestStartSkipsPullAndLicenseCheckWhenImageIsLocal verifies the offline-friendly
+// success path from the #325 review: when a pinned image is configured and already
+// present locally, lstk pulls nothing and never contacts the license server — the
+// container validates its own bundled license at startup. Covers all four bullets:
+// image set in config, found locally and started, no pull, no CLI license check.
+//
+// A real LocalStack image is tagged under a custom, pinned reference that no registry
+// can serve (so any pull would fail loudly), and the license endpoint points at a
+// server that fails the test if it is ever contacted.
+func TestStartSkipsPullAndLicenseCheckWhenImageIsLocal(t *testing.T) {
+	requireDocker(t)
+	authToken := env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+
+	const sourceImage = "localstack/localstack-pro:latest"
+	const localImage = "lstk-local-only-test"
+	const pinnedTag = "1.0.0"
+	reader, err := dockerClient.ImagePull(ctx, sourceImage, client.ImagePullOptions{})
+	require.NoError(t, err, "failed to pull source image")
+	_, _ = io.Copy(io.Discard, reader)
+	_ = reader.Close()
+
+	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: sourceImage, Target: localImage + ":" + pinnedTag})
+	require.NoError(t, err, "failed to tag local image")
+	t.Cleanup(func() {
+		_, _ = dockerClient.ImageRemove(context.Background(), localImage+":"+pinnedTag, client.ImageRemoveOptions{Force: true})
+	})
+
+	var licenseHits int32
+	licenseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&licenseHits, 1)
+		w.WriteHeader(http.StatusForbidden) // would make a pre-flight check fatal
+	}))
+	defer licenseServer.Close()
+
+	configContent := fmt.Sprintf(`
+[[containers]]
+type = "aws"
+tag = %q
+port = "4566"
+image = %q
+`, pinnedTag, localImage)
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	// Real (inherited) HOME like the other fresh-start container tests: the started
+	// container writes root-owned files into $HOME/.cache/lstk/volume. Config is
+	// isolated via --config below.
+	e := env.With(env.APIEndpoint, licenseServer.URL).With(env.AuthToken, authToken)
+	stdout, stderr, err := runLstk(t, ctx, "", e, "--config", configFile, "--non-interactive", "start")
+	require.NoError(t, err, "lstk start should use the local image without a license check: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	combined := stdout + stderr
+	assert.Contains(t, combined, "Using local image", "the local pinned image must be reused, not pulled")
+	assert.NotContains(t, combined, "Pulling", "no image should be pulled when it is present locally")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&licenseHits), "the license server must never be contacted for a local image")
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
+	require.NoError(t, err, "failed to inspect container")
+	assert.True(t, inspect.Container.State.Running, "container should be running from the local image")
 }
 
 func cleanup() {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -693,6 +693,101 @@ image = "lstk-nonexistent-custom-image"
 	assert.Contains(t, combined, "Failed to pull lstk-nonexistent-custom-image:latest")
 }
 
+// TestStartFallsBackToLocalImageWhenPullFails verifies the offline degradation
+// path for image pulls: when the configured image cannot be pulled (registry
+// unreachable, or the image was never published) but is already present locally,
+// lstk warns and starts the local image instead of failing.
+//
+// The scenario is reproduced without cutting off the network by tagging a real
+// LocalStack image under a name no registry can serve: the pull fails, but
+// ImageExists reports the image locally, so the fallback fires. A valid token is
+// still required for the (real) container to activate and become healthy.
+func TestStartFallsBackToLocalImageWhenPullFails(t *testing.T) {
+	requireDocker(t)
+	authToken := env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+
+	const sourceImage = "localstack/localstack-pro:latest"
+	const localImage = "lstk-offline-fallback-test"
+	reader, err := dockerClient.ImagePull(ctx, sourceImage, client.ImagePullOptions{})
+	require.NoError(t, err, "failed to pull source image")
+	_, _ = io.Copy(io.Discard, reader)
+	_ = reader.Close()
+
+	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: sourceImage, Target: localImage + ":latest"})
+	require.NoError(t, err, "failed to tag local image")
+	t.Cleanup(func() {
+		_, _ = dockerClient.ImageRemove(context.Background(), localImage+":latest", client.ImageRemoveOptions{Force: true})
+	})
+
+	configContent := fmt.Sprintf(`
+[[containers]]
+type = "aws"
+tag = "latest"
+port = "4566"
+image = %q
+`, localImage)
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	e := env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.APIEndpoint, mockServer.URL).
+		With(env.AuthToken, authToken)
+	stdout, stderr, err := runLstk(t, ctx, "", e, "--config", configFile, "--non-interactive", "start")
+	require.NoError(t, err, "lstk start should fall back to the local image: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	assert.Contains(t, stdout+stderr, "using the local image", "expected the local-image fallback warning")
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
+	require.NoError(t, err, "failed to inspect container")
+	assert.True(t, inspect.Container.State.Running, "container should be running from the local image")
+}
+
+// TestStartContinuesWhenLicenseServerUnreachable verifies the offline degradation
+// path for license validation: when the license server cannot be reached — a
+// transport-level failure (offline/proxy/cert), not a definitive rejection — lstk
+// skips the pre-flight check and lets the container validate its own bundled
+// license instead of blocking the start.
+//
+// The endpoint is made unreachable by closing the mock server immediately, so the
+// pre-flight request is refused at the transport level rather than returning an
+// *api.LicenseError. A "latest" tag defers validation until after the (successful)
+// pull, so the unreachable endpoint is hit at the post-pull check.
+func TestStartContinuesWhenLicenseServerUnreachable(t *testing.T) {
+	requireDocker(t)
+	authToken := env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+
+	unreachable := createMockLicenseServer(true)
+	unreachableURL := unreachable.URL
+	unreachable.Close()
+
+	e := env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.APIEndpoint, unreachableURL).
+		With(env.AuthToken, authToken)
+	stdout, stderr, err := runLstk(t, ctx, "", e, "--non-interactive", "start")
+	require.NoError(t, err, "lstk start should continue when the license server is unreachable: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	assert.Contains(t, stdout+stderr, "Could not reach the license server", "expected the license-unreachable warning")
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
+	require.NoError(t, err, "failed to inspect container")
+	assert.True(t, inspect.Container.State.Running, "container should be running")
+}
+
 func cleanup() {
 	ctx := context.Background()
 	// ContainerRemove with Force already SIGKILLs the container; an explicit

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -816,6 +816,9 @@ func TestStartSkipsPullAndLicenseCheckWhenImageIsLocal(t *testing.T) {
 	const sourceImage = "localstack/localstack-pro:latest"
 	const localImage = "lstk-local-only-test"
 	const pinnedTag = "1.0.0"
+	// A pinned tag names the container "localstack-aws-<tag>", not the bare
+	// "localstack-aws" that the shared cleanup() removes.
+	const wantContainer = "localstack-aws-" + pinnedTag
 	reader, err := dockerClient.ImagePull(ctx, sourceImage, client.ImagePullOptions{})
 	require.NoError(t, err, "failed to pull source image")
 	_, _ = io.Copy(io.Discard, reader)
@@ -826,6 +829,15 @@ func TestStartSkipsPullAndLicenseCheckWhenImageIsLocal(t *testing.T) {
 	t.Cleanup(func() {
 		_, _ = dockerClient.ImageRemove(context.Background(), localImage+":"+pinnedTag, client.ImageRemoveOptions{Force: true})
 	})
+
+	// Remove the pinned-tag container explicitly: cleanup() only knows the bare
+	// "localstack-aws" name, so without this the started container leaks and holds
+	// port 4566 for every test that follows on this shard.
+	removeContainer := func() {
+		_, _ = dockerClient.ContainerRemove(context.Background(), wantContainer, client.ContainerRemoveOptions{Force: true})
+	}
+	removeContainer()
+	t.Cleanup(removeContainer)
 
 	var licenseHits int32
 	licenseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -857,7 +869,7 @@ image = %q
 	assert.NotContains(t, combined, "Pulling", "no image should be pulled when it is present locally")
 	assert.Equal(t, int32(0), atomic.LoadInt32(&licenseHits), "the license server must never be contacted for a local image")
 
-	inspect, err := dockerClient.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
+	inspect, err := dockerClient.ContainerInspect(ctx, wantContainer, client.ContainerInspectOptions{})
 	require.NoError(t, err, "failed to inspect container")
 	assert.True(t, inspect.Container.State.Running, "container should be running from the local image")
 }


### PR DESCRIPTION
> **Stacked on #325.** This PR's base is the image-override branch, so its diff shows offline changes only; it auto-retargets to `main` when #325 merges. The local-image fallback integration test relies on the `image=` field introduced in #325.

## What

Makes `lstk start` degrade gracefully in offline / enterprise environments that cannot reach Docker Hub or the license server (offline/air-gapped, corporate proxy, or TLS interception) — without an explicit flag.

- **Image pull**: if `PullImage` fails but the image is already present locally (new `runtime.ImageExists`), lstk warns `"using the local image"` and starts the local image instead of failing.
- **License pre-flight**: `validateLicense` now distinguishes a definitive server rejection (`*api.LicenseError`, e.g. HTTP 403/400 — still fatal) from a transport-level failure (any other error — offline/proxy/cert). On a transport failure it skips the pre-flight check and lets the container validate its own bundled license at startup.
- `runtime.PullImage` always closes its `progress` channel, even when `ImagePull` fails early, so the local-image fallback path does not leak the progress goroutine.
- Context cancellation is propagated during the license pre-flight so Ctrl+C aborts cleanly.

## Scope

Second of the two PRs split out of DEVX-703. The **custom `image` override** half ships separately in #325. This PR is **offline graceful-degradation only**.

> Note: this addresses the *truly offline* case (network requests **fail**). The separate slow-network / demo case raised in #team-cli (a working-but-slow link where the pull *succeeds* but takes 20 min) is a different problem — graceful degradation never triggers there because nothing fails. That is being tracked as its own piece of work (`--offline` to skip the pull when the image is local + a cancellable pull).

## Tests

- Unit (`internal/container`): `TestPullImages_FallsBackToLocalImageWhenPullFails`, `TestPullImages_FailsWhenPullFailsAndImageMissing`, `TestValidateLicense_ContinuesWhenServerUnreachable`, `TestValidateLicense_FailsOnServerRejection`.
- Integration: local-image fallback and license-server-unreachable E2E coverage (added on this branch).

Refs DEVX-703
