### PR TITLE
feat: allow configuring GATEWAY_LISTEN and host exposure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,14 @@ Created automatically on first run with defaults. Supports emulator types: `aws`
 
 Each `[[containers]]` block may set an optional `image` to override the default Docker Hub image (e.g. an internal registry mirror or a locally loaded offline image). `ContainerConfig.Image()` returns `image` as-is when it already carries a tag (so the separately-configured `tag` is dropped in that case), otherwise it appends `tag` (or `latest`); the default `localstack/<product>:<tag>` is used when `image` is unset.
 
+## GATEWAY_LISTEN and host exposure
+
+`GATEWAY_LISTEN` is not hardcoded — it is read from the container's resolved env (set it via an `[env.*]` profile referenced by the container's `env` field). When unset it defaults to `:4566,:443`. Parsing/derivation lives in `internal/container/gateway.go` (`parseGatewayListen`), mirroring the v1 CLI:
+
+- The **container env value** blanks a `127.0.0.1` host so the gateway still listens on all interfaces inside the container (`:4566`), and preserves any non-loopback host verbatim.
+- The **host publish IP** for *all* published ports (gateway ports + the 4510-4559 service range) is the host part of the first entry, defaulting to `127.0.0.1`. So `GATEWAY_LISTEN = "0.0.0.0:4566,0.0.0.0:443"` exposes the emulator beyond loopback (e.g. on an EC2/MicroVM host). This is threaded through as `runtime.ContainerConfig.BindHost` and applied in `internal/runtime/docker.go`.
+- Gateway ports beyond the primary edge port (4566, which is published on the configured `port`) are published host-port == container-port, so listing an extra port like `:8443` publishes it. `servicePortRange()` covers only 4510-4559 now — 443 comes from the default `GATEWAY_LISTEN`.
+
 ## Volume Mounts
 
 Each `[[containers]]` block accepts a `volumes` list of Docker-style `"host:container[:ro]"` bind specs (e.g. for Snowflake init hooks mounted into `/etc/localstack/init/{boot,start,ready,shutdown}.d`). The persistence/cache mount to `/var/lib/localstack` is folded into this list: the entry whose container target is `/var/lib/localstack` (`persistenceTarget` in `internal/config/containers.go`) defines the host dir backing it, and that path is what `VolumeDir()`, `lstk volume path`, and `lstk volume clear` resolve. Resolution precedence in `VolumeDir()`: a `volumes` entry targeting `/var/lib/localstack` → the legacy singular `volume = "..."` field (still honored for backward compatibility) → the default OS cache dir. Setting the persistence dir via both `volume` and a `volumes` entry with differing sources is a validation error.

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -36,6 +36,14 @@ port = "4566"    # Host port the emulator will be accessible on
 #   SERVICES=s3,sqs         - Limit services to load
 #   EAGER_SERVICE_LOADING=1 - Preload services at startup
 #
+#   GATEWAY_LISTEN=:4566,:443  - Gateway listen addresses (default). The host
+#                                part of the first entry sets the host IP that
+#                                published ports bind to: use
+#                                "0.0.0.0:4566,0.0.0.0:443" to expose the
+#                                emulator beyond loopback (e.g. on an EC2 host).
+#                                Extra ports listed here (e.g. :8443) are also
+#                                published on the host.
+#
 # See full list of configuration options:
 # > https://docs.localstack.cloud/references/configuration/
 #

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -36,13 +36,12 @@ port = "4566"    # Host port the emulator will be accessible on
 #   SERVICES=s3,sqs         - Limit services to load
 #   EAGER_SERVICE_LOADING=1 - Preload services at startup
 #
