### PR TITLE
feat: forward LOCALSTACK_CLIENT_NAME and LOCALSTACK_CLIENT_VERSION to container

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -27,6 +27,7 @@ import (
 	"github.com/localstack/lstk/internal/ports"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/localstack/lstk/internal/telemetry"
+	"github.com/localstack/lstk/internal/version"
 )
 
 const envPersistenceEnabled = "LOCALSTACK_PERSISTENCE=1"
@@ -782,10 +783,12 @@ func envHasKey(env []string, key string) bool {
 }
 
 func agentEnv(cl caller.Classification) []string {
+	var env []string
 	if cl.AgentIdentity != "" {
-		return []string{"AI_AGENT=" + cl.AgentIdentity}
+		env = append(env, "AI_AGENT="+cl.AgentIdentity)
 	}
-	return nil
+	env = append(env, "LOCALSTACK_CLIENT_NAME=lstk", "LOCALSTACK_CLIENT_VERSION="+version.Version())
+	return env
 }
 
 func hasDuplicateContainerTypes(containers []config.ContainerConfig) bool {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 	"github.com/localstack/lstk/internal/telemetry"
+	"github.com/localstack/lstk/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -374,14 +375,19 @@ func TestFilterHostEnv(t *testing.T) {
 }
 
 func TestAgentEnv(t *testing.T) {
-	assert.Equal(t, []string{"AI_AGENT=claude-code"},
+	ver := version.Version()
+	clientVars := []string{"LOCALSTACK_CLIENT_NAME=lstk", "LOCALSTACK_CLIENT_VERSION=" + ver}
+
+	assert.Equal(t, append([]string{"AI_AGENT=claude-code"}, clientVars...),
 		agentEnv(caller.Classification{AgentIdentity: "claude-code"}),
 		"a detected agent is forwarded as AI_AGENT")
-	assert.Nil(t, agentEnv(caller.Classification{Interactive: true}),
-		"a human start forwards no AI_AGENT")
-	assert.Nil(t, agentEnv(caller.Classification{CIIdentity: "github-actions"}),
-		"CI without an agent is carried by the forwarded CI variable, not AI_AGENT")
-	assert.Equal(t, []string{"AI_AGENT=claude-code"},
+	assert.Equal(t, clientVars,
+		agentEnv(caller.Classification{Interactive: true}),
+		"a human start forwards no AI_AGENT but still forwards client vars")
+	assert.Equal(t, clientVars,
+		agentEnv(caller.Classification{CIIdentity: "github-actions"}),
+		"CI without an agent still forwards client vars")
+	assert.Equal(t, append([]string{"AI_AGENT=claude-code"}, clientVars...),
 		agentEnv(caller.Classification{AgentIdentity: "claude-code", CIIdentity: "github-actions"}),
 		"an agent running inside CI still forwards its AI_AGENT identity")
 }


### PR DESCRIPTION
## Summary

- `agentEnv()` now always appends `LOCALSTACK_CLIENT_NAME=lstk` and `LOCALSTACK_CLIENT_VERSION=<version>` to the container environment
- `AI_AGENT` is still only injected when an AI agent environment is detected
- Tests updated to assert the client vars are always present

## Motivation

Follow-up to the session telemetry work in the LocalStack runtime (localstack-pro [#7396](https://github.com/localstack/localstack-pro/pull/7396)) and the matching change in the Python CLI (localstack-cli-standalone [#22](https://github.com/localstack/localstack-cli-standalone/pull/22)).

The analytics reviewer requested that the runtime be able to identify which CLI name and version started the container. Without these env vars, a missing `ai_agent_started` field in session telemetry is ambiguous — it could mean "not started by an agent" or "started by an older CLI that doesn't report this". Passing `LOCALSTACK_CLIENT_NAME` and `LOCALSTACK_CLIENT_VERSION` lets the backend filter by CLI version and answer questions like "what % of sessions were started by an agent in the last 30 days" with confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)