### PR TITLE
Reuse local image when already present for pinned tags

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -314,6 +314,20 @@ func pullImages(ctx context.Context, rt runtime.Runtime, sink output.Sink, tel *
 			return nil, fmt.Errorf("failed to remove existing container %s: %w", c.Name, err)
 		}
 
+		// Reuse a locally present image for pinned tags instead of re-pulling.
+		// Floating "latest"/empty tags always pull until pull_policy support lands.
+		if c.Tag != "" && c.Tag != "latest" {
+			exists, err := rt.ImageExists(ctx, c.Image)
+			if err != nil {
+				return nil, fmt.Errorf("failed to check for local image %s: %w", c.Image, err)
+			}
+			if exists {
+				sink.Emit(output.MessageEvent{Severity: output.SeveritySuccess, Text: fmt.Sprintf("Using local image %s", c.Image)})
+				pulled[c.Name] = false
+				continue
+			}
+		}
+
 		sink.Emit(output.SpinnerStart(fmt.Sprintf("Pulling %s", c.Image)))
 		sink.Emit(output.ContainerStatusEvent{Phase: "pulling", Container: c.Image})
 		progress := make(chan runtime.PullProgress)

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -474,3 +474,59 @@ func TestStartContainers_AzureLicenseError(t *testing.T) {
 		t.Fatal("no telemetry event received")
 	}
 }
+
+func TestPullImages_ReusesLocalImageWhenPresent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockTel := telemetry.New("", true)
+
+	c := runtime.ContainerConfig{
+		Image:        "localstack/localstack-pro:3.5.0",
+		Name:         "localstack-aws",
+		EmulatorType: config.EmulatorAWS,
+		Tag:          "3.5.0",
+	}
+
+	mockRT.EXPECT().Remove(gomock.Any(), c.Name).Return(nil)
+	mockRT.EXPECT().ImageExists(gomock.Any(), c.Image).Return(true, nil)
+	// No PullImage call expected when the image is already present.
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	pulled, err := pullImages(context.Background(), mockRT, sink, mockTel, []runtime.ContainerConfig{c})
+
+	require.NoError(t, err)
+	assert.False(t, pulled[c.Name], "telemetry must not count a reused image as pulled")
+	assert.Contains(t, out.String(), "Using local image localstack/localstack-pro:3.5.0")
+}
+
+func TestPullImages_PullsWhenImageMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockTel := telemetry.New("", true)
+
+	c := runtime.ContainerConfig{
+		Image:        "localstack/localstack-pro:3.5.0",
+		Name:         "localstack-aws",
+		EmulatorType: config.EmulatorAWS,
+		Tag:          "3.5.0",
+	}
+
+	mockRT.EXPECT().Remove(gomock.Any(), c.Name).Return(nil)
+	mockRT.EXPECT().ImageExists(gomock.Any(), c.Image).Return(false, nil)
+	mockRT.EXPECT().PullImage(gomock.Any(), c.Image, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, progress chan<- runtime.PullProgress) error {
+			close(progress)
+			return nil
+		})
+
+	var out bytes.Buffer
+	sink := output.NewPlainSink(&out)
+
+	pulled, err := pullImages(context.Background(), mockRT, sink, mockTel, []runtime.ContainerConfig{c})
+
+	require.NoError(t, err)
+	assert.True(t, pulled[c.Name], "a freshly pulled image must be counted as pulled")
+	assert.Contains(t, out.String(), "Pulled localstack/localstack-pro:3.5.0")
+}

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -471,3 +471,13 @@ func (d *DockerRuntime) GetImageVersion(ctx context.Context, imageName string) (
 
 	return "", fmt.Errorf("LOCALSTACK_BUILD_VERSION not found in image environment")
 }
+
+func (d *DockerRuntime) ImageExists(ctx context.Context, image string) (bool, error) {
+	if _, err := d.client.ImageInspect(ctx, image); err != nil {
+		if errdefs.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to inspect image: %w", err)
+	}
+	return true, nil
+}

--- a/internal/runtime/mock_runtime.go
+++ b/internal/runtime/mock_runtime.go
@@ -43,21 +43,6 @@ func (m *MockRuntime) EXPECT() *MockRuntimeMockRecorder {
 	return m.recorder
 }
 