-#   GATEWAY_LISTEN=:4566,:443  - Gateway listen addresses (default). The host
-#                                part of the first entry sets the host IP that
-#                                published ports bind to: use
-#                                "0.0.0.0:4566,0.0.0.0:443" to expose the
-#                                emulator beyond loopback (e.g. on an EC2 host).
-#                                Extra ports listed here (e.g. :8443) are also
-#                                published on the host.
+#   GATEWAY_LISTEN=:4566,:443  - Ports the gateway listens on (default shown).
+#                                The first entry's host sets what IP published
+#                                ports bind to — use "0.0.0.0:4566,0.0.0.0:443"
+#                                to make the emulator reachable from other
+#                                machines (e.g. on EC2). Extra ports listed
+#                                (e.g. :8443) are published too.
 #
 # See full list of configuration options:
 # > https://docs.localstack.cloud/references/configuration/

--- a/internal/container/gateway.go
+++ b/internal/container/gateway.go
@@ -100,23 +100,35 @@ func (g gatewayListen) containerEnvValue() string {
 		if host == defaultBindHost {
 			host = ""
 		}
-		parts[i] = host + ":" + e.port
+		parts[i] = net.JoinHostPort(host, e.port)
 	}
 	return strings.Join(parts, ",")
 }
 
 // extraGatewayPorts returns the gateway ports that must be published in addition
 // to the primary edge port (which is mapped separately via the container's
-// configured host port). Each is exposed host-port == container-port.
+// configured host port). Each is exposed host-port == container-port. Ports
+// already covered by the primary port or the service port range are skipped
+// so callers don't publish the same container port twice.
 func (g gatewayListen) extraGatewayPorts(primaryPort string) []runtime.PortMapping {
 	var ports []runtime.PortMapping
 	seen := map[string]bool{primaryPort: true}
 	for _, e := range g {
-		if seen[e.port] {
+		if seen[e.port] || inServicePortRange(e.port) {
 			continue
 		}
 		seen[e.port] = true
 		ports = append(ports, runtime.PortMapping{ContainerPort: e.port, HostPort: e.port})
 	}
 	return ports
+}
+
+// inServicePortRange reports whether port falls in the 4510-4559 range already
+// published by servicePortRange.
+func inServicePortRange(port string) bool {
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		return false
+	}
+	return p >= servicePortRangeStart && p <= servicePortRangeEnd
 }

