### PR TITLE
test: disable Azure CLI telemetry in integration test env

### DIFF
--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -23,7 +23,18 @@ const (
 	OtelEndpoint       Key = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	AWSAccessKeyID     Key = "AWS_ACCESS_KEY_ID"
 	AWSSecretAccessKey Key = "AWS_SECRET_ACCESS_KEY"
+	// AzureCollectTelemetry controls the Azure CLI's usage telemetry.
+	AzureCollectTelemetry Key = "AZURE_CORE_COLLECT_TELEMETRY"
 )
+
+// DisableAzureTelemetry is the value used to turn the Azure CLI's telemetry off in
+// every test environment. When telemetry is on, `az` spawns a detached background
+// uploader process that outlives the `az` invocation and keeps a handle on its
+// working directory / HOME — which for tests is a t.TempDir(). On Windows that open
+// handle makes t.TempDir()'s RemoveAll cleanup fail ("being used by another process").
+// Disabling it here prevents that flake and stops tests emitting to Azure's telemetry
+// backend, mirroring UnreachableAnalyticsEndpoint for our own analytics.
+const DisableAzureTelemetry = "false"
 
 // UnreachableAnalyticsEndpoint is a closed local port used as the default
 // analytics endpoint for every test environment, so the binary under test never
@@ -49,11 +60,17 @@ func Require(t testing.TB, key Key) string {
 type Environ []string
 
 func Without(keys ...Key) Environ {
-	return Environ(os.Environ()).With(AnalyticsEndpoint, UnreachableAnalyticsEndpoint).Without(keys...)
+	return Environ(os.Environ()).
+		With(AnalyticsEndpoint, UnreachableAnalyticsEndpoint).
+		With(AzureCollectTelemetry, DisableAzureTelemetry).
+		Without(keys...)
 }
 
 func With(key Key, value string) Environ {
-	return Environ(os.Environ()).With(AnalyticsEndpoint, UnreachableAnalyticsEndpoint).With(key, value)
+	return Environ(os.Environ()).
+		With(AnalyticsEndpoint, UnreachableAnalyticsEndpoint).
+		With(AzureCollectTelemetry, DisableAzureTelemetry).
+		With(key, value)
 }
 
 func (e Environ) Without(keys ...Key) Environ {

--- a/test/integration/env/env.go
+++ b/test/integration/env/env.go
@@ -23,18 +23,11 @@ const (
 	OtelEndpoint       Key = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	AWSAccessKeyID     Key = "AWS_ACCESS_KEY_ID"
 	AWSSecretAccessKey Key = "AWS_SECRET_ACCESS_KEY"
-	// AzureCollectTelemetry controls the Azure CLI's usage telemetry.
+	// AzureCollectTelemetry controls the Azure CLI's usage telemetry. Defaulted to
+	// "false" in every test environment: an enabled `az` spawns a background uploader
+	// that keeps a handle on the test's temp dir, breaking t.TempDir() cleanup on Windows.
 	AzureCollectTelemetry Key = "AZURE_CORE_COLLECT_TELEMETRY"
 )
-
-// DisableAzureTelemetry is the value used to turn the Azure CLI's telemetry off in
-// every test environment. When telemetry is on, `az` spawns a detached background
-// uploader process that outlives the `az` invocation and keeps a handle on its
-// working directory / HOME — which for tests is a t.TempDir(). On Windows that open
-// handle makes t.TempDir()'s RemoveAll cleanup fail ("being used by another process").
-// Disabling it here prevents that flake and stops tests emitting to Azure's telemetry
-// backend, mirroring UnreachableAnalyticsEndpoint for our own analytics.
-const DisableAzureTelemetry = "false"
 
 // UnreachableAnalyticsEndpoint is a closed local port used as the default
 // analytics endpoint for every test environment, so the binary under test never
@@ -62,14 +55,14 @@ type Environ []string
 func Without(keys ...Key) Environ {
 	return Environ(os.Environ()).
 		With(AnalyticsEndpoint, UnreachableAnalyticsEndpoint).
-		With(AzureCollectTelemetry, DisableAzureTelemetry).
+		With(AzureCollectTelemetry, "false").
 		Without(keys...)
 }
 
 func With(key Key, value string) Environ {
 	return Environ(os.Environ()).
 		With(AnalyticsEndpoint, UnreachableAnalyticsEndpoint).
-		With(AzureCollectTelemetry, DisableAzureTelemetry).
+		With(AzureCollectTelemetry, "false").
 		With(key, value)
 }
 

--- a/test/integration/env/env_test.go
+++ b/test/integration/env/env_test.go
@@ -39,6 +39,36 @@ func TestBaseEnvDefaultsAnalyticsEndpointToUnreachable(t *testing.T) {
 	}
 }
 
+// Guards against the Azure CLI's background telemetry uploader lingering with an
+// open handle to a test's temp dir (HOME / working dir), which on Windows makes
+// t.TempDir()'s RemoveAll cleanup fail with "being used by another process". The
+// base env helpers must disable Azure telemetry unless a test explicitly overrides it.
+func TestBaseEnvDisablesAzureTelemetry(t *testing.T) {
+	cases := map[string]Environ{
+		"With":    With("SOME_VAR", "value"),
+		"Without": Without(AuthToken),
+	}
+	for name, e := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, found := resolve(e, AzureCollectTelemetry)
+			if !found {
+				t.Fatalf("%s did not set %s", name, AzureCollectTelemetry)
+			}
+			if got != DisableAzureTelemetry {
+				t.Fatalf("%s Azure telemetry = %q, want %q", name, got, DisableAzureTelemetry)
+			}
+		})
+	}
+}
+
+func TestExplicitAzureTelemetryOverridesDefault(t *testing.T) {
+	e := With(AzureCollectTelemetry, "true")
+	got, _ := resolve(e, AzureCollectTelemetry)
+	if got != "true" {
+		t.Fatalf("Azure telemetry = %q, want %q (explicit override must win over default)", got, "true")
+	}
+}
+
 func TestExplicitAnalyticsEndpointOverridesDefault(t *testing.T) {
 	const mock = "http://127.0.0.1:54321"
 	e := With(APIEndpoint, "http://example").With(AnalyticsEndpoint, mock)

--- a/test/integration/env/env_test.go
+++ b/test/integration/env/env_test.go
@@ -54,8 +54,8 @@ func TestBaseEnvDisablesAzureTelemetry(t *testing.T) {
 			if !found {
 				t.Fatalf("%s did not set %s", name, AzureCollectTelemetry)
 			}
-			if got != DisableAzureTelemetry {
-				t.Fatalf("%s Azure telemetry = %q, want %q", name, got, DisableAzureTelemetry)
+			if got != "false" {
+				t.Fatalf("%s Azure telemetry = %q, want %q", name, got, "false")
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

`main` is red on the **Windows** integration-test job. `TestAzStopInterceptionNoOpWhenNotIntercepting` passes its assertions but then fails during `t.TempDir()` auto-cleanup:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat
C:\Users\RUNNER~1\AppData\Local\Temp\TestAzStopInterceptionNoOpWhenNotIntercepting3716188435\001:
The process cannot access the file because it is being used by another process.
```

(Introduced by #357 — failing run: https://github.com/localstack/lstk/actions/runs/28601912948)

## Root cause

The test runs real `az` commands (via `lstk az stop-interception` and a raw `az cloud show`). When Azure CLI telemetry is enabled, `az` spawns a **detached background telemetry-upload process** that outlives the `az` invocation and keeps an open handle on the test's temp working directory (`t.TempDir()`, dir `\001`). When Go's `t.TempDir()` cleanup runs `RemoveAll` while that uploader is still alive, Windows refuses to delete a directory another process holds open. Unix removes directories with open handles, which is why only the Windows job flakes.

The codebase already disables this telemetry (`core.collect_telemetry=false`) for the *isolated* Azure config dir in `setLstkPrefs`, but `stop-interception` deliberately targets the *global* `~/.azure` and doesn't touch telemetry prefs — so under test it runs with telemetry on.

## Fix

Default `AZURE_CORE_COLLECT_TELEMETRY=false` in every test environment (`env.With` / `env.Without`), mirroring the existing `UnreachableAnalyticsEndpoint` guard that already keeps tests off our own analytics backend. It propagates to every `az` invocation (through `runLstk` → `az` and `runAzRaw`), so no uploader spawns → no lingering handle → cleanup succeeds. Explicit per-test overrides still win (exec dedups to the last value).

## Tests

Added two unit tests on the env helper, matching the existing analytics-endpoint pair:
- `TestBaseEnvDisablesAzureTelemetry` — the default is set by both constructors.
- `TestExplicitAzureTelemetryOverridesDefault` — an explicit value wins.

## Verification note

The failure is Windows-only (`RemoveAll` with an open handle is a no-op on Unix), so it can't be reproduced on macOS/Linux dev machines or the Linux CI shards. The new unit tests guard the mechanism (telemetry disabled in the base env); the Windows CI job on this PR is the end-to-end confirmation.

Fixes PRO-362.
