### PR TITLE
fix: guidance for port-conflict errors on 443 / service ports

### DIFF
--- a/internal/container/port_conflict_test.go
+++ b/internal/container/port_conflict_test.go
@@ -326,3 +326,14 @@ func TestPortConflictActions(t *testing.T) {
 	assert.Empty(t, portConflictActions(runtime.FlavorDockerDesktop, runtime.FlavorUnknown, "443"))
 	assert.Empty(t, portConflictActions(runtime.FlavorRancherDesktop, runtime.FlavorUnknown, "8443"))
 }
+
+func TestEmitPortInUseErrorOmitsConfigForFixedPort(t *testing.T) {
+	sink := &recordingSink{}
+
+	emitPortInUseError(sink, "4510", false)
+
+	errs := sink.errorEvents()
+	require.Len(t, errs, 1)
+	require.Len(t, errs[0].Actions, 1)
+	assert.Equal(t, "Identify the process using it:", errs[0].Actions[0].Label)
+}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -908,11 +908,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			}
 		}
 		if conflictPort, err := ports.CheckAvailable(requiredSpecs...); err != nil {
-			sink.Emit(output.ErrorEvent{
-				Title:   fmt.Sprintf("Port %s is already in use", conflictPort),
-				Summary: "LocalStack requires this port. Free it before starting.",
-				Actions: portConflictActions(rt.Flavor(), runtime.DetectInstalledFlavor(), conflictPort),
-			})
+			emitPortInUseError(sink, conflictPort, portConflictActions(rt.Flavor(), runtime.DetectInstalledFlavor(), conflictPort)...)
 			tel.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
 				EventType: telemetry.LifecycleStartError,
 				Emulator:  c.EmulatorType,
@@ -1155,15 +1151,18 @@ func portConflictActions(activeFlavor, installedFlavor, port string) []output.Er
 	return nil
 }
 
-func emitPortInUseError(sink output.Sink, port string) {
-	actions := []output.ErrorAction{}
+func emitPortInUseError(sink output.Sink, port string, extraActions ...output.ErrorAction) {
+	actions := []output.ErrorAction{
+		{Label: "Identify the process using it:", Value: ports.InspectCommand(port)},
+	}
+	actions = append(actions, extraActions...)
 	configPath, pathErr := config.ConfigFilePath()
 	if pathErr == nil {
-		actions = append(actions, output.ErrorAction{Label: "Use another port in the configuration:", Value: configPath})
+		actions = append(actions, output.ErrorAction{Label: "Or use another port in the configuration:", Value: configPath})
 	}
 	sink.Emit(output.ErrorEvent{
 		Title:   fmt.Sprintf("Port %s already in use", port),
-		Summary: "Free the port or configure a different one.",
+		Summary: "Another process is already using this port.",
 		Actions: actions,
 	})
 }

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -884,7 +884,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 				emitLocalStackAlreadyRunningWarning(sink, c.Port, info.Version, c.Tag)
 				continue
 			}
-			emitPortInUseError(sink, c.Port)
+			emitPortInUseError(sink, c.Port, true)
 			tel.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
 				EventType: telemetry.LifecycleStartError,
 				Emulator:  c.EmulatorType,