--- a/internal/container/gateway.go
+++ b/internal/container/gateway.go
@@ -1,0 +1,122 @@
+package container
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+// defaultGatewayListen is the value lstk uses when the user has not supplied a
+// GATEWAY_LISTEN of their own. The gateway listens on the AWS edge port (4566)
+// and on 443 for TLS routing.
+const defaultGatewayListen = ":4566,:443"
+
+// defaultBindHost is the host IP that published ports are bound to when the
+// GATEWAY_LISTEN entries carry no explicit host (i.e. they listen on all
+// interfaces inside the container, but are only exposed on loopback).
+const defaultBindHost = "127.0.0.1"
+
+// gatewayEntry is a single "[host]:port" pair from GATEWAY_LISTEN. An empty host
+// means "all interfaces" inside the container.
+type gatewayEntry struct {
+	host string
+	port string
+}
+
+// gatewayListen is the parsed form of a GATEWAY_LISTEN value.
+type gatewayListen []gatewayEntry
+
+// parseGatewayListen parses a GATEWAY_LISTEN value of the form
+// "[host]:port[,[host]:port...]" (e.g. ":4566,:443" or "0.0.0.0:4566,0.0.0.0:443").
+// An empty value falls back to defaultGatewayListen.
+func parseGatewayListen(value string) (gatewayListen, error) {
+	if strings.TrimSpace(value) == "" {
+		value = defaultGatewayListen
+	}
+
+	var entries gatewayListen
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		host, port, err := splitHostPort(part)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, gatewayEntry{host: host, port: port})
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("GATEWAY_LISTEN %q has no valid entries", value)
+	}
+	return entries, nil
+}
+
+// splitHostPort splits a single GATEWAY_LISTEN entry into host and port. A bare
+// port ("4566") is treated as an empty host. The port must be numeric and the
+// host, when present, a valid IP address.
+func splitHostPort(entry string) (host, port string, err error) {
+	s := entry
+	if !strings.Contains(s, ":") {
+		s = ":" + s
+	}
+	host, port, err = net.SplitHostPort(s)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid GATEWAY_LISTEN entry %q: %w", entry, err)
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return "", "", fmt.Errorf("invalid port in GATEWAY_LISTEN entry %q", entry)
+	}
+	if host != "" {
+		if _, err := netip.ParseAddr(host); err != nil {
+			return "", "", fmt.Errorf("invalid host in GATEWAY_LISTEN entry %q: %w", entry, err)
+		}
+	}
+	return host, port, nil
+}
+
+// bindHost returns the host IP to bind published ports to, taken from the first
+// entry (mirroring the v1 CLI). A blank host defaults to loopback so the
+// historical behaviour is preserved unless the user opts into wider exposure.
+func (g gatewayListen) bindHost() string {
+	if len(g) == 0 || g[0].host == "" {
+		return defaultBindHost
+	}
+	return g[0].host
+}
+
+// containerEnvValue compiles the GATEWAY_LISTEN value passed into the container.
+// A loopback host is blanked so the gateway still listens on all interfaces
+// inside the container even when the host only publishes it on loopback; any
+// other host is kept verbatim.
+func (g gatewayListen) containerEnvValue() string {
+	parts := make([]string, len(g))
+	for i, e := range g {
+		host := e.host
+		if host == defaultBindHost {
+			host = ""
+		}
+		parts[i] = host + ":" + e.port
+	}
+	return strings.Join(parts, ",")
+}
+
+// extraGatewayPorts returns the gateway ports that must be published in addition
+// to the primary edge port (which is mapped separately via the container's
+// configured host port). Each is exposed host-port == container-port.
+func (g gatewayListen) extraGatewayPorts(primaryPort string) []runtime.PortMapping {
+	var ports []runtime.PortMapping
+	seen := map[string]bool{primaryPort: true}
+	for _, e := range g {
+		if seen[e.port] {
+			continue
+		}
+		seen[e.port] = true
+		ports = append(ports, runtime.PortMapping{ContainerPort: e.port, HostPort: e.port})
+	}
+	return ports
+}

--- a/internal/container/gateway_test.go
+++ b/internal/container/gateway_test.go
@@ -55,3 +55,26 @@ func TestParseGatewayListenInvalid(t *testing.T) {
 		assert.Error(t, err, "expected error for %q", value)
 	}
 }
+
+func TestParseGatewayListenExtraPortsSkipsServicePortRange(t *testing.T) {
+	g, err := parseGatewayListen("0.0.0.0:4566,0.0.0.0:443,0.0.0.0:4520,0.0.0.0:8443")
+	require.NoError(t, err)
+	extra := g.extraGatewayPorts("4566")
+	require.Len(t, extra, 2, "the 4520 entry already falls in the service port range and must not be duplicated")
+	assert.Equal(t, "443", extra[0].ContainerPort)
+	assert.Equal(t, "8443", extra[1].ContainerPort)
+}
+
+func TestParseGatewayListenBracketedIPv6Host(t *testing.T) {
+	g, err := parseGatewayListen("[::]:4566,[::]:443")
+	require.NoError(t, err)
+	assert.Equal(t, "::", g.bindHost())
+	assert.Equal(t, "[::]:4566,[::]:443", g.containerEnvValue())
+}
+
+func TestParseGatewayListenUnbracketedIPv6HostErrors(t *testing.T) {
+	// Unbracketed IPv6 is ambiguous with the host:port separator, so it must
+	// be rejected rather than mis-parsed.
+	_, err := parseGatewayListen("::1:4566")
+	assert.Error(t, err)
+}

