### PR TITLE
fix: propagate os.UserHomeDir() errors in snapshot save and load

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -209,7 +209,10 @@ func runSnapshotLoad(cfg *env.Env, tel *telemetry.Client, logger log.Logger) fun
 			return err
 		}
 
-		home, _ := os.UserHomeDir()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
 		src, err := snapshot.ParseSource(args[0], home)
 		if err != nil {
 			return err
@@ -419,7 +422,10 @@ func runSnapshotSave(cfg *env.Env) func(*cobra.Command, []string) error {
 			destArg = args[0]
 		}
 
-		home, _ := os.UserHomeDir()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
 		dest, err := snapshot.ParseDestination(destArg, home, time.Now())
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

- `runSnapshotSave` and `runSnapshotLoad` were silently ignoring the error from `os.UserHomeDir()` (`home, _ := os.UserHomeDir()`), passing an empty home path to `ParseSource`/`ParseDestination` when the home directory cannot be resolved
- `runSnapshotRemove` in the same file already handled this correctly — this brings the other two functions in line
- Fixes DEVX-938: https://linear.app/localstack/issue/DEVX-938/snapshot-saveload-silently-drop-osuserhomedir-errors

## Test plan

- [ ] `lstk snapshot save` and `lstk snapshot load` return a clear error when the home directory cannot be resolved, rather than silently computing a wrong path

🤖 Generated with [Claude Code](https://claude.com/claude-code)