@@ -908,7 +908,7 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			}
 		}
 		if conflictPort, err := ports.CheckAvailable(requiredSpecs...); err != nil {
-			emitPortInUseError(sink, conflictPort, portConflictActions(rt.Flavor(), runtime.DetectInstalledFlavor(), conflictPort)...)
+			emitPortInUseError(sink, conflictPort, !inServicePortRange(conflictPort), portConflictActions(rt.Flavor(), runtime.DetectInstalledFlavor(), conflictPort)...)
 			tel.EmitEmulatorLifecycleEvent(ctx, telemetry.LifecycleEvent{
 				EventType: telemetry.LifecycleStartError,
 				Emulator:  c.EmulatorType,
@@ -1151,14 +1151,16 @@ func portConflictActions(activeFlavor, installedFlavor, port string) []output.Er
 	return nil
 }
 
-func emitPortInUseError(sink output.Sink, port string, extraActions ...output.ErrorAction) {
+func emitPortInUseError(sink output.Sink, port string, configurable bool, extraActions ...output.ErrorAction) {
 	actions := []output.ErrorAction{
 		{Label: "Identify the process using it:", Value: ports.InspectCommand(port)},
 	}
 	actions = append(actions, extraActions...)
-	configPath, pathErr := config.ConfigFilePath()
-	if pathErr == nil {
-		actions = append(actions, output.ErrorAction{Label: "Or use another port in the configuration:", Value: configPath})
+	if configurable {
+		configPath, pathErr := config.ConfigFilePath()
+		if pathErr == nil {
+			actions = append(actions, output.ErrorAction{Label: "Or use another port in the configuration:", Value: configPath})
+		}
 	}
 	sink.Emit(output.ErrorEvent{
 		Title:   fmt.Sprintf("Port %s already in use", port),

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -895,12 +895,12 @@ func selectContainersToStart(ctx context.Context, rt runtime.Runtime, sink outpu
 			return nil, output.NewSilentError(err)
 		}
 
-		// Check extra ports required by this emulator (443 for HTTPS, 4510-4559 for
+		// Check extra ports used by this emulator (443 for HTTPS, 4510-4559 for
 		// the service port range). Required ports are singletons: if one is taken,
-		// another LocalStack instance is likely running and we cannot start a new
-		// one. Optional ports (443 from the default GATEWAY_LISTEN) are commonly
-		// squatted by other software — e.g. Rancher Desktop's Traefik ingress — so
-		// a busy one is dropped with a warning instead of blocking the start.
+		// another process is already using it and we cannot start a new instance.
+		// Optional ports (443 from the default GATEWAY_LISTEN) are commonly squatted
+		// by other software — e.g. Rancher Desktop's Traefik ingress — so a busy one
+		// is dropped with a warning instead of blocking the start.
 		var requiredSpecs []string
 		for _, ep := range c.ExtraPorts {
 			if !ep.Optional {

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -3,6 +3,7 @@ package ports
 import (
 	"fmt"
 	"net"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -50,4 +51,18 @@ func dial(port string) error {
 	}
 	_ = conn.Close()
 	return fmt.Errorf("port %s already in use", port)
+}
+
+// InspectCommand returns a shell command the user can run to identify the
+// process currently listening on the given port, tailored to the host OS.
+// On Windows it uses netstat; elsewhere (macOS, Linux, *BSD) it uses lsof.
+func InspectCommand(port string) string {
+	return inspectCommand(runtime.GOOS, port)
+}
+
+func inspectCommand(goos, port string) string {
+	if goos == "windows" {
+		return fmt.Sprintf("netstat -ano | findstr :%s", port)
+	}
+	return fmt.Sprintf("lsof -i tcp:%s", port)
 }

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -64,5 +64,11 @@ func inspectCommand(goos, port string) string {
 	if goos == "windows" {
 		return fmt.Sprintf("netstat -ano | findstr :%s", port)
 	}
+	// Privileged ports (<1024, e.g. 443) are typically held by root-owned
+	// processes such as sshd; lsof only reports other users' sockets under
+	// sudo, so suggest sudo there to avoid an empty result.
+	if p, err := strconv.Atoi(port); err == nil && p < 1024 {
+		return fmt.Sprintf("sudo lsof -i tcp:%s", port)
+	}
 	return fmt.Sprintf("lsof -i tcp:%s", port)
 }

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -62,13 +62,13 @@ func InspectCommand(port string) string {
 
 func inspectCommand(goos, port string) string {
 	if goos == "windows" {
-		return fmt.Sprintf("netstat -ano | findstr :%s", port)
+		return fmt.Sprintf("netstat -ano -p tcp | findstr LISTENING | findstr :%s", port)
 	}
 	// Privileged ports (<1024, e.g. 443) are typically held by root-owned
 	// processes such as sshd; lsof only reports other users' sockets under
 	// sudo, so suggest sudo there to avoid an empty result.
 	if p, err := strconv.Atoi(port); err == nil && p < 1024 {
-		return fmt.Sprintf("sudo lsof -i tcp:%s", port)
+		return fmt.Sprintf("sudo lsof -nP -iTCP:%s -sTCP:LISTEN", port)
 	}
-	return fmt.Sprintf("lsof -i tcp:%s", port)
+	return fmt.Sprintf("lsof -nP -iTCP:%s -sTCP:LISTEN", port)
 }

--- a/internal/ports/ports_test.go
+++ b/internal/ports/ports_test.go
@@ -73,6 +73,24 @@ func TestCheckAvailable(t *testing.T) {
 	}
 }
 
+func TestInspectCommand(t *testing.T) {
+	tests := []struct {
+		goos string
+		port string
+		want string
+	}{
+		{"darwin", "443", "lsof -i tcp:443"},
+		{"linux", "4566", "lsof -i tcp:4566"},
+		{"windows", "443", "netstat -ano | findstr :443"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.goos, func(t *testing.T) {
+			assert.Equal(t, tt.want, inspectCommand(tt.goos, tt.port))
+		})
+	}
+}
+
 // bindPort opens a listener on a random port and keeps it open for the test duration.
 func bindPort(t *testing.T) string {
 	t.Helper()

--- a/internal/ports/ports_test.go
+++ b/internal/ports/ports_test.go
@@ -79,8 +79,10 @@ func TestInspectCommand(t *testing.T) {
 		port string
 		want string
 	}{
-		{"darwin", "443", "lsof -i tcp:443"},
-		{"linux", "4566", "lsof -i tcp:4566"},
+		{"darwin", "443", "sudo lsof -i tcp:443"}, // privileged port -> sudo
+		{"linux", "443", "sudo lsof -i tcp:443"},  // privileged port -> sudo
+		{"linux", "4566", "lsof -i tcp:4566"},     // non-privileged -> plain
+		{"darwin", "4510", "lsof -i tcp:4510"},    // service range -> plain
 		{"windows", "443", "netstat -ano | findstr :443"},
 	}
 
@@ -109,4 +111,3 @@ func freePort(t *testing.T) string {
 	require.NoError(t, ln.Close())
 	return port
 }
-

--- a/internal/ports/ports_test.go
+++ b/internal/ports/ports_test.go
@@ -79,11 +79,11 @@ func TestInspectCommand(t *testing.T) {
 		port string
 		want string
 	}{
-		{"darwin", "443", "sudo lsof -i tcp:443"}, // privileged port -> sudo
-		{"linux", "443", "sudo lsof -i tcp:443"},  // privileged port -> sudo
-		{"linux", "4566", "lsof -i tcp:4566"},     // non-privileged -> plain
-		{"darwin", "4510", "lsof -i tcp:4510"},    // service range -> plain
-		{"windows", "443", "netstat -ano | findstr :443"},
+		{"darwin", "443", "sudo lsof -nP -iTCP:443 -sTCP:LISTEN"},
+		{"linux", "443", "sudo lsof -nP -iTCP:443 -sTCP:LISTEN"},
+		{"linux", "4566", "lsof -nP -iTCP:4566 -sTCP:LISTEN"},
+		{"darwin", "4510", "lsof -nP -iTCP:4510 -sTCP:LISTEN"},
+		{"windows", "443", "netstat -ano -p tcp | findstr LISTENING | findstr :443"},
 	}
 
 	for _, tt := range tests {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -344,10 +344,50 @@ func TestStartCommandFailsWhenPortInUse(t *testing.T) {
 	require.Error(t, err, "expected lstk start to fail when port is in use")
 	requireExitCode(t, 1, err)
 	assert.Contains(t, stdout, "Port 4566 already in use")
-	assert.Contains(t, stdout, "Free the port or configure a different one.")
-	assert.Contains(t, stdout, "Use another port in the configuration:")
+	assert.Contains(t, stdout, "Another process is already using this port")
+	assert.Contains(t, stdout, "Identify the process using it:")
+	assert.Contains(t, stdout, inspectCommandFor("4566"))
+	assert.Contains(t, stdout, "Or use another port in the configuration:")
 
 	// Both lstk_lifecycle (start_error) and lstk_command events should be emitted.
+	byName := collectTelemetryByName(t, events, 2)
+	assert.Contains(t, byName, "lstk_lifecycle")
+	assert.Contains(t, byName, "lstk_command")
+}
+
+// inspectCommandFor mirrors ports.InspectCommand for the current OS so the
+// port-conflict tests can assert the diagnostic hint without importing the
+// internal package.
+func inspectCommandFor(port string) string {
+	if runtime.GOOS == "windows" {
+		return "netstat -ano | findstr :" + port
+	}
+	return "lsof -i tcp:" + port
+}
+
+// TestStartCommandFailsWhenExtraPortInUse covers the extra-port branch (443 and
+// the 4510-4559 service range) of the pre-flight check. 443 is privileged and
+// cannot be bound by a non-root test process, so we occupy a service-range port
+// (4510) with the primary edge port (4566) left free. This exercises the same
+// branch and asserts it now surfaces the same guidance as the 4566 conflict.
+func TestStartCommandFailsWhenExtraPortInUse(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ln, err := net.Listen("tcp", ":4510")
+	require.NoError(t, err, "failed to bind port 4510 for test")
+	defer func() { _ = ln.Close() }()
+
+	analyticsSrv, events := mockAnalyticsServer(t)
+	stdout, _, err := runLstk(t, testContext(t), "", env.With(env.AuthToken, "fake-token").With(env.AnalyticsEndpoint, analyticsSrv.URL), "start")
+	require.Error(t, err, "expected lstk start to fail when an extra port is in use")
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stdout, "Port 4510 already in use")
+	assert.Contains(t, stdout, "Another process is already using this port")
+	assert.Contains(t, stdout, "Identify the process using it:")
+	assert.Contains(t, stdout, inspectCommandFor("4510"))
+
 	byName := collectTelemetryByName(t, events, 2)
 	assert.Contains(t, byName, "lstk_lifecycle")
 	assert.Contains(t, byName, "lstk_command")

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -360,12 +360,12 @@ func TestStartCommandFailsWhenPortInUse(t *testing.T) {
 // internal package.
 func inspectCommandFor(port string) string {
 	if runtime.GOOS == "windows" {
-		return "netstat -ano | findstr :" + port
+		return "netstat -ano -p tcp | findstr LISTENING | findstr :" + port
 	}
 	if p, err := strconv.Atoi(port); err == nil && p < 1024 {
-		return "sudo lsof -i tcp:" + port
+		return "sudo lsof -nP -iTCP:" + port + " -sTCP:LISTEN"
 	}
-	return "lsof -i tcp:" + port
+	return "lsof -nP -iTCP:" + port + " -sTCP:LISTEN"
 }
 
 // TestStartCommandFailsWhenExtraPortInUse covers the required extra-port branch
@@ -388,6 +388,7 @@ func TestStartCommandFailsWhenExtraPortInUse(t *testing.T) {
 	assert.Contains(t, stdout, "Another process is already using this port")
 	assert.Contains(t, stdout, "Identify the process using it:")
 	assert.Contains(t, stdout, inspectCommandFor("4510"))
+	assert.NotContains(t, stdout, "use another port in the configuration")
 
 	byName := collectTelemetryByName(t, events, 2)
 	assert.Contains(t, byName, "lstk_lifecycle")

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -362,14 +362,15 @@ func inspectCommandFor(port string) string {
 	if runtime.GOOS == "windows" {
 		return "netstat -ano | findstr :" + port
 	}
+	if p, err := strconv.Atoi(port); err == nil && p < 1024 {
+		return "sudo lsof -i tcp:" + port
+	}
 	return "lsof -i tcp:" + port
 }
 
-// TestStartCommandFailsWhenExtraPortInUse covers the extra-port branch (443 and
-// the 4510-4559 service range) of the pre-flight check. 443 is privileged and
-// cannot be bound by a non-root test process, so we occupy a service-range port
-// (4510) with the primary edge port (4566) left free. This exercises the same
-// branch and asserts it now surfaces the same guidance as the 4566 conflict.
+// TestStartCommandFailsWhenExtraPortInUse covers the required extra-port branch
+// of the pre-flight check. It occupies service-range port 4510 with the primary
+// edge port left free and asserts the same guidance as the 4566 conflict.
 func TestStartCommandFailsWhenExtraPortInUse(t *testing.T) {
 	requireDocker(t)
 	cleanup()


### PR DESCRIPTION
## What

`lstk start` runs a pre-flight port check before starting the emulator. The **primary** edge port (4566) conflict path gave the user a next step (reconfigure the port); the **extra-ports** path (443 and the 4510–4559 service range) emitted a bare title + summary with **no actions at all**. Bart hit this on 443 (held by an unrelated `sshd`) and had no way to tell what was holding the port.

This routes both branches through the same `emitPortInUseError` helper so they render consistent guidance, and adds an OS-aware "identify the process" hint.

### Before (extra-port conflict)
```
✗ Port 443 is already in use
  LocalStack requires this port. Free it before starting.
```

### After (both 4566 and 443 / service ports)
```
✗ Port 443 already in use
  Another process is already using this port.
  ==> Identify the process using it: sudo lsof -i tcp:443
  ==> Or use another port in the configuration: …/config.toml
```

## Details

- `internal/container/start.go` — extra-ports branch now calls `emitPortInUseError` instead of emitting a bare `ErrorEvent`; the helper gained an "Identify the process using it" action.
- `internal/ports/ports.go` — new `InspectCommand(port)`: `lsof -i tcp:<port>` on macOS/Linux, `netstat -ano | findstr :<port>` on Windows. Privileged ports (<1024, e.g. 443) suggest **`sudo lsof`**, because `lsof` only lists other users' sockets under sudo — without it the hint returns nothing for a root-owned holder like `sshd` on 443, i.e. the reported case.
- Neutral summary ("Another process is already using this port.") — deliberately does **not** claim it's a stray LocalStack instance (that case is already handled upstream by `FindRunningByImage`, and Bart's was `sshd`).
- Tests: unit test for `inspectCommand` across OS/privileged-port branches; integration test `TestStartCommandFailsWhenExtraPortInUse` (binds 4510, since 443 is privileged and unbindable in a test).

Design choice, consistent with peers: this **suggests a command** rather than naming the process inline. Docker keeps its hot-path error generic and points to `netstat` in docs; ddev put process-naming in a separate opt-in `port-diagnose` command. Inline process-naming was intentionally kept out.

## Scope / follow-ups

This closes the concrete defect (a guidance-less extra-ports error). It does **not** yet cover the case where the pre-flight `localhost` dial passes but Docker fails to bind at container start — that raw `Bind for …: port is already allocated` still surfaces with no guidance and is mis-bucketed as `start_failed`. That path (which a privileged-port / non-loopback-bindHost / TOCTOU conflict routes into) is the harder half and is tracked as a follow-up; **this PR's green check does not mean that half is done.**

Refs PRO-363.
