### PR TITLE
fix: preserve persistence setting across `lstk restart`

### DIFF
--- a/internal/container/restart.go
+++ b/internal/container/restart.go
@@ -3,14 +3,37 @@ package container
 import (
 	"context"
 
+	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
 )
 
 func Restart(ctx context.Context, rt runtime.Runtime, sink output.Sink, stopOpts StopOptions, startOpts StartOptions, interactive bool) error {
+	// Persistence is a property of the running instance, not just a per-run flag.
+	// If the caller didn't explicitly request it, carry forward the setting of the
+	// currently running container so `lstk restart` doesn't silently drop persistence.
+	if !startOpts.Persist {
+		startOpts.Persist = runningPersistenceEnabled(ctx, rt, startOpts.Containers)
+	}
+
 	if err := Stop(ctx, rt, sink, startOpts.Containers, stopOpts); err != nil {
 		return err
 	}
 	_, err := Start(ctx, rt, sink, startOpts, interactive)
 	return err
+}
+
+// runningPersistenceEnabled reports whether any of the running containers was
+// started with persistence enabled.
+func runningPersistenceEnabled(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig) bool {
+	for _, c := range containers {
+		name, err := ResolveRunningContainerName(ctx, rt, c)
+		if err != nil || name == "" {
+			continue
+		}
+		if isPersistenceEnabled(ctx, rt, name) {
+			return true
+		}
+	}
+	return false
 }

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -72,6 +72,33 @@ func TestRestartCommandPersistFlagSetsPersistenceEnv(t *testing.T) {
 	assert.Equal(t, "1", envVars["LOCALSTACK_PERSISTENCE"])
 }
 
+func TestRestartCommandPreservesPersistenceWithoutFlag(t *testing.T) {
+	requireDocker(t)
+	_ = env.Require(t, env.AuthToken)
+
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mockServer := createMockLicenseServer(true)
+	defer mockServer.Close()
+
+	ctx := testContext(t)
+	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "start", "--persist")
+	require.NoError(t, err, "lstk start --persist failed: %s", stderr)
+
+	// Restart without --persist should carry the setting forward from the running instance.
+	_, stderr, err = runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL), "restart")
+	require.NoError(t, err, "lstk restart failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	inspect, err := dockerClient.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
+	require.NoError(t, err, "failed to inspect container after restart")
+	require.True(t, inspect.Container.State.Running)
+
+	envVars := containerEnvToMap(inspect.Container.Config.Env)
+	assert.Equal(t, "1", envVars["LOCALSTACK_PERSISTENCE"])
+}
+
 func TestRestartCommandFailsWhenNotRunning(t *testing.T) {
 	requireDocker(t)
 	cleanup()


### PR DESCRIPTION
`lstk restart` recreated the container using only the per-run `--persist` flag. Restarting an instance that was started with `--persist` (without re-passing the flag) silently dropped persistence, so `lstk status` showed "No resources deployed" and looked like data loss.

This treats persistence as a property of the running instance: when the caller doesn't explicitly pass `--persist`, `Restart` now inspects the currently running container and carries its persistence setting forward before stopping it. Explicitly passing `--persist` still works as before. Both the interactive and non-interactive restart paths go through `container.Restart`, so both are covered.

Added an integration test (`TestRestartCommandPreservesPersistenceWithoutFlag`) that starts with `--persist`, restarts without the flag, and asserts `LOCALSTACK_PERSISTENCE=1` is still set — it fails before this change and passes after.