--- a/internal/container/gateway_test.go
+++ b/internal/container/gateway_test.go
@@ -1,0 +1,57 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGatewayListenDefaults(t *testing.T) {
+	for _, value := range []string{"", "   "} {
+		g, err := parseGatewayListen(value)
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1", g.bindHost())
+		assert.Equal(t, ":4566,:443", g.containerEnvValue())
+	}
+}
+
+func TestParseGatewayListenExternalHost(t *testing.T) {
+	g, err := parseGatewayListen("0.0.0.0:4566,0.0.0.0:443")
+	require.NoError(t, err)
+	assert.Equal(t, "0.0.0.0", g.bindHost())
+	// Non-loopback hosts are preserved in the container env value.
+	assert.Equal(t, "0.0.0.0:4566,0.0.0.0:443", g.containerEnvValue())
+}
+
+func TestParseGatewayListenLoopbackHostIsBlankedForContainer(t *testing.T) {
+	g, err := parseGatewayListen("127.0.0.1:4566,127.0.0.1:443")
+	require.NoError(t, err)
+	// Bind host is loopback, but the container listens on all interfaces.
+	assert.Equal(t, "127.0.0.1", g.bindHost())
+	assert.Equal(t, ":4566,:443", g.containerEnvValue())
+}
+
+func TestParseGatewayListenExtraPortsPublished(t *testing.T) {
+	g, err := parseGatewayListen("0.0.0.0:4566,0.0.0.0:443,0.0.0.0:8443")
+	require.NoError(t, err)
+	extra := g.extraGatewayPorts("4566")
+	require.Len(t, extra, 2)
+	assert.Equal(t, "443", extra[0].ContainerPort)
+	assert.Equal(t, "443", extra[0].HostPort)
+	assert.Equal(t, "8443", extra[1].ContainerPort)
+}
+
+func TestParseGatewayListenBarePort(t *testing.T) {
+	g, err := parseGatewayListen("4566")
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", g.bindHost())
+	assert.Equal(t, ":4566", g.containerEnvValue())
+}
+
+func TestParseGatewayListenInvalid(t *testing.T) {
+	for _, value := range []string{"notaport", ":abc", "999.999.999.999:4566"} {
+		_, err := parseGatewayListen(value)
+		assert.Error(t, err, "expected error for %q", value)
+	}
+}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -880,11 +880,12 @@ func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {
 // servicePortRange returns the external service ports LocalStack opens for
 // per-service access (4510-4559). The gateway ports (4566, 443, ...) are
 // published separately from GATEWAY_LISTEN.
+const servicePortRangeStart = 4510
+const servicePortRangeEnd = 4559
+
 func servicePortRange() []runtime.PortMapping {
-	const start = 4510
-	const end = 4559
-	ports := make([]runtime.PortMapping, 0, end-start+1)
-	for p := start; p <= end; p++ {
+	ports := make([]runtime.PortMapping, 0, servicePortRangeEnd-servicePortRangeStart+1)
+	for p := servicePortRangeStart; p <= servicePortRangeEnd; p++ {
 		ps := strconv.Itoa(p)
 		ports = append(ports, runtime.PortMapping{ContainerPort: ps, HostPort: ps})
 	}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -101,10 +101,20 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			return "", err
 		}
 
+		// GATEWAY_LISTEN is configurable via the [env.*] profiles. It controls
+		// which ports the gateway listens on inside the container and, through
+		// the host part of its first entry, which host IP published ports bind
+		// to (e.g. "0.0.0.0:4566,0.0.0.0:443" exposes the emulator beyond
+		// loopback). When unset it defaults to ":4566,:443" bound to loopback.
+		gateway, err := parseGatewayListen(envValue(resolvedEnv, "GATEWAY_LISTEN"))
+		if err != nil {
+			return "", err
+		}
+
 		containerName := c.Name()
 		env := append(resolvedEnv,
 			"LOCALSTACK_AUTH_TOKEN="+token,
-			"GATEWAY_LISTEN=:4566,:443",
+			"GATEWAY_LISTEN="+gateway.containerEnvValue(),
 			"MAIN_CONTAINER_NAME="+containerName,
 			"LOCALSTACK_HOST="+endpoint.Hostname+":"+c.Port,
 		)
@@ -154,18 +164,25 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 			binds = append(binds, runtime.BindMount{HostPath: m.Source, ContainerPath: m.Target, ReadOnly: m.ReadOnly})
 		}
 
+		// The primary edge port is published via the configured host port (c.Port);
+		// any further gateway ports (443, and e.g. 8443) plus the service port range
+		// are published host-port == container-port.
+		primaryPort, _, _ := strings.Cut(containerPort, "/")
+		extraPorts := append(gateway.extraGatewayPorts(primaryPort), servicePortRange()...)
+
 		containers[i] = runtime.ContainerConfig{
 			Image:         image,
 			Name:          containerName,
 			EmulatorType:  c.Type,
 			Port:          c.Port,
 			ContainerPort: containerPort,
+			BindHost:      gateway.bindHost(),
 			HealthPath:    healthPath,
 			Env:           env,
 			Tag:           c.Tag,
 			ProductName:   productName,
 			Binds:         binds,
-			ExtraPorts:    servicePortRange(),
+			ExtraPorts:    extraPorts,
 		}
 	}
 