-// FindRunningByImage mocks base method.
-func (m *MockRuntime) FindRunningByImage(ctx context.Context, imageRepos []string, containerPort string) (*RunningContainer, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindRunningByImage", ctx, imageRepos, containerPort)
-	ret0, _ := ret[0].(*RunningContainer)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindRunningByImage indicates an expected call of FindRunningByImage.
-func (mr *MockRuntimeMockRecorder) FindRunningByImage(ctx, imageRepos, containerPort any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindRunningByImage", reflect.TypeOf((*MockRuntime)(nil).FindRunningByImage), ctx, imageRepos, containerPort)
-}
-
 // ContainerEnv mocks base method.
 func (m *MockRuntime) ContainerEnv(ctx context.Context, containerName string) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -100,8 +85,23 @@ func (mr *MockRuntimeMockRecorder) EmitUnhealthyError(sink, err any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmitUnhealthyError", reflect.TypeOf((*MockRuntime)(nil).EmitUnhealthyError), sink, err)
 }
 
+// FindRunningByImage mocks base method.
+func (m *MockRuntime) FindRunningByImage(ctx context.Context, imageRepos []string, containerPort string) (*RunningContainer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindRunningByImage", ctx, imageRepos, containerPort)
+	ret0, _ := ret[0].(*RunningContainer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindRunningByImage indicates an expected call of FindRunningByImage.
+func (mr *MockRuntimeMockRecorder) FindRunningByImage(ctx, imageRepos, containerPort any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindRunningByImage", reflect.TypeOf((*MockRuntime)(nil).FindRunningByImage), ctx, imageRepos, containerPort)
+}
+
 // GetBoundPort mocks base method.
-func (m *MockRuntime) GetBoundPort(ctx context.Context, containerName string, containerPort string) (string, error) {
+func (m *MockRuntime) GetBoundPort(ctx context.Context, containerName, containerPort string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBoundPort", ctx, containerName, containerPort)
 	ret0, _ := ret[0].(string)
@@ -128,6 +128,21 @@ func (m *MockRuntime) GetImageVersion(ctx context.Context, imageName string) (st
 func (mr *MockRuntimeMockRecorder) GetImageVersion(ctx, imageName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageVersion", reflect.TypeOf((*MockRuntime)(nil).GetImageVersion), ctx, imageName)
+}
+
+// ImageExists mocks base method.
+func (m *MockRuntime) ImageExists(ctx context.Context, image string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImageExists", ctx, image)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImageExists indicates an expected call of ImageExists.
+func (mr *MockRuntimeMockRecorder) ImageExists(ctx, image any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageExists", reflect.TypeOf((*MockRuntime)(nil).ImageExists), ctx, image)
 }
 
 // IsHealthy mocks base method.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -64,6 +64,8 @@ type Runtime interface {
 	Logs(ctx context.Context, containerID string, tail int) (string, error)
 	StreamLogs(ctx context.Context, containerID string, out io.Writer, follow bool) error
 	GetImageVersion(ctx context.Context, imageName string) (string, error)
+	// ImageExists reports whether the given image is already present locally.
+	ImageExists(ctx context.Context, image string) (bool, error)
 	// GetBoundPort returns the host port bound to the given container port (e.g. "4566/tcp").
 	GetBoundPort(ctx context.Context, containerName string, containerPort string) (string, error)
 	FindRunningByImage(ctx context.Context, imageRepos []string, containerPort string) (*RunningContainer, error)

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -52,50 +52,45 @@ func TestStartCommandSucceedsWithValidToken(t *testing.T) {
 }
 
 // PRO-323: a pinned image already present locally must be reused, not re-pulled.
+// Tags the lightweight test image under a pinned localstack-pro tag so the image
+// is present locally; lstk should skip the pull and emit "Using local image".
+// We only assert the pull decision (emitted before the container starts) — the
+// stand-in image is not a real emulator, so the subsequent start fails fast when
+// it exits. A dedicated host port keeps this off the shared 4566 used by the
+// other container tests.
 func TestStartCommandReusesLocalImageWhenPresent(t *testing.T) {
 	requireDocker(t)
-	requireAuthToken(t)
-
 	cleanup()
 	t.Cleanup(cleanup)
 
 	ctx := testContext(t)
 
-	// Pull the real default AWS image once, then pin it under a fixed local tag so
-	// lstk sees a pinned tag whose image is already present.
-	const baseImage = "localstack/localstack-pro:latest"
-	reader, err := dockerClient.ImagePull(ctx, baseImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull base image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
-
 	const pinnedTag = "reuse-local-test"
 	const pinnedImage = "localstack/localstack-pro:" + pinnedTag
-	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: baseImage, Target: pinnedImage})
+	reader, err := dockerClient.ImagePull(ctx, testImage, client.ImagePullOptions{})
+	require.NoError(t, err, "failed to pull test image")
+	_, _ = io.Copy(io.Discard, reader)
+	_ = reader.Close()
+	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: testImage, Target: pinnedImage})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = dockerClient.ImageRemove(context.Background(), pinnedImage, client.ImageRemoveOptions{})
 	})
 
-	// Real LocalStack writes root-owned files under $HOME/.cache, so use os.MkdirTemp
-	// with best-effort cleanup rather than t.TempDir (whose RemoveAll runs as the
-	// non-root test user and would fail). See startRealLocalStack for context.
-	home, err := os.MkdirTemp("", "lstk-reuse-home")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(home) })
-
+	home := t.TempDir()
 	configFile := filepath.Join(home, "config.toml")
 	require.NoError(t, os.WriteFile(configFile,
-		[]byte(fmt.Sprintf("[[containers]]\ntype = \"aws\"\ntag = %q\nport = \"4566\"\n", pinnedTag)), 0644))
+		[]byte(fmt.Sprintf("[[containers]]\ntype = \"aws\"\ntag = %q\nport = \"4599\"\n", pinnedTag)), 0644))
 
 	mockServer := createMockLicenseServer(true)
 	defer mockServer.Close()
 
