### PR TITLE
feat(snapshot): add inspect command for local snapshots

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -38,6 +38,13 @@ const snapshotShowLong = `Show metadata for a cloud snapshot on the LocalStack p
 
   lstk snapshot show pod:my-baseline    # prints name, created date, size, version, services, and resource counts`
 
+const snapshotInspectLong = `Inspect a local snapshot file, showing its structure and where the bytes go.
+
+This reads the on-disk .snapshot file directly — no running emulator, no platform call, and no authentication. It is the local counterpart to 'snapshot show', which reports metadata for cloud snapshots. Sizes are broken down per service (combining control-plane state and data assets), largest first.
+
+  lstk snapshot inspect ./checkpoint.snapshot   # size breakdown of a local snapshot
+  lstk snapshot inspect ./checkpoint --json      # machine-readable output for scripts and agents`
+
 const snapshotRemoveLong = `Delete a cloud snapshot from the LocalStack platform.
 
 Only cloud snapshots (pod: prefix) can be removed. This operation cannot be undone.
@@ -97,6 +104,7 @@ func newSnapshotCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cob
 	cmd.AddCommand(newSnapshotListCmd(cfg, logger))
 	cmd.AddCommand(newSnapshotRemoveCmd(cfg))
 	cmd.AddCommand(newSnapshotShowCmd(cfg, logger))
+	cmd.AddCommand(newSnapshotInspectCmd(cfg))
 	return cmd
 }
 
@@ -543,6 +551,45 @@ func runSnapshotShow(cfg *env.Env, logger log.Logger) func(*cobra.Command, []str
 		}
 		sink := output.NewPlainSink(os.Stdout)
 		return snapshot.Show(cmd.Context(), client, cfg.AuthToken, ref.Value, sink)
+	}
+}
+
+func newSnapshotInspectCmd(cfg *env.Env) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inspect FILE",
+		Short: "Inspect a local snapshot's structure and size breakdown",
+		Long:  snapshotInspectLong,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runSnapshotInspect(cfg),
+	}
+	cmd.Flags().Bool("json", false, "Output the size breakdown as JSON")
+	return cmd
+}
+
+func runSnapshotInspect(cfg *env.Env) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		jsonOut, err := cmd.Flags().GetBool("json")
+		if err != nil {
+			return err
+		}
+
+		home, _ := os.UserHomeDir()
+		ref, err := snapshot.ParseInspectable(args[0], home)
+		if err != nil {
+			return err
+		}
+
+		if jsonOut {
+			// Machine-output mode: write JSON to stdout, bypassing the event
+			// sink (which renders human output only).
+			return snapshot.InspectJSON(ref.Value, os.Stdout)
+		}
+
+		if isInteractiveMode(cfg) {
+			return ui.RunSnapshotInspect(cmd.Context(), ref.Value)
+		}
+		sink := output.NewPlainSink(os.Stdout)
+		return snapshot.Inspect(ref.Value, sink)
 	}
 }
 

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -135,6 +135,25 @@ type SnapshotShownEvent struct {
 	Resources         []SnapshotResourceLine
 }
 
+// SnapshotServiceSize is the byte usage of one service in a snapshot, combining
+// its control-plane state (api_states/) and data-asset payloads (assets/).
+type SnapshotServiceSize struct {
+	Service      string `json:"service"`
+	Uncompressed int64  `json:"uncompressed_bytes"`
+	Compressed   int64  `json:"compressed_bytes"`
+}
+
+// SnapshotInspectedEvent reports the per-service size breakdown of a local
+// snapshot file for the `snapshot inspect` command. Sizes are tallied per
+// archive entry with no running emulator and no platform call; services are
+// sorted largest-first.
+type SnapshotInspectedEvent struct {
+	Path              string                `json:"path"`
+	TotalUncompressed int64                 `json:"total_uncompressed_bytes"`
+	TotalCompressed   int64                 `json:"total_compressed_bytes"`
+	Services          []SnapshotServiceSize `json:"services"`
+}
+
 type AuthCompleteEvent struct{}
 
 // Event is a sealed marker — only event types in this package implement it,
@@ -155,6 +174,7 @@ func (DeferredEvent) sealedEvent()            {}
 func (SnapshotLoadedEvent) sealedEvent()      {}
 func (PodSnapshotRemovedEvent) sealedEvent()  {}
 func (SnapshotShownEvent) sealedEvent()       {}
+func (SnapshotInspectedEvent) sealedEvent()   {}
 func (ContainerStatusEvent) sealedEvent()     {}
 func (ProgressEvent) sealedEvent()            {}
 func (UserInputRequestEvent) sealedEvent()    {}

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -2,6 +2,8 @@ package output
 
 import (
 	"fmt"
+	"math"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -56,6 +58,8 @@ func FormatEventLine(event Event) (string, bool) {
 		return formatPodSnapshotRemoved(e), true
 	case SnapshotShownEvent:
 		return formatSnapshotShown(e), true
+	case SnapshotInspectedEvent:
+		return formatSnapshotInspected(e), true
 	case AuthCompleteEvent:
 		return "", false
 	default:
@@ -296,6 +300,52 @@ func formatSnapshotShown(e SnapshotShownEvent) string {
 			sb.WriteString(fmt.Sprintf("  %-*s%s", snapshotShowLabelWidth-2, r.Service, strings.Join(parts, ", ")))
 		}
 	}
+	return sb.String()
+}
+
+func formatSnapshotInspected(e SnapshotInspectedEvent) string {
+	pct := func(b int64) string {
+		if e.TotalUncompressed <= 0 {
+			return "0%"
+		}
+		return fmt.Sprintf("%d%%", int64(math.Round(float64(b)*100/float64(e.TotalUncompressed))))
+	}
+
+	type sizeRow struct{ label, size, pct string }
+	var rows []sizeRow
+	for _, s := range e.Services {
+		rows = append(rows, sizeRow{s.Service, formatBytes(s.Uncompressed), pct(s.Uncompressed)})
+	}
+	totalRow := sizeRow{"TOTAL", formatBytes(e.TotalUncompressed), "100%"}
+
+	labelW, sizeW := 0, 0
+	for _, r := range append(append([]sizeRow{}, rows...), totalRow) {
+		if len(r.label) > labelW {
+			labelW = len(r.label)
+		}
+		if len(r.size) > sizeW {
+			sizeW = len(r.size)
+		}
+	}
+
+	line := func(r sizeRow) string {
+		return fmt.Sprintf("%-*s  %*s  %4s", labelW, r.label, sizeW, r.size, r.pct)
+	}
+
+	const indent = "  " // left margin for the whole block
+
+	var sb strings.Builder
+	sb.WriteString(indent + fmt.Sprintf("~ Snapshot analysis for %s", filepath.Base(e.Path)))
+	sb.WriteString("\n")
+	sb.WriteString(indent + "  " + formatBytes(e.TotalUncompressed))
+	for _, r := range rows {
+		sb.WriteString("\n")
+		sb.WriteString(indent + line(r))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(indent + strings.Repeat("─", labelW+2+sizeW+2+4))
+	sb.WriteString("\n")
+	sb.WriteString(indent + line(totalRow))
 	return sb.String()
 }
 

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -460,6 +460,63 @@ func TestFormatSnapshotShown(t *testing.T) {
 	}
 }
 
+func TestFormatSnapshotInspected(t *testing.T) {
+	t.Parallel()
+
+	event := SnapshotInspectedEvent{
+		Path:              "./x.snapshot",
+		TotalUncompressed: 1500,
+		TotalCompressed:   1350,
+		Services: []SnapshotServiceSize{
+			{Service: "s3", Uncompressed: 1200, Compressed: 1100},
+			{Service: "dynamodb", Uncompressed: 200, Compressed: 180},
+			{Service: "iam", Uncompressed: 100, Compressed: 70},
+		},
+	}
+
+	got, ok := FormatEventLine(event)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	lines := strings.Split(got, "\n")
+
+	// The whole block carries a two-space left margin; the size line sits one
+	// level under the title.
+	if want := "  ~ Snapshot analysis for x.snapshot"; lines[0] != want {
+		t.Fatalf("header = %q, want %q", lines[0], want)
+	}
+	if want := "    1.5 KB"; lines[1] != want {
+		t.Fatalf("size line = %q, want %q", lines[1], want)
+	}
+
+	idx := func(substr string) int {
+		for i, l := range lines {
+			if strings.Contains(l, substr) {
+				return i
+			}
+		}
+		return -1
+	}
+
+	// Flat per-service rows, rendered in the order given (largest-first):
+	// s3 > dynamodb > iam, all at the base margin (not nested deeper).
+	s3Idx, dynIdx, iamIdx := idx("s3"), idx("dynamodb"), idx("iam")
+	if s3Idx == -1 || dynIdx == -1 || iamIdx == -1 || s3Idx >= dynIdx || dynIdx >= iamIdx {
+		t.Fatalf("expected s3 > dynamodb > iam in order; got:\n%s", got)
+	}
+	if !strings.HasPrefix(lines[s3Idx], "  s3") || strings.HasPrefix(lines[s3Idx], "    ") {
+		t.Fatalf("expected service rows at the base left margin; got %q", lines[s3Idx])
+	}
+
+	last := lines[len(lines)-1]
+	if !strings.Contains(last, "TOTAL") || !strings.Contains(last, "100%") {
+		t.Fatalf("expected final TOTAL line with 100%%; got %q", last)
+	}
+	if !strings.Contains(got, "─") {
+		t.Fatalf("expected a separator rule; got:\n%s", got)
+	}
+}
+
 func TestFormatBytes(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/snapshot/destination.go
+++ b/internal/snapshot/destination.go
@@ -117,6 +117,18 @@ func ParseShowable(ref, cwd, home string) (Destination, error) {
 	return parseCloudOnly(ref, cwd, home, "show local snapshots")
 }
 
+// ParseInspectable parses a ref for snapshot inspect. Only local file paths are
+// accepted; cloud (pod:) refs are rejected because inspect reads the on-disk
+// archive and never contacts the platform — the inverse of ParseShowable.
+// home is used to expand a leading "~"; pass "" to disable tilde expansion.
+func ParseInspectable(ref, home string) (Destination, error) {
+	lower := strings.ToLower(ref)
+	if strings.HasPrefix(lower, "pod:") || strings.Contains(lower, "://") {
+		return Destination{}, fmt.Errorf("'%s' is a cloud snapshot; 'snapshot inspect' only reads local files. Use 'lstk snapshot show %s' to view cloud snapshot metadata", ref, ref)
+	}
+	return ParseSource(ref, home)
+}
+
 // parseCloudOnly validates that ref is a cloud (pod:) reference, rejecting local
 // file paths with a message naming the unsupported action (e.g. "delete local files").
 func parseCloudOnly(ref, cwd, home, action string) (Destination, error) {

--- a/internal/snapshot/inspect.go
+++ b/internal/snapshot/inspect.go
@@ -1,0 +1,119 @@
+package snapshot
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/localstack/lstk/internal/output"
+)
+
+// ComputeInspect opens a local .snapshot archive (a ZIP) and tallies its byte
+// usage per service, combining control-plane state (api_states/) and data-asset
+// payloads (assets/). It needs no running emulator, platform call, or auth.
+// Services are sorted largest-first by uncompressed size.
+func ComputeInspect(path string) (output.SnapshotInspectedEvent, error) {
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		return output.SnapshotInspectedEvent{}, err
+	}
+	defer func() { _ = r.Close() }()
+
+	type agg struct{ unc, comp int64 }
+	totals := map[string]*agg{}
+	var order []string
+	ev := output.SnapshotInspectedEvent{Path: path}
+
+	for _, f := range r.File {
+		if strings.HasSuffix(f.Name, "/") {
+			continue // directory entry, no payload
+		}
+		unc := int64(f.UncompressedSize64)
+		comp := int64(f.CompressedSize64)
+		ev.TotalUncompressed += unc
+		ev.TotalCompressed += comp
+
+		svc := serviceOf(f.Name)
+		a := totals[svc]
+		if a == nil {
+			a = &agg{}
+			totals[svc] = a
+			order = append(order, svc)
+		}
+		a.unc += unc
+		a.comp += comp
+	}
+
+	ev.Services = make([]output.SnapshotServiceSize, 0, len(order))
+	for _, svc := range order {
+		a := totals[svc]
+		ev.Services = append(ev.Services, output.SnapshotServiceSize{
+			Service:      svc,
+			Uncompressed: a.unc,
+			Compressed:   a.comp,
+		})
+	}
+	sort.SliceStable(ev.Services, func(i, j int) bool {
+		if ev.Services[i].Uncompressed != ev.Services[j].Uncompressed {
+			return ev.Services[i].Uncompressed > ev.Services[j].Uncompressed
+		}
+		return ev.Services[i].Service < ev.Services[j].Service
+	})
+	return ev, nil
+}
+
+// Inspect computes a local snapshot's size breakdown and emits it as a
+// SnapshotInspectedEvent. On a read/parse error it emits a friendly ErrorEvent
+// and returns a silent error.
+func Inspect(path string, sink output.Sink) error {
+	ev, err := ComputeInspect(path)
+	if err != nil {
+		sink.Emit(output.ErrorEvent{
+			Title:   fmt.Sprintf("Could not read snapshot %q", path),
+			Summary: "The file is not a valid snapshot archive.",
+			Actions: []output.ErrorAction{
+				{Label: "Inspect a saved snapshot:", Value: "lstk snapshot inspect ./my-snapshot.snapshot"},
+			},
+		})
+		return output.NewSilentError(fmt.Errorf("inspect snapshot %q: %w", path, err))
+	}
+	sink.Emit(output.DeferredEvent{Inner: ev})
+	return nil
+}
+
+// InspectJSON writes a local snapshot's size breakdown to w as JSON. This is a
+// machine-output mode used by `snapshot inspect --json`; sizes are raw bytes so
+// callers (scripts, agents) can compute their own percentages.
+func InspectJSON(path string, w io.Writer) error {
+	ev, err := ComputeInspect(path)
+	if err != nil {
+		return fmt.Errorf("inspect snapshot %q: %w", path, err)
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(ev)
+}
+
+// serviceOf maps an archive entry path to the AWS service it belongs to. The two
+// known layouts place the service at different depths:
+//
+//	api_states/<account>/<service>/[<region>/]...  -> service
+//	assets/<service>/...                           -> service
+//
+// Services are aggregated across accounts and regions. Anything else (root
+// files, unrecognized layouts) is bucketed under "(other)".
+func serviceOf(name string) string {
+	name = strings.TrimPrefix(name, "./")
+	parts := strings.Split(name, "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "api_states" && parts[2] != "":
+		return parts[2]
+	case len(parts) >= 2 && parts[0] == "assets" && parts[1] != "":
+		return parts[1]
+	default:
+		return "(other)"
+	}
+}

--- a/internal/snapshot/inspect_test.go
+++ b/internal/snapshot/inspect_test.go
@@ -1,0 +1,183 @@
+package snapshot_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/localstack/lstk/internal/snapshot"
+)
+
+// writeSnapshot builds a .snapshot ZIP whose entries are stored (uncompressed)
+// so each entry's compressed and uncompressed sizes equal its byte length.
+func writeSnapshot(t *testing.T, entries map[string]int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.snapshot")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	zw := zip.NewWriter(f)
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Store})
+		if err != nil {
+			t.Fatalf("create header %q: %v", name, err)
+		}
+		if _, err := w.Write(bytes.Repeat([]byte("x"), entries[name])); err != nil {
+			t.Fatalf("write %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return path
+}
+
+func TestComputeInspect(t *testing.T) {
+	t.Parallel()
+
+	path := writeSnapshot(t, map[string]int{
+		"api_states/": 0, // directory entry, must be skipped
+		// api_states/<account>/<service>/<region>/...: service is the 3rd segment,
+		// aggregated across accounts and regions.
+		"api_states/000000000000/s3/us-east-1/store.state.avro":       100,
+		"api_states/949334387222/s3/us-east-1/store.state.avro":       30, // 2nd account, same service
+		"api_states/000000000000/dynamodb/us-east-1/store.state.avro": 50,
+		// assets/<service>/...: service is the 2nd segment.
+		"assets/ecr/layer1":                         1000,
+		"assets/rds/dump.sql":                       400,
+		"assets/dynamodb/000000000000_us-east-1.db": 200,
+		"manifest.json":                             10, // root-level file -> (other)
+	})
+
+	ev, err := snapshot.ComputeInspect(path)
+	if err != nil {
+		t.Fatalf("ComputeInspect: %v", err)
+	}
+
+	if got, want := ev.TotalUncompressed, int64(1790); got != want {
+		t.Fatalf("TotalUncompressed = %d, want %d", got, want)
+	}
+	if got, want := ev.TotalCompressed, int64(1790); got != want {
+		t.Fatalf("TotalCompressed = %d, want %d (stored entries)", got, want)
+	}
+
+	// One flat row per service, combining control-plane state and data assets,
+	// aggregated across accounts/regions, sorted largest-first:
+	//   ecr 1000 (data) > rds 400 (data) > dynamodb 250 (50 state + 200 data) >
+	//   s3 130 (100+30 state, two accounts) > (other) 10 (manifest.json).
+	want := []struct {
+		service string
+		size    int64
+	}{
+		{"ecr", 1000},
+		{"rds", 400},
+		{"dynamodb", 250},
+		{"s3", 130},
+		{"(other)", 10},
+	}
+	if len(ev.Services) != len(want) {
+		t.Fatalf("services = %+v, want %d entries", ev.Services, len(want))
+	}
+	for i, w := range want {
+		if ev.Services[i].Service != w.service || ev.Services[i].Uncompressed != w.size {
+			t.Fatalf("service[%d] = %+v, want %s %d", i, ev.Services[i], w.service, w.size)
+		}
+	}
+	for _, s := range ev.Services {
+		if s.Service == "000000000000" || s.Service == "949334387222" {
+			t.Fatalf("service %q is an account id; services must aggregate across accounts", s.Service)
+		}
+	}
+}
+
+func TestComputeInspectInvalidFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "not-a-zip.snapshot")
+	if err := os.WriteFile(path, []byte("definitely not a zip"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := snapshot.ComputeInspect(path); err == nil {
+		t.Fatal("expected error for a non-zip file, got nil")
+	}
+}
+
+func TestInspectJSON(t *testing.T) {
+	t.Parallel()
+
+	path := writeSnapshot(t, map[string]int{
+		"assets/ecr/layer1": 1000,
+		"api_states/000000000000/s3/us-east-1/store.state.avro": 100,
+	})
+
+	var buf bytes.Buffer
+	if err := snapshot.InspectJSON(path, &buf); err != nil {
+		t.Fatalf("InspectJSON: %v", err)
+	}
+
+	var got struct {
+		TotalUncompressed int64 `json:"total_uncompressed_bytes"`
+		Services          []struct {
+			Service      string `json:"service"`
+			Uncompressed int64  `json:"uncompressed_bytes"`
+		} `json:"services"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal JSON: %v\n%s", err, buf.String())
+	}
+	if got.TotalUncompressed != 1100 {
+		t.Fatalf("total = %d, want 1100", got.TotalUncompressed)
+	}
+	if len(got.Services) == 0 || got.Services[0].Service != "ecr" || got.Services[0].Uncompressed != 1000 {
+		t.Fatalf("services = %+v, want ecr (1000) first", got.Services)
+	}
+}
+
+func TestParseInspectable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects pod refs pointing at show", func(t *testing.T) {
+		t.Parallel()
+		if _, err := snapshot.ParseInspectable("pod:my-baseline", ""); err == nil {
+			t.Fatal("expected error for pod: ref")
+		}
+	})
+
+	t.Run("rejects remote schemes", func(t *testing.T) {
+		t.Parallel()
+		if _, err := snapshot.ParseInspectable("s3://bucket/key", ""); err == nil {
+			t.Fatal("expected error for s3:// ref")
+		}
+	})
+
+	t.Run("accepts an existing local file", func(t *testing.T) {
+		t.Parallel()
+		path := writeSnapshot(t, map[string]int{"assets/s3/obj1": 1})
+		dest, err := snapshot.ParseInspectable(path, "")
+		if err != nil {
+			t.Fatalf("ParseInspectable: %v", err)
+		}
+		if dest.Kind != snapshot.KindLocal || dest.Value != path {
+			t.Fatalf("dest = %+v, want KindLocal %q", dest, path)
+		}
+	})
+
+	t.Run("errors on a missing local file", func(t *testing.T) {
+		t.Parallel()
+		if _, err := snapshot.ParseInspectable(filepath.Join(t.TempDir(), "nope.snapshot"), ""); err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -590,6 +590,21 @@ func styleDeferredEvent(inner output.Event) (string, bool) {
 			}
 		case output.MessageEvent:
 			parts[i] = styles.Highlight.Render(p)
+		case output.SnapshotInspectedEvent:
+			// The "~ Snapshot analysis for <file>" title uses the light Nimbo
+			// purple (same as the "~ N snapshots" list summary), with a blank
+			// line above and below the two-line header. The size line, the
+			// separator rule, and the TOTAL footer are subdued gray; per-service
+			// rows stay neutral.
+			trimmed := strings.TrimLeft(p, " ")
+			switch {
+			case i == 0:
+				parts[i] = "\n" + styles.Highlight.Render(p)
+			case i == 1:
+				parts[i] = styles.SecondaryMessage.Render(p) + "\n"
+			case strings.HasPrefix(trimmed, "─"), strings.HasPrefix(trimmed, "TOTAL"):
+				parts[i] = styles.SecondaryMessage.Render(p)
+			}
 		}
 	}
 	styled := strings.Join(parts, "\n")

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -377,6 +377,69 @@ func TestAppDeferredEventStyling(t *testing.T) {
 	}
 }
 