@@ -828,6 +845,18 @@ func envHasKey(env []string, key string) bool {
 	return false
 }
 
+// envValue returns the value of the last entry matching key (KEY=value), or "".
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	value := ""
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			value = strings.TrimPrefix(e, prefix)
+		}
+	}
+	return value
+}
+
 func agentEnv(cl caller.Classification) []string {
 	var env []string
 	if cl.AgentIdentity != "" {
@@ -848,10 +877,13 @@ func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {
 	return false
 }
 
+// servicePortRange returns the external service ports LocalStack opens for
+// per-service access (4510-4559). The gateway ports (4566, 443, ...) are
+// published separately from GATEWAY_LISTEN.
 func servicePortRange() []runtime.PortMapping {
 	const start = 4510
 	const end = 4559
-	ports := []runtime.PortMapping{{ContainerPort: "443", HostPort: "443"}}
+	ports := make([]runtime.PortMapping, 0, end-start+1)
 	for p := start; p <= end; p++ {
 		ps := strconv.Itoa(p)
 		ports = append(ports, runtime.PortMapping{ContainerPort: ps, HostPort: ps})

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -342,13 +342,12 @@ func TestEmitPostStartPointers_UnknownEmulator_NoTip(t *testing.T) {
 func TestServicePortRange_ReturnsExpectedPorts(t *testing.T) {
 	ports := servicePortRange()
 
-	require.Len(t, ports, 51)
-	assert.Equal(t, "443", ports[0].ContainerPort)
-	assert.Equal(t, "443", ports[0].HostPort)
-	assert.Equal(t, "4510", ports[1].ContainerPort)
-	assert.Equal(t, "4510", ports[1].HostPort)
-	assert.Equal(t, "4559", ports[50].ContainerPort)
-	assert.Equal(t, "4559", ports[50].HostPort)
+	// 443 is published via GATEWAY_LISTEN, not the service range.
+	require.Len(t, ports, 50)
+	assert.Equal(t, "4510", ports[0].ContainerPort)
+	assert.Equal(t, "4510", ports[0].HostPort)
+	assert.Equal(t, "4559", ports[49].ContainerPort)
+	assert.Equal(t, "4559", ports[49].HostPort)
 }
 
 func TestFilterHostEnv(t *testing.T) {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -231,14 +231,21 @@ func (d *DockerRuntime) PullImage(ctx context.Context, imageName string, progres
 }
 
 func (d *DockerRuntime) Start(ctx context.Context, config ContainerConfig) (string, error) {
-	loopback := netip.MustParseAddr("127.0.0.1")
+	bindHostStr := config.BindHost
+	if bindHostStr == "" {
+		bindHostStr = "127.0.0.1"
+	}
+	bindHost, err := netip.ParseAddr(bindHostStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid bind host %q: %w", bindHostStr, err)
+	}
 
 	containerPort, err := network.ParsePort(config.ContainerPort)
 	if err != nil {
 		return "", fmt.Errorf("invalid container port %q: %w", config.ContainerPort, err)
 	}
 	exposedPorts := network.PortSet{containerPort: struct{}{}}
-	portBindings := network.PortMap{containerPort: []network.PortBinding{{HostIP: loopback, HostPort: config.Port}}}
+	portBindings := network.PortMap{containerPort: []network.PortBinding{{HostIP: bindHost, HostPort: config.Port}}}
 
 	for _, ep := range config.ExtraPorts {
 		proto := ep.Protocol
@@ -250,7 +257,7 @@ func (d *DockerRuntime) Start(ctx context.Context, config ContainerConfig) (stri
 			return "", fmt.Errorf("invalid extra port %q: %w", ep.ContainerPort, err)
 		}
 		exposedPorts[p] = struct{}{}
-		portBindings[p] = []network.PortBinding{{HostIP: loopback, HostPort: ep.HostPort}}
+		portBindings[p] = []network.PortBinding{{HostIP: bindHost, HostPort: ep.HostPort}}
 	}
 
 	var binds []string

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -29,6 +29,7 @@ type ContainerConfig struct {
 	EmulatorType  config.EmulatorType
 	Port          string
 	ContainerPort string // internal port the emulator listens on inside the container (e.g. "4566/tcp")
+	BindHost      string // host IP to bind published ports to (e.g. "127.0.0.1" or "0.0.0.0"); defaults to loopback when empty
 	HealthPath    string
 	Env           []string // e.g., ["KEY=value", "FOO=bar"]
 	Tag           string

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -368,6 +368,52 @@ port = "4567"
 		"LOCALSTACK_HOST must reflect configured host port so LocalStack accepts requests on it")
 }
 
+func TestStartCommandConfiguresGatewayListen(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	// A custom GATEWAY_LISTEN supplied via an [env.*] profile must be honored:
+	// the value reaches the container, the host part exposes ports beyond
+	// loopback, and an extra gateway port (8443) is published on the host.
+	configContent := `
+[[containers]]
+type = "aws"
+tag = "latest"
+port = "4566"
+env = ["expose"]
+
+[env.expose]
+GATEWAY_LISTEN = "0.0.0.0:4566,0.0.0.0:443,0.0.0.0:8443"
+`
+	configFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "--config", configFile, "start")
+	require.NoError(t, err, "lstk start failed: %s", stderr)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
+	require.NoError(t, err, "failed to inspect container")
+
+	envVars := containerEnvToMap(inspect.Container.Config.Env)
+	assert.Equal(t, "0.0.0.0:4566,0.0.0.0:443,0.0.0.0:8443", envVars["GATEWAY_LISTEN"],
+		"configured GATEWAY_LISTEN must be passed to the container")
+
+	for _, p := range []string{"4566/tcp", "443/tcp", "8443/tcp", "4510/tcp"} {
+		bindings := inspect.Container.HostConfig.PortBindings[network.MustParsePort(p)]
+		if assert.NotEmpty(t, bindings, "port %s should be bound", p) {
+			assert.Equal(t, "0.0.0.0", bindings[0].HostIP.String(),
+				"port %s should bind to the host IP from GATEWAY_LISTEN", p)
+		}
+	}
+}
+
 func TestStartCommandSetsUpContainerCorrectly(t *testing.T) {
 	requireDocker(t)
 	_ = env.Require(t, env.AuthToken)


### PR DESCRIPTION
`GATEWAY_LISTEN` used to be hardcoded, and published ports were always bound to 127.0.0.1, so LocalStack could never be reached from outside the host (e.g. an EC2 or MicroVM sandbox).
This PR makes it configurable.

You can now set GATEWAY_LISTEN through an [env.*] profile:
```
[[containers]]
type = "aws"
env = ["expose"]

[env.expose]
GATEWAY_LISTEN = "0.0.0.0:4566,0.0.0.0:443"
```

The host part of the first address (0.0.0.0 above) controls which host IP all published ports bind to. 
Any extra port you list (e.g. :8443) also gets published. If you don't set anything, behavior is unchanged (:4566,:443, bound to loopback).

Covered by unit tests for the parsing logic and an integration test checking the value reaches the container and ports bind correctly.