-	e := append(testEnvWithHome(home, ""), string(env.APIEndpoint)+"="+mockServer.URL)
-	stdout, stderr, err := runLstk(t, ctx, "", e, "--config", configFile, "start")
-	require.NoError(t, err, "lstk start failed:\nstdout: %s\nstderr: %s", stdout, stderr)
+	e := append(testEnvWithHome(home, ""),
+		string(env.APIEndpoint)+"="+mockServer.URL,
+		string(env.AuthToken)+"=fake-token")
+	stdout, _, _ := runLstk(t, ctx, "", e, "--config", configFile, "start")
 
-	assert.Contains(t, stdout, "Using local image", "a pinned image present locally should be reused")
+	assert.Contains(t, stdout, "Using local image "+pinnedImage, "a pinned image present locally should be reused")
 	assert.NotContains(t, stdout, "Pulling", "lstk must not re-pull an image that is already present")
 }
 

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -51,6 +51,54 @@ func TestStartCommandSucceedsWithValidToken(t *testing.T) {
 		"persistence bullet must be omitted when --persist is not set")
 }
 
+// PRO-323: a pinned image already present locally must be reused, not re-pulled.
+func TestStartCommandReusesLocalImageWhenPresent(t *testing.T) {
+	requireDocker(t)
+	requireAuthToken(t)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+
+	// Pull the real default AWS image once, then pin it under a fixed local tag so
+	// lstk sees a pinned tag whose image is already present.
+	const baseImage = "localstack/localstack-pro:latest"
+	reader, err := dockerClient.ImagePull(ctx, baseImage, client.ImagePullOptions{})
+	require.NoError(t, err, "failed to pull base image")
+	_, _ = io.Copy(io.Discard, reader)
+	_ = reader.Close()
+
+	const pinnedTag = "reuse-local-test"
+	const pinnedImage = "localstack/localstack-pro:" + pinnedTag
+	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: baseImage, Target: pinnedImage})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = dockerClient.ImageRemove(context.Background(), pinnedImage, client.ImageRemoveOptions{})
+	})
+
+	// Real LocalStack writes root-owned files under $HOME/.cache, so use os.MkdirTemp
+	// with best-effort cleanup rather than t.TempDir (whose RemoveAll runs as the
+	// non-root test user and would fail). See startRealLocalStack for context.
+	home, err := os.MkdirTemp("", "lstk-reuse-home")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+
+	configFile := filepath.Join(home, "config.toml")
+	require.NoError(t, os.WriteFile(configFile,
+		[]byte(fmt.Sprintf("[[containers]]\ntype = \"aws\"\ntag = %q\nport = \"4566\"\n", pinnedTag)), 0644))
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	e := append(testEnvWithHome(home, ""), string(env.APIEndpoint)+"="+mockServer.URL)
+	stdout, stderr, err := runLstk(t, ctx, "", e, "--config", configFile, "start")
+	require.NoError(t, err, "lstk start failed:\nstdout: %s\nstderr: %s", stdout, stderr)
+
+	assert.Contains(t, stdout, "Using local image", "a pinned image present locally should be reused")
+	assert.NotContains(t, stdout, "Pulling", "lstk must not re-pull an image that is already present")
+}
+
 func TestStartCommandSucceedsWithKeyringToken(t *testing.T) {
 	requireDocker(t)
 	cleanup()


### PR DESCRIPTION
## Summary

`lstk start` ran `docker pull` on **every** start, even when the image was already present locally — `rt.PullImage` was unconditional. On slow networks this meant repeated multi-minute re-downloads for no benefit.

This adds `ImageExists` to the `Runtime` interface (backed by `ImageInspect` + `errdefs.IsNotFound` on Docker) and, in `pullImages`, skips the pull when a **pinned-tag** image is already local — emitting a `Using local image` message instead and recording `pulled[name]=false` so start telemetry (`LifecycleStartSuccess.Pulled`) doesn't over-count. Stopped-container cleanup (`rt.Remove`) still runs on both branches, and post-pull license validation is unaffected since the image is present.

A net-new probe is needed because `GetImageVersion` can't double as one: it errors both when the image is absent *and* when `LOCALSTACK_BUILD_VERSION` is missing, conflating the two.

## Scope

Skip-if-present applies to **pinned tags** only. Floating `latest`/empty still pulls until the `pull_policy` work lands (PRO-325).

## Tests

- Integration: pre-pull a pinned image, run `lstk start`, assert `Using local image` present and `Pulling` absent.
- Unit (MockRuntime): `ImageExists` true → 0 `PullImage` calls, `pulled[name]==false`; false → 1 call, `pulled[name]==true`.


| CLI output using local image |
|--------|
| <img width="669" height="260" alt="Screenshot 2026-06-24 at 20 59 29" src="https://github.com/user-attachments/assets/7369a86d-b1fd-4a6b-b9cc-d77722b3c499" /> | 