+func TestAppDeferredSnapshotInspectStyling(t *testing.T) {
+	// Mutates the global lipgloss color profile, so it must not run in parallel.
+	original := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(original) })
+
+	app := NewApp("dev", "", "", nil)
+	event := output.SnapshotInspectedEvent{
+		Path:              "./x.snapshot",
+		TotalUncompressed: 1500,
+		TotalCompressed:   1350,
+		Services: []output.SnapshotServiceSize{
+			{Service: "s3", Uncompressed: 1300, Compressed: 1200},
+			{Service: "iam", Uncompressed: 200, Compressed: 150},
+		},
+	}
+
+	model, _ := app.Update(output.DeferredEvent{Inner: event})
+	app = model.(App)
+	out := app.DeferredOutput()
+
+	rendered, ok := output.FormatEventLine(event)
+	if !ok {
+		t.Fatal("expected inspect event to format")
+	}
+	var title, size, service, total, sep string
+	for i, line := range strings.Split(rendered, "\n") {
+		trimmed := strings.TrimLeft(line, " ")
+		switch {
+		case i == 0:
+			title = line
+		case i == 1:
+			size = line
+		case strings.HasPrefix(trimmed, "s3"):
+			service = line
+		case strings.HasPrefix(trimmed, "TOTAL"):
+			total = line
+		case strings.HasPrefix(trimmed, "─"):
+			sep = line
+		}
+	}
+
+	// The title uses the light purple (same as the list summary) with a blank
+	// line above it.
+	if want := "\n" + styles.Highlight.Render(title); !strings.Contains(out, want) {
+		t.Fatalf("expected light-purple title %q in deferred output, got: %q", want, out)
+	}
+	// The size line is gray with a blank line below it.
+	if want := styles.SecondaryMessage.Render(size) + "\n"; !strings.Contains(out, want) {
+		t.Fatalf("expected gray size line %q with blank line below in deferred output, got: %q", want, out)
+	}
+	// The separator rule and the TOTAL footer are subdued gray.
+	for _, want := range []string{sep, total} {
+		if !strings.Contains(out, styles.SecondaryMessage.Render(want)) {
+			t.Fatalf("expected gray row %q in deferred output, got: %q", want, out)
+		}
+	}
+	// Per-service rows stay neutral (neither purple nor gray).
+	if strings.Contains(out, styles.Highlight.Render(service)) || strings.Contains(out, styles.SecondaryMessage.Render(service)) {
+		t.Fatal("per-service rows should not be colored")
+	}
+}
+
 func TestAppDeferredNoteStyledLikeStatus(t *testing.T) {
 	// Mutates the global lipgloss color profile, so it must not run in parallel.
 	original := lipgloss.ColorProfile()

--- a/internal/ui/run_snapshot_inspect.go
+++ b/internal/ui/run_snapshot_inspect.go
@@ -1,0 +1,14 @@
+package ui
+
+import (
+	"context"
+
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/snapshot"
+)
+
+func RunSnapshotInspect(parentCtx context.Context, path string) error {
+	return runWithTUI(parentCtx, withoutHeader(), func(ctx context.Context, sink output.Sink) error {
+		return snapshot.Inspect(path, sink)
+	})
+}

--- a/test/integration/snapshot_inspect_test.go
+++ b/test/integration/snapshot_inspect_test.go
@@ -1,0 +1,124 @@
+package integration_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeInspectFixture builds a .snapshot ZIP (stored entries, so compressed and
+// uncompressed sizes equal the byte lengths) for the inspect command to read.
+func writeInspectFixture(t *testing.T, path string, entries map[string]int) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	zw := zip.NewWriter(f)
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Store})
+		require.NoError(t, err)
+		_, err = w.Write(bytes.Repeat([]byte("x"), entries[name]))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+}
+
+func TestSnapshotInspectLocalFileWithoutDocker(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demo.snapshot")
+	writeInspectFixture(t, path, map[string]int{
+		"api_states/000000000000/s3/us-east-1/store.state.avro":       100,
+		"api_states/000000000000/dynamodb/us-east-1/store.state.avro": 50,
+		"assets/ecr/layer1": 4000,
+		"assets/s3/obj1":    1000,
+	})
+
+	stdout, stderr, err := runLstk(t, testContext(t), dir,
+		testEnvWithHome(t.TempDir(), ""),
+		"--non-interactive", "snapshot", "inspect", path,
+	)
+	require.NoError(t, err, "lstk snapshot inspect failed: %s", stderr)
+
+	// Flat per-service breakdown, sorted largest-first; each service combines
+	// its control-plane state and data assets (s3 = 100 state + 1000 data).
+	assert.Contains(t, stdout, "ecr")
+	assert.Contains(t, stdout, "s3")
+	assert.Contains(t, stdout, "dynamodb")
+	assert.Less(t, strings.Index(stdout, "ecr"), strings.Index(stdout, "s3"),
+		"ecr (4000) should sort before s3 (1100)")
+	assert.Contains(t, stdout, "TOTAL")
+	assert.Contains(t, stdout, "100%")
+}
+
+func TestSnapshotInspectJSONWithoutDocker(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demo.snapshot")
+	writeInspectFixture(t, path, map[string]int{
+		"assets/ecr/layer1": 4000,
+		"api_states/000000000000/s3/us-east-1/store.state.avro": 100,
+	})
+
+	stdout, stderr, err := runLstk(t, testContext(t), dir,
+		testEnvWithHome(t.TempDir(), ""),
+		"--non-interactive", "snapshot", "inspect", path, "--json",
+	)
+	require.NoError(t, err, "lstk snapshot inspect --json failed: %s", stderr)
+
+	var got struct {
+		Path              string `json:"path"`
+		TotalUncompressed int64  `json:"total_uncompressed_bytes"`
+		Services          []struct {
+			Service      string `json:"service"`
+			Uncompressed int64  `json:"uncompressed_bytes"`
+		} `json:"services"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got), "stdout was not valid JSON:\n%s", stdout)
+	assert.Equal(t, int64(4100), got.TotalUncompressed)
+	require.NotEmpty(t, got.Services)
+	assert.Equal(t, "ecr", got.Services[0].Service)
+}
+
+func TestSnapshotInspectRejectsPodRef(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, err := runLstk(t, testContext(t), t.TempDir(),
+		testEnvWithHome(t.TempDir(), ""),
+		"--non-interactive", "snapshot", "inspect", "pod:my-baseline",
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, strings.ToLower(stderr), "local")
+	assert.Contains(t, stderr, "snapshot show")
+}
+
+func TestSnapshotInspectInvalidFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.snapshot")
+	require.NoError(t, os.WriteFile(path, []byte("not a zip"), 0o600))
+
+	stdout, _, err := runLstk(t, testContext(t), dir,
+		testEnvWithHome(t.TempDir(), ""),
+		"--non-interactive", "snapshot", "inspect", path,
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stdout, "not a valid snapshot archive")
+}


### PR DESCRIPTION
## What

Adds `lstk snapshot inspect <file>` — an offline, per-service size breakdown of a local `.snapshot` archive.

No running emulator, no platform call, no auth.

```
$ lstk snapshot inspect ./checkpoint.snapshot

  ~ Snapshot analysis for checkpoint.snapshot
    4.5 MB
  s3                 3.9 MB   87%
  dynamodb         172.4 KB    4%
  iam              107.4 KB    2%
  cloudfront        78.4 KB    2%
  ...
  ───────────────────────────────
  TOTAL              4.5 MB  100%
```

## Why

`snapshot show` is cloud-only and reports resource *counts* plus one aggregate size — it can't answer "what's eating the space in my local snapshot?". `inspect` reads the archive directly and attributes bytes per service, combining each service's control-plane state (`api_states/`) and data payloads (`assets/`), aggregated across accounts and regions.

## Details

- Opens the `.snapshot` ZIP with stdlib `archive/zip` and tallies sizes per entry — no emulator, platform, or auth.
- One row per service, sorted largest-first, with % of total and a grand total.
- `--json` emits the same data (raw bytes) for scripts and agents.
- Cloud (`pod:`) refs are rejected and pointed at `snapshot show`.
- New typed `SnapshotInspectedEvent` with plain + TUI rendering parity. Unit + integration tests; no Docker required.

## Note

This branch rebases the work from #331 onto the latest `main` (picking up the `PullSkippableEvent`/ESC-to-skip changes from #341). The cherry-pick applied cleanly with no textual conflicts; both new events coexist in the sink/format switch lists.