### PR TITLE
fix: handle long log/NDJSON lines without "token too long" (DEVX-750)

### DIFF
--- a/internal/container/logs.go
+++ b/internal/container/logs.go
@@ -11,15 +11,19 @@ import (
 	"github.com/localstack/lstk/internal/runtime"
 )
 
-// maxLogLineBytes caps how much of a single log line lstk buffers before
-// emitting it. Anything beyond this is discarded (with a marker) rather than
-// held in memory, so a pathologically long line (e.g. a CDK CloudFormation
-// template dumped as one line in a request body) can neither exhaust memory nor
-// overflow a fixed scanner buffer.
-const maxLogLineBytes = 256 * 1024
+// maxLogLineBytes caps how much of a single log line lstk emits before
+// truncating it (with a marker). Anything beyond this is drained and discarded
+// rather than held in memory, so a pathologically long line (e.g. a CDK
+// CloudFormation template or a binary asset upload dumped as one line in a
+// request body) can neither exhaust memory nor overflow a fixed scanner buffer.
+// Kept deliberately small so a single oversized line stays readable in a
+// terminal instead of flooding the scrollback with hundreds of KB.
+const maxLogLineBytes = 8 * 1024
 
-// logReaderBufferSize is the bufio.Reader buffer size; larger than the default
-// so each ReadSlice call returns bigger chunks when draining a long line.
+// logReaderBufferSize is the bufio.Reader buffer size, larger than the default
+// so each ReadSlice call returns bigger chunks — this speeds up draining the
+// discarded tail of a very long line (independent of maxLogLineBytes, which
+// bounds only what is kept and emitted).
 const logReaderBufferSize = 64 * 1024
 
 func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []config.ContainerConfig, follow bool, verbose bool) error {

--- a/internal/container/logs.go
+++ b/internal/container/logs.go
@@ -11,6 +11,17 @@ import (
 	"github.com/localstack/lstk/internal/runtime"
 )
 
+// maxLogLineBytes caps how much of a single log line lstk buffers before
+// emitting it. Anything beyond this is discarded (with a marker) rather than
+// held in memory, so a pathologically long line (e.g. a CDK CloudFormation
+// template dumped as one line in a request body) can neither exhaust memory nor
+// overflow a fixed scanner buffer.
+const maxLogLineBytes = 256 * 1024
+
+// logReaderBufferSize is the bufio.Reader buffer size; larger than the default
+// so each ReadSlice call returns bigger chunks when draining a long line.
+const logReaderBufferSize = 64 * 1024
+
 func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []config.ContainerConfig, follow bool, verbose bool) error {
 	if err := rt.IsHealthy(ctx); err != nil {
 		rt.EmitUnhealthyError(sink, err)
@@ -32,17 +43,68 @@ func Logs(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers 
 		errCh <- err
 	}()
 
-	scanner := bufio.NewScanner(pr)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !verbose && shouldFilter(line) {
-			continue
+	reader := bufio.NewReaderSize(pr, logReaderBufferSize)
+	for {
+		line, truncated, ok, err := readBoundedLine(reader, maxLogLineBytes)
+		if ok {
+			if verbose || !shouldFilter(line) {
+				level, _ := parseLogLine(line)
+				if truncated > 0 {
+					line = fmt.Sprintf("%s … (%d more bytes truncated)", line, truncated)
+				}
+				sink.Emit(output.LogLineEvent{Source: output.LogSourceEmulator, Line: line, Level: level})
+			}
 		}
-		level, _ := parseLogLine(line)
-		sink.Emit(output.LogLineEvent{Source: output.LogSourceEmulator, Line: line, Level: level})
-	}
-	if err := scanner.Err(); err != nil && ctx.Err() == nil {
-		return err
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			if ctx.Err() != nil {
+				break
+			}
+			return err
+		}
 	}
 	return <-errCh
+}
+
+// readBoundedLine reads one newline-delimited line from r, buffering at most max
+// bytes of content. Bytes beyond max are drained and discarded (counted in
+// truncated) so memory stays bounded regardless of line length. The returned
+// line has its trailing newline (and any preceding carriage return) stripped.
+// ok is false only when nothing was read (e.g. clean EOF at a line boundary).
+func readBoundedLine(r *bufio.Reader, max int) (line string, truncated int, ok bool, err error) {
+	var buf []byte
+	for {
+		var chunk []byte
+		chunk, err = r.ReadSlice('\n')
+		if err == nil {
+			chunk = trimEOL(chunk) // only the terminating chunk carries the newline
+		}
+		ok = ok || len(chunk) > 0 || err == nil
+		if room := max - len(buf); room > 0 {
+			if len(chunk) <= room {
+				buf = append(buf, chunk...)
+			} else {
+				buf = append(buf, chunk[:room]...)
+				truncated += len(chunk) - room
+			}
+		} else {
+			truncated += len(chunk)
+		}
+		if err == bufio.ErrBufferFull {
+			continue // line longer than the reader buffer; keep draining to the newline
+		}
+		return string(buf), truncated, ok, err
+	}
+}
+
+func trimEOL(b []byte) []byte {
+	if n := len(b); n > 0 && b[n-1] == '\n' {
+		b = b[:n-1]
+		if n = len(b); n > 0 && b[n-1] == '\r' {
+			b = b[:n-1]
+		}
+	}
+	return b
 }

--- a/internal/container/logs_test.go
+++ b/internal/container/logs_test.go
@@ -1,0 +1,99 @@
+package container
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// captureSink records every LogLineEvent it receives.
+type captureSink struct {
+	mu    sync.Mutex
+	lines []output.LogLineEvent
+}
+
+func (s *captureSink) Emit(e output.Event) {
+	if le, ok := e.(output.LogLineEvent); ok {
+		s.mu.Lock()
+		s.lines = append(s.lines, le)
+		s.mu.Unlock()
+	}
+}
+
+func runLogs(t *testing.T, content string, verbose bool) *captureSink {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsHealthy(gomock.Any()).Return(nil)
+	mockRT.EXPECT().
+		StreamLogs(gomock.Any(), "localstack-aws", gomock.Any(), false).
+		DoAndReturn(func(_ context.Context, _ string, out io.Writer, _ bool) error {
+			_, err := io.WriteString(out, content)
+			return err
+		})
+
+	sink := &captureSink{}
+	containers := []config.ContainerConfig{{Type: config.EmulatorAWS}}
+	err := Logs(context.Background(), mockRT, sink, containers, false, verbose)
+	require.NoError(t, err)
+	return sink
+}
+
+// A single log line longer than maxLogLineBytes must not error (regression for
+// "bufio.Scanner: token too long") and must be emitted truncated, not buffered
+// whole in memory.
+func TestLogs_LongLineIsTruncatedNotErrored(t *testing.T) {
+	t.Parallel()
+	huge := strings.Repeat("x", maxLogLineBytes+50_000)
+	line := "2026-07-07T10:05:11.240  INFO --- [  MainThread] l.foo : " + huge + "\n"
+
+	sink := runLogs(t, line, false)
+
+	require.Len(t, sink.lines, 1)
+	emitted := sink.lines[0].Line
+	assert.LessOrEqual(t, len(emitted), maxLogLineBytes+64, "emitted line must be bounded near the cap")
+	assert.Contains(t, emitted, "truncated")
+	assert.Equal(t, output.LogLevelInfo, sink.lines[0].Level, "level still parsed from the prefix")
+}
+
+func TestLogs_NormalLinesPassThrough(t *testing.T) {
+	t.Parallel()
+	content := "2026-07-07T10:05:11.240  INFO --- [  MainThread] l.foo : hello\n" +
+		"2026-07-07T10:05:12.240  WARN --- [  MainThread] l.bar : world\n"
+
+	sink := runLogs(t, content, false)
+
+	require.Len(t, sink.lines, 2)
+	assert.Equal(t, "2026-07-07T10:05:11.240  INFO --- [  MainThread] l.foo : hello", sink.lines[0].Line)
+	assert.Equal(t, output.LogLevelInfo, sink.lines[0].Level)
+	assert.Equal(t, output.LogLevelWarn, sink.lines[1].Level)
+}
+
+// A final line without a trailing newline must still be emitted.
+func TestLogs_NoTrailingNewline(t *testing.T) {
+	t.Parallel()
+	sink := runLogs(t, "2026-07-07T10:05:11.240  INFO --- [  MainThread] l.foo : tail", false)
+
+	require.Len(t, sink.lines, 1)
+	assert.Equal(t, "2026-07-07T10:05:11.240  INFO --- [  MainThread] l.foo : tail", sink.lines[0].Line)
+}
+
+func TestLogs_FilteredLinesDropped(t *testing.T) {
+	t.Parallel()
+	content := "2026-07-07T10:05:11.240  INFO --- [  MainThread] localstack.request.http : noise\n" +
+		"2026-07-07T10:05:12.240  INFO --- [  MainThread] l.foo : keep\n"
+
+	sink := runLogs(t, content, false)
+
+	require.Len(t, sink.lines, 1)
+	assert.Contains(t, sink.lines[0].Line, "keep")
+}

--- a/internal/emulator/aws/client.go
+++ b/internal/emulator/aws/client.go
@@ -93,14 +93,14 @@ func (c *Client) FetchResources(ctx context.Context, host string) ([]emulator.Re
 	// Each line of the NDJSON stream is a JSON object mapping an AWS resource type
 	// (e.g. "AWS::S3::Bucket") to a list of resource entries.
 	var rows []emulator.Resource
-	scanner := bufio.NewScanner(resp.Body)
-	buf := make([]byte, 1024*1024)
-	scanner.Buffer(buf, 1024*1024)
-
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
+	nd := newNDJSONReader(resp.Body)
+	for {
+		line, ok, err := nd.next()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read resources stream: %w", err)
+		}
+		if !ok {
+			break
 		}
 
 		var chunk map[string][]instanceResource
@@ -124,10 +124,6 @@ func (c *Client) FetchResources(ctx context.Context, host string) ([]emulator.Re
 				})
 			}
 		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to read resources stream: %w", err)
 	}
 
 	sort.Slice(rows, func(i, j int) bool {
@@ -208,13 +204,14 @@ func (c *Client) ImportState(ctx context.Context, host string, src io.Reader, st
 		return fmt.Errorf("LocalStack returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
-	scanner := bufio.NewScanner(resp.Body)
-	buf := make([]byte, 1024*1024)
-	scanner.Buffer(buf, 1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
+	nd := newNDJSONReader(resp.Body)
+	for {
+		line, ok, err := nd.next()
+		if err != nil {
+			return err
+		}
+		if !ok {
+			break
 		}
 		var event struct {
 			Service string `json:"service"`
@@ -231,7 +228,37 @@ func (c *Client) ImportState(ctx context.Context, host string, src io.Reader, st
 			return fmt.Errorf("load failed for service %s: %s", event.Service, event.Message)
 		}
 	}
-	return scanner.Err()
+	return nil
+}
+
+// ndjsonReader reads newline-delimited JSON streams without the fixed
+// token-size limit of bufio.Scanner (which errors with "token too long" on any
+// single line larger than its buffer). Lines grow to whatever size the stream
+// produces, so a large JSON object on one line is read whole and can be parsed.
+type ndjsonReader struct {
+	r *bufio.Reader
+}
+
+func newNDJSONReader(r io.Reader) *ndjsonReader {
+	return &ndjsonReader{r: bufio.NewReader(r)}
+}
+
+// next returns the next non-empty, trimmed line. ok is false at end of stream.
+// A read error other than io.EOF is returned in err.
+func (n *ndjsonReader) next() (line string, ok bool, err error) {
+	for {
+		s, readErr := n.r.ReadString('\n')
+		s = strings.TrimSpace(s)
+		if s != "" {
+			return s, true, nil
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return "", false, nil
+			}
+			return "", false, readErr
+		}
+	}
 }
 
 // isInvalidSnapshotFileMsg reports whether an emulator error message indicates

--- a/internal/emulator/aws/longline_test.go
+++ b/internal/emulator/aws/longline_test.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hugeValue is larger than the 1 MB scanner buffer these NDJSON parsers used, so
+// a single JSON line containing it triggers "bufio.Scanner: token too long".
+var hugeValue = strings.Repeat("x", 2*1024*1024)
+
+func TestFetchResources_HandlesLongLine(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintf(w, `{"AWS::S3::Bucket": [{"region_name": "us-east-1", "account_id": "000000000000", "id": %q}]}`+"\n", hugeValue)
+	}))
+	defer server.Close()
+
+	c := NewClient()
+	rows, err := c.FetchResources(context.Background(), server.Listener.Addr().String())
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, hugeValue, rows[0].Name)
+}
+
+func TestImportState_HandlesLongLine(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"service": "s3", "status": "ok", "message": %q}`+"\n", hugeValue)
+	}))
+	defer server.Close()
+
+	c := NewClient()
+	err := c.ImportState(context.Background(), server.Listener.Addr().String(), bytes.NewReader([]byte("{}")), "")
+	require.NoError(t, err)
+}
+
+func TestSavePodSnapshot_HandlesLongLine(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"event": "progress", "status": "ok", "message": %q}`+"\n", hugeValue)
+		_, _ = fmt.Fprintln(w, `{"event": "completion", "status": "ok", "info": {"version": 1, "services": ["s3"], "size": 10}}`)
+	}))
+	defer server.Close()
+
+	c := NewClient()
+	res, err := c.SavePodSnapshot(context.Background(), server.Listener.Addr().String(), "my-pod", "the-token")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Version)
+}
+
+func TestLoadPodSnapshot_HandlesLongLine(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"event": "service", "service": %q, "status": "ok"}`+"\n", hugeValue)
+		_, _ = fmt.Fprintln(w, `{"event": "completion", "status": "ok"}`)
+	}))
+	defer server.Close()
+
+	c := NewClient()
+	services, err := c.LoadPodSnapshot(context.Background(), server.Listener.Addr().String(), "my-pod", "the-token", "")
+	require.NoError(t, err)
+	require.Len(t, services, 1)
+	assert.Equal(t, hugeValue, services[0])
+}

--- a/internal/emulator/aws/remote.go
+++ b/internal/emulator/aws/remote.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -186,13 +185,14 @@ func (c *Client) doPodSave(ctx context.Context, host, podName, authToken string,
 
 	// The response is a newline-delimited JSON stream. We scan until we find a
 	// completion event and surface any server-side error as a Go error.
-	scanner := bufio.NewScanner(resp.Body)
-	buf := make([]byte, 1024*1024)
-	scanner.Buffer(buf, 1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
+	nd := newNDJSONReader(resp.Body)
+	for {
+		line, ok, err := nd.next()
+		if err != nil {
+			return snapshot.PodSaveResult{}, fmt.Errorf("reading response: %w", err)
+		}
+		if !ok {
+			break
 		}
 		var event struct {
 			Event   string `json:"event"`
@@ -217,9 +217,6 @@ func (c *Client) doPodSave(ctx context.Context, host, podName, authToken string,
 				Size:     event.Info.Size,
 			}, nil
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return snapshot.PodSaveResult{}, fmt.Errorf("reading response: %w", err)
 	}
 	return snapshot.PodSaveResult{}, fmt.Errorf("pod save: server closed stream without a completion event")
 }
@@ -254,13 +251,14 @@ func (c *Client) doPodLoad(ctx context.Context, host, podName, authToken, strate
 	}
 
 	var services []string
-	scanner := bufio.NewScanner(resp.Body)
-	buf := make([]byte, 1024*1024)
-	scanner.Buffer(buf, 1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
+	nd := newNDJSONReader(resp.Body)
+	for {
+		line, ok, err := nd.next()
+		if err != nil {
+			return nil, fmt.Errorf("reading response: %w", err)
+		}
+		if !ok {
+			break
 		}
 		var event struct {
 			Event   string `json:"event"`
@@ -294,9 +292,6 @@ func (c *Client) doPodLoad(ctx context.Context, host, podName, authToken, strate
 			}
 			return services, nil
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
 	}
 	return services, nil
 }


### PR DESCRIPTION
## What

`lstk logs` crashed with `bufio.Scanner: token too long` whenever the emulator emitted a log line larger than `bufio.Scanner`'s 64 KB default buffer — e.g. a CDK CloudFormation template dumped as one line inside an HTTP request body:

```
✗ bufio.Scanner: token too long
```

This fixes that, plus four sibling NDJSON parsers with the same latent bug.

## Changes

**`internal/container/logs.go`** — replaced `bufio.Scanner` with a bounded `bufio.Reader` loop (`readBoundedLine`). It keeps at most **8 KB** of a line, then drains and discards the rest with a ` … (N more bytes truncated)` marker — small enough to stay readable in a terminal, while the reader buffer (64 KB) only paces how fast the discarded tail is drained. Memory is hard-bounded regardless of line length, so a pathologically long line can neither exhaust memory (the naive `ReadString` fix) nor overflow a fixed buffer (the Scanner bug). Safe because line classification (`shouldFilter`/`parseLogLine`) only inspects the line prefix.

**`internal/emulator/aws/{client.go,remote.go}`** — the same bug affected four NDJSON stream parsers (`FetchResources`, `ImportState`, `doPodSave`, `doPodLoad`), which capped `Scanner` at 1 MB. These parse JSON per line, so **truncation is not viable** (a partial line won't unmarshal). Added a shared `ndjsonReader` (`bufio.Reader` + `ReadString('\n')`) that grows to the full line, and swapped all four sites onto it — preserving empty-line skipping and per-site unmarshal tolerance.

## Tests

TDD red→green. New tests fail on the old code with `token too long` and pass after:
- `internal/container/logs_test.go` — long line truncated (not errored), plus pass-through / no-trailing-newline / filtering.
- `internal/emulator/aws/longline_test.go` — >1 MB single line across all four NDJSON sites.

## Reviewer notes

- Truncation applies **only** to `lstk logs` (display stream). The NDJSON parsers read whole lines by necessity (JSON parse); no hard cap there, but those are emulator control-plane streams, not arbitrary user payloads.
- 8 KB emit cap for logs is a judgment call: enough to show a line's prefix + a taste of its payload, then the truncation marker. Started at 256 KB (old Scanner ceiling) but lowered it after live testing showed multiple ~MB binary-blob lines flooding terminal scrollback. Easy to make configurable if preferred.

Linear: DEVX-750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Before / After (live emulator, same instance)

Reproduced against a running LocalStack with a CDK deploy that logs a large template + binary asset upload as single lines. `bin/lstk` = this branch; `lstk-old` = same binary built from `main`'s `logs.go`.
<details>
<summary>
    Before — stream dies on the first oversized line; only 52 lines make it out; non-zero exit.
</summary>

```log
$ lstk logs

LocalStack version: 2026.6.1
LocalStack build date: 2026-07-01
LocalStack build git hash: 4dcdcb5da

2026-07-07T09:58:20.017  INFO --- [  MainThread] l.p.c.b.licensingv2        : Successfully activated cached license ccd3fed7-f523-4abe-a2cd-2539c92a0617:enterprise from /var/lib/localstack/cache/license.json 🔑✅
2026-07-07T09:58:21.990  INFO --- [  MainThread] l.p.c.extensions.plugins   : loaded 0 extensions
2026-07-07T09:58:23.812  INFO --- [ady_monitor)] localstack.appinspector    : Running database migrations for AppInspector...
2026-07-07T09:58:23.827  INFO --- [ady_monitor)] localstack.appinspector    : AppInspector database migrations completed successfully.
2026-07-07T09:58:24.278  INFO --- [ady_monitor)] localstack.appinspector    : AppInspector enabled via APP_INSPECTOR
Ready.
2026-07-07T10:05:04.942  INFO --- [et.reactor-1] localstack.request.aws     : AWS sts.GetCallerIdentity => 200
2026-07-07T10:05:05.120  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStacks => 400 (ValidationError)
2026-07-07T10:05:05.147  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStacks => 400 (ValidationError)
2026-07-07T10:05:05.179  INFO --- [et.reactor-2] localstack.request.aws     : AWS cloudformation.DescribeStacks => 400 (ValidationError)
2026-07-07T10:05:05.660  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.CreateChangeSet => 200
2026-07-07T10:05:05.670  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeChangeSet => 200
2026-07-07T10:05:05.679  INFO --- [et.reactor-2] localstack.request.aws     : AWS cloudformation.ExecuteChangeSet => 200
2026-07-07T10:05:05.685  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStacks => 200
2026-07-07T10:05:05.884  INFO --- [et.reactor-1] l.p.c.s.e.provider_basic   : {"InfoCode": "InternalInfoEvents at process_rules", "InfoMessage": "No rules attached to event_bus: default"}
2026-07-07T10:05:05.992  INFO --- [et.reactor-3] l.p.c.services.iam.plugins : Configured IAM provider to use Advance Policy Simulator
2026-07-07T10:05:06.018  INFO --- [et.reactor-2] l.p.c.s.ecr.registry       : Starting ECR Docker registry (ECR_ENDPOINT_STRATEGY=domain) for region us-east-1 in account 000000000000
2026-07-07T10:05:07.690  INFO --- [et.reactor-3] localstack.request.aws     : AWS cloudformation.DescribeStackEvents => 200
2026-07-07T10:05:09.722  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStackEvents => 200
2026-07-07T10:05:10.698  INFO --- [et.reactor-2] localstack.request.aws     : AWS cloudformation.DescribeStacks => 200
2026-07-07T10:05:10.709  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStackEvents => 200
2026-07-07T10:05:10.979  INFO --- [et.reactor-3] localstack.request.aws     : AWS sts.AssumeRole => 200
2026-07-07T10:05:10.982  INFO --- [et.reactor-1] localstack.request.aws     : AWS sts.AssumeRole => 200
2026-07-07T10:05:11.123  INFO --- [et.reactor-1] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.124  INFO --- [et.reactor-1] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.125  INFO --- [et.reactor-2] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.125  INFO --- [et.reactor-2] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.132  INFO --- [et.reactor-2] localstack.request.aws     : AWS sts.AssumeRole => 200
2026-07-07T10:05:11.155  INFO --- [et.reactor-1] localstack.request.aws     : AWS ssm.GetParameter => 200
2026-07-07T10:05:11.173  INFO --- [et.reactor-2] localstack.request.aws     : AWS cloudformation.DescribeStacks => 200
2026-07-07T10:05:11.177  INFO --- [et.reactor-4] localstack.request.aws     : AWS cloudformation.DescribeStacks => 200
2026-07-07T10:05:11.191  INFO --- [et.reactor-3] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.191  INFO --- [et.reactor-3] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.195  INFO --- [et.reactor-4] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.195  INFO --- [et.reactor-4] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.205  INFO --- [et.reactor-2] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.206  INFO --- [et.reactor-2] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.207  INFO --- [et.reactor-5] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.207  INFO --- [et.reactor-5] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.219  INFO --- [et.reactor-3] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.219  INFO --- [et.reactor-3] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.219  INFO --- [et.reactor-2] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.219  INFO --- [et.reactor-2] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.227 ERROR --- [et.reactor-2] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 0), invalid XML received:
b'{\n "Resources": {\n  "EventStream271A91DB": {\n   "Type": "AWS::Kinesis::Stream",\n   "Properties": {\n    "RetentionPeriodHours": 24,\n    "StreamEncryption": {\n     "Fn::If": [\n      "AwsCdkKinesisEncryptedStreamsUnsupportedRegions",\n      {\n       "Ref": "AWS::NoValue"\n      },\n      {\n       "EncryptionType": "KMS",\n       "KeyId": "alias/aws/kinesis"\n      }\n     ]\n    },\n    "StreamModeDetails": {\n     "StreamMode": "ON_DEMAND"\n    }\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventStream/Resource"\n   }\n  },\n  "EventTable3F3CD4B2": {\n   "Type": "AWS::DynamoDB::Table",\n   "Properties": {\n    "AttributeDefinitions": [\n     {\n      "AttributeName": "eventId",\n      "AttributeType": "S"\n     }\n    ],\n    "BillingMode": "PAY_PER_REQUEST",\n    "KeySchema": [\n     {\n      "AttributeName": "eventId",\n      "KeyType": "HASH"\n     }\n    ]\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventTable/Resource"\n   }\n  },\n  "ProcessorServiceRole5039D372": {\n   "Type": "AWS::IAM::Role",\n   "Properties": {\n    "AssumeRolePolicyDocument": {\n     "Statement": [\n      {\n       "Action": "sts:AssumeRole",\n       "Effect": "Allow",\n       "Principal": {\n        "Service": "lambda.amazonaws.com"\n       }\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "ManagedPolicyArns": [\n     {\n      "Fn::Join": [\n       "",\n       [\n        "arn:",\n        {\n         "Ref": "AWS::Partition"\n        },\n        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"\n       ]\n      ]\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/Resource"\n   }\n  },\n  "ProcessorServiceRoleDefaultPolicyDA9D4DBA": {\n   "Type": "AWS::IAM::Policy",\n   "Properties": {\n    "PolicyDocument": {\n     "Statement": [\n      {\n       "Action": [\n        "kinesis:DescribeStreamSummary",\n        "kinesis:GetRecords",\n        "kinesis:GetShardIterator",\n        "kinesis:ListShards",\n        "kinesis:SubscribeToShard",\n        "kinesis:DescribeStream",\n        "kinesis:ListStreams",\n        "kinesis:DescribeStreamConsumer"\n       ],\n       "Effect": "Allow",\n       "Resource": {\n        "Fn::GetAtt": [\n         "EventStream271A91DB",\n         "Arn"\n        ]\n       }\n      },\n      {\n       "Action": [\n        "dynamodb:BatchWriteItem",\n        "dynamodb:PutItem",\n        "dynamodb:UpdateItem",\n        "dynamodb:DeleteItem",\n        "dynamodb:DescribeTable"\n       ],\n       "Effect": "Allow",\n       "Resource": [\n        {\n         "Fn::GetAtt": [\n          "EventTable3F3CD4B2",\n          "Arn"\n         ]\n        }\n       ]\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "PolicyName": "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "Roles": [\n     {\n      "Ref": "ProcessorServiceRole5039D372"\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/DefaultPolicy/Resource"\n   }\n  },\n  "Processor60228016": {\n   "Type": "AWS::Lambda::Function",\n   "Properties": {\n    "Code": {\n     "S3Bucket": {\n      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"\n     },\n     "S3Key": "ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5.zip"\n    },\n    "Environment": {\n     "Variables": {\n      "TABLE_NAME": {\n       "Ref": "EventTable3F3CD4B2"\n      }\n     }\n    },\n    "Handler": "index.handler",\n    "Role": {\n     "Fn::GetAtt": [\n      "ProcessorServiceRole5039D372",\n      "Arn"\n     ]\n    },\n    "Runtime": "nodejs22.x"\n   },\n   "DependsOn": [\n    "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "ProcessorServiceRole5039D372"\n   ],\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/Resource",\n    "aws:asset:path": "asset.ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5",\n    "aws:asset:is-bundled": true,\n    "aws:asset:property": "Code"\n   }\n  },\n  "ProcessorKinesisEventSourcetest347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE378F1CA5": {\n   "Type": "AWS::Lambda::EventSourceMapping",\n   "Properties": {\n    "BatchSize": 10,\n    "EventSourceArn": {\n     "Fn::GetAtt": [\n      "EventStream271A91DB",\n      "Arn"\n     ]\n    },\n    "FilterCriteria": {\n     "Filters": [\n      {\n       "Pattern": "{\\"data\\":{\\"payload\\":{\\"type\\":[\\"purchase\\"]}}}"\n      }\n     ]\n    },\n    "FunctionName": {\n     "Ref": "Processor60228016"\n    },\n    "StartingPosition": "TRIM_HORIZON"\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/KinesisEventSource:test347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE/Resource"\n   }\n  },\n  "CDKMetadata": {\n   "Type": "AWS::CDK::Metadata",\n   "Properties": {\n    "Analytics": "v2:deflate64:H4sIAAAAAAAA/2VQu27DMAz8lu4y2zoZujZGu7UN7OwGLTGB/KAMU0oQGPr3QnLQpdMd73BHkCWU+zd4ecKbFNoMxWg7WBuPelB4k3YdLJNYSdpCOKnqzBuLytwZJ2c6WE/YjZSsTKIaceoMtuwM9QLfGT4Da28dK4sTrLXbAhmPbrT6nsaNRSW7FkXIC7wnULKDQ9AD+QMKPephrc781/pxJfaNC4umL5xny5fU91+NMemVY2NzribJtsqLGo+XR/Qn+Dn4qNIR0MvztdzDa/pUL9YWS2BvJ4J6w1+9mSJwRgEAAA=="\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/CDKMetadata/Default"\n   },\n   "Condition": "CDKMetadataAvailable"\n  }\n },\n "Conditions": {\n  "AwsCdkKinesisEncryptedStreamsUnsupportedRegions": {\n   "Fn::Or": [\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-north-1"\n     ]\n    },\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-northwest-1"\n     ]\n    }\n   ]\n  },\n  "CDKMetadataAvailable": {\n   "Fn::Or": [\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "af-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-3"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-3"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-4"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-west-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-north-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-northwest-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-central-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-north-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-south-2"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-west-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-west-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-west-3"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "il-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "me-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "me-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "sa-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "us-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "us-east-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "us-west-1"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "us-west-2"\n     ]\n    }\n   ]\n  }\n },\n "Outputs": {\n  "StreamName": {\n   "Value": {\n    "Ref": "EventStream271A91DB"\n   }\n  },\n  "TableName": {\n   "Value": {\n    "Ref": "EventTable3F3CD4B2"\n   }\n  }\n },\n "Parameters": {\n  "BootstrapVersion": {\n   "Type": "AWS::SSM::Parameter::Value<String>",\n   "Default": "/cdk-bootstrap/hnb659fds/version",\n   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"\n  }\n },\n "Rules": {\n  "CheckBootstrapVersion": {\n   "Assertions": [\n    {\n     "Assert": {\n      "Fn::Not": [\n       {\n        "Fn::Contains": [\n         [\n          "1",\n          "2",\n          "3",\n          "4",\n          "5"\n         ],\n         {\n          "Ref": "BootstrapVersion"\n         }\n        ]\n       }\n      ]\n     },\n     "AssertDescription": "CDK bootstrap stack version 6 required. Please run \'cdk bootstrap\' with a recent version of the CDK CLI."\n    }\n   ]\n  }\n }\n}'
2026-07-07T10:05:11.240 ERROR --- [et.reactor-1] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 2), invalid XML received:
✗ bufio.Scanner: token too long
```
</details>

<details>
<summary>
    After — the oversized line is emitted truncated with a byte-count marker, the stream keeps going to completion (77 lines), clean exit.
</summary>

```log
$ ./bin/lstk logs

LocalStack version: 2026.6.1
LocalStack build date: 2026-07-01
LocalStack build git hash: 4dcdcb5da

2026-07-07T09:58:20.017  INFO --- [  MainThread] l.p.c.b.licensingv2        : Successfully activated cached license ccd3fed7-f523-4abe-a2cd-2539c92a0617:enterprise from /var/lib/localstack/cache/license.json 🔑✅
2026-07-07T09:58:21.990  INFO --- [  MainThread] l.p.c.extensions.plugins   : loaded 0 extensions
2026-07-07T09:58:23.812  INFO --- [ady_monitor)] localstack.appinspector    : Running database migrations for AppInspector...
2026-07-07T09:58:23.827  INFO --- [ady_monitor)] localstack.appinspector    : AppInspector database migrations completed successfully.
2026-07-07T09:58:24.278  INFO --- [ady_monitor)] localstack.appinspector    : AppInspector enabled via APP_INSPECTOR
Ready.
2026-07-07T10:05:04.942  INFO --- [et.reactor-1] localstack.request.aws     : AWS sts.GetCallerIdentity => 200
2026-07-07T10:05:05.120  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStacks => 400 (ValidationError)
2026-07-07T10:05:05.147  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStacks => 400 (ValidationError)
2026-07-07T10:05:05.179  INFO --- [et.reactor-2] localstack.request.aws     : AWS cloudformation.DescribeStacks => 400 (ValidationError)
2026-07-07T10:05:05.660  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.CreateChangeSet => 200
2026-07-07T10:05:05.670  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeChangeSet => 200
2026-07-07T10:05:05.679  INFO --- [et.reactor-2] localstack.request.aws     : AWS cloudformation.ExecuteChangeSet => 200
2026-07-07T10:05:05.685  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStacks => 200
2026-07-07T10:05:05.884  INFO --- [et.reactor-1] l.p.c.s.e.provider_basic   : {"InfoCode": "InternalInfoEvents at process_rules", "InfoMessage": "No rules attached to event_bus: default"}
2026-07-07T10:05:05.992  INFO --- [et.reactor-3] l.p.c.services.iam.plugins : Configured IAM provider to use Advance Policy Simulator
2026-07-07T10:05:06.018  INFO --- [et.reactor-2] l.p.c.s.ecr.registry       : Starting ECR Docker registry (ECR_ENDPOINT_STRATEGY=domain) for region us-east-1 in account 000000000000
2026-07-07T10:05:07.690  INFO --- [et.reactor-3] localstack.request.aws     : AWS cloudformation.DescribeStackEvents => 200
2026-07-07T10:05:09.722  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStackEvents => 200
2026-07-07T10:05:10.698  INFO --- [et.reactor-2] localstack.request.aws     : AWS cloudformation.DescribeStacks => 200
2026-07-07T10:05:10.709  INFO --- [et.reactor-1] localstack.request.aws     : AWS cloudformation.DescribeStackEvents => 200
2026-07-07T10:05:10.979  INFO --- [et.reactor-3] localstack.request.aws     : AWS sts.AssumeRole => 200
2026-07-07T10:05:10.982  INFO --- [et.reactor-1] localstack.request.aws     : AWS sts.AssumeRole => 200
2026-07-07T10:05:11.123  INFO --- [et.reactor-1] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.124  INFO --- [et.reactor-1] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.125  INFO --- [et.reactor-2] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.125  INFO --- [et.reactor-2] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.132  INFO --- [et.reactor-2] localstack.request.aws     : AWS sts.AssumeRole => 200
2026-07-07T10:05:11.155  INFO --- [et.reactor-1] localstack.request.aws     : AWS ssm.GetParameter => 200
2026-07-07T10:05:11.173  INFO --- [et.reactor-2] localstack.request.aws     : AWS cloudformation.DescribeStacks => 200
2026-07-07T10:05:11.177  INFO --- [et.reactor-4] localstack.request.aws     : AWS cloudformation.DescribeStacks => 200
2026-07-07T10:05:11.191  INFO --- [et.reactor-3] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.191  INFO --- [et.reactor-3] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.195  INFO --- [et.reactor-4] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.195  INFO --- [et.reactor-4] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.205  INFO --- [et.reactor-2] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.206  INFO --- [et.reactor-2] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.207  INFO --- [et.reactor-5] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.207  INFO --- [et.reactor-5] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.219  INFO --- [et.reactor-3] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.219  INFO --- [et.reactor-3] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.219  INFO --- [et.reactor-2] l.p.c.s.i.p.handler        : User: arn:aws:sts::000000000000:assumed-role/cdk-hnb659fds-file-publishing-role-000000000000-us-east-1/aws-cdk-cristian is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
2026-07-07T10:05:11.219  INFO --- [et.reactor-2] localstack.request.aws     : AWS s3.ListBuckets => 200
2026-07-07T10:05:11.227 ERROR --- [et.reactor-2] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 0), invalid XML received:
b'{\n "Resources": {\n  "EventStream271A91DB": {\n   "Type": "AWS::Kinesis::Stream",\n   "Properties": {\n    "RetentionPeriodHours": 24,\n    "StreamEncryption": {\n     "Fn::If": [\n      "AwsCdkKinesisEncryptedStreamsUnsupportedRegions",\n      {\n       "Ref": "AWS::NoValue"\n      },\n      {\n       "EncryptionType": "KMS",\n       "KeyId": "alias/aws/kinesis"\n      }\n     ]\n    },\n    "StreamModeDetails": {\n     "StreamMode": "ON_DEMAND"\n    }\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventStream/Resource"\n   }\n  },\n  "EventTable3F3CD4B2": {\n   "Type": "AWS::DynamoDB::Table",\n   "Properties": {\n    "AttributeDefinitions": [\n     {\n      "AttributeName": "eventId",\n      "AttributeType": "S"\n     }\n    ],\n    "BillingMode": "PAY_PER_REQUEST",\n    "KeySchema": [\n     {\n      "AttributeName": "eventId",\n      "KeyType": "HASH"\n     }\n    ]\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventTable/Resource"\n   }\n  },\n  "ProcessorServiceRole5039D372": {\n   "Type": "AWS::IAM::Role",\n   "Properties": {\n    "AssumeRolePolicyDocument": {\n     "Statement": [\n      {\n       "Action": "sts:AssumeRole",\n       "Effect": "Allow",\n       "Principal": {\n        "Service": "lambda.amazonaws.com"\n       }\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "ManagedPolicyArns": [\n     {\n      "Fn::Join": [\n       "",\n       [\n        "arn:",\n        {\n         "Ref": "AWS::Partition"\n        },\n        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"\n       ]\n      ]\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/Resource"\n   }\n  },\n  "ProcessorServiceRoleDefaultPolicyDA9D4DBA": {\n   "Type": "AWS::IAM::Policy",\n   "Properties": {\n    "PolicyDocument": {\n     "Statement": [\n      {\n       "Action": [\n        "kinesis:DescribeStreamSummary",\n        "kinesis:GetRecords",\n        "kinesis:GetShardIterator",\n        "kinesis:ListShards",\n        "kinesis:SubscribeToShard",\n        "kinesis:DescribeStream",\n        "kinesis:ListStreams",\n        "kinesis:DescribeStreamConsumer"\n       ],\n       "Effect": "Allow",\n       "Resource": {\n        "Fn::GetAtt": [\n         "EventStream271A91DB",\n         "Arn"\n        ]\n       }\n      },\n      {\n       "Action": [\n        "dynamodb:BatchWriteItem",\n        "dynamodb:PutItem",\n        "dynamodb:UpdateItem",\n        "dynamodb:DeleteItem",\n        "dynamodb:DescribeTable"\n       ],\n       "Effect": "Allow",\n       "Resource": [\n        {\n         "Fn::GetAtt": [\n          "EventTable3F3CD4B2",\n          "Arn"\n         ]\n        }\n       ]\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "PolicyName": "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "Roles": [\n     {\n      "Ref": "ProcessorServiceRole5039D372"\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/DefaultPolicy/Resource"\n   }\n  },\n  "Processor60228016": {\n   "Type": "AWS::Lambda::Function",\n   "Properties": {\n    "Code": {\n     "S3Bucket": {\n      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"\n     },\n     "S3Key": "ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5.zip"\n    },\n    "Environment": {\n     "Variables": {\n      "TABLE_NAME": {\n       "Ref": "EventTable3F3CD4B2"\n      }\n     }\n    },\n    "Handler": "index.handler",\n    "Role": {\n     "Fn::GetAtt": [\n      "ProcessorServiceRole5039D372",\n      "Arn"\n     ]\n    },\n    "Runtime": "nodejs22.x"\n   },\n   "DependsOn": [\n    "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "ProcessorServiceRole5039D372"\n   ],\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/Resource",\n    "aws:asset:path": "asset.ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5",\n    "aws:asset:is-bundled": true,\n    "aws:asset:property": "Code"\n   }\n  },\n  "ProcessorKinesisEventSourcetest347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE378F1CA5": {\n   "Type": "AWS::Lambda::EventSourceMapping",\n   "Properties": {\n    "BatchSize": 10,\n    "EventSourceArn": {\n     "Fn::GetAtt": [\n      "EventStream271A91DB",\n      "Arn"\n     ]\n    },\n    "FilterCriteria": {\n     "Filters": [\n      {\n       "Pattern": "{\\"data\\":{\\"payload\\":{\\"type\\":[\\"purchase\\"]}}}"\n      }\n     ]\n    },\n    "FunctionName": {\n     "Ref": "Processor60228016"\n    },\n    "StartingPosition": "TRIM_HORIZON"\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/KinesisEventSource:test347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE/Resource"\n   }\n  },\n  "CDKMetadata": {\n   "Type": "AWS::CDK::Metadata",\n   "Properties": {\n    "Analytics": "v2:deflate64:H4sIAAAAAAAA/2VQu27DMAz8lu4y2zoZujZGu7UN7OwGLTGB/KAMU0oQGPr3QnLQpdMd73BHkCWU+zd4ecKbFNoMxWg7WBuPelB4k3YdLJNYSdpCOKnqzBuLytwZJ2c6WE/YjZSsTKIaceoMtuwM9QLfGT4Da28dK4sTrLXbAhmPbrT6nsaNRSW7FkXIC7wnULKDQ9AD+QMKPephrc781/pxJfaNC4umL5xny5fU91+NMemVY2NzribJtsqLGo+XR/Qn+Dn4qNIR0MvztdzDa/pUL9YWS2BvJ4J6w1+9mSJwRgEAAA=="\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/CDKMetadata/Default"\n   },\n   "Condition": "CDKMetadataAvailable"\n  }\n },\n "Conditions": {\n  "AwsCdkKinesisEncryptedStreamsUnsupportedRegions": {\n   "Fn::Or": [\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-north-1"\n     ]\n    },\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-northwest-1"\n     ]\n    }\n   ]\n  },\n  "CDKMetadataAvailable": {\n   "Fn::Or": [\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "af-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-3"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-3"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-4"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-west-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-north-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-northwest-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n          … (2916 more bytes truncated)
2026-07-07T10:05:11.240 ERROR --- [et.reactor-1] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 2), invalid XML received:
b'PK\x03\x04\x14\x00\x08\x00\x08\x00\x00\x00!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00index.js\xec\xbdk{\x1b7\xb2 \xfc=\xbf\x02\xe6z\xbdTL\xb5.\x8e2\x19N\x18E\x91\x95\x89Nl\xcb#\xc9\x99\x99\xd5x\xe9\x16\tR\x1d\x91\xddLwS\x8e\xa2\xe8\xbf\xbfO\xdd\x80Bw\x93\xa2\x1c_r\xde\xdd|\x88\xc5\x06P(\x14\nuC\x01h\xcd\x0bk\x8a2O\x06e\xebo\x9f]\xc5\xb9\xe9\xf7\x07\xb9\x8dKkz\xe6\xe8\xfcg;(#\xfa-\xa5C;z\x99g3_<\xb4\xa3$\xb5\xf0\xcd\xe6\xe5\xb5T\x1b\xdb\xf2\xe8m\n_\x9f\xdab\xe0k\xfb\xefP\x1b\xca\xf2dVfy\xbd\xdd\x8bxj\x8bE\r\xb1P\xb5y\x99gev4\n\xaa\xe3\xb7\xf2zf\x8fFR\xf3".\x18+_s\x06M\xa1Z\xe4K\xf5Hl15=\xd3\x1e\xa5\x1d\x93\xdbb\xcd\xf4\xbe1\xa3y:(\x93,5\xfd~\x92&e{\xcd\xdc|fLn\xcby\x9e\x9aQj\x1e=2\xed\x1c\x91oov\xcc(=\xeb\xf7\xfd\xb8\x11\xf5\xf6(];\xdb|\xfdz\xad=JM\xcfl\xae\xad!\xf4\xbf}v+\xa8\x0e\xb2\xe94K\xff\xeb\x04\xfa\x1e\x9cw\xcc4\x1bV\xfb\xce\xed/\xf3$\xb7a\xf7\xd3lh~\xff\xdd@\xc7\x83\xf3\x86\x8e\x07\xe7\xdcq\x1bj\xf6\xcc\x8d\xb1\xbf\xce\xb2\xbc,\xba\xe6\xe6\xd6\xdc\xaeE\xfc\x93z\xc4\xff\xcb\'\x85\x1dU\x02\xdc\xca8\x1f\xdb\xb2c\xe2\xc9\x04\xf1\x03J\x8c\xb2\xdc\xb4\x81\x99\xd2xjM\x92b\xe1g\xc6\x18\xd3\xef3\xff\xb8vP\xa5cn\xcc\xd8\x96]\xa8w\x06\x1f^w\x8cM\xe7S\x9b\xc7\xe7\x13\xdb5e>\xb7\xe6vM\xf5?\xc8f\xd7\xc0\\\xc0 \xed2\xeb\x98Q\x9eM;\xc6\xfe:\xb0\xb3\xb2c\x86\xb6\x188l\x92\x91iC1L\x0b\xccs6\xc2\xda\xa6\xd7\xeb\x99V\x86<\xde\x02\x92\xd5\xcad\x9a[4\xbf<\xae\x89-\xcd\xa5\xbd6\xd9\xc84Lk\x9eM\xd7\xd6p\xa8\xc6@\xc7\x0f\xfa}\xcfV\xd1 \x9eL\x10\xddK{\xbd\x06\xf8\x00\xa0\x07\xbd\x1e#.\r\x03:e\x1d\xa8\xe5H\xd4&.\xc8\xb3\xe9\xd9\xa5\xbd\xae\x10\xeaA\x1bFnz\x01f\xb0\xc8\x90\x00\x08hm\r\xc6\n\xd5"Ob$\xae1\xb7\x9e\x8b\xcbLQ\xbb\xcc\x0eN\x9e\x03\xa5\xa7\xd9\xb0c\x92\xe2E6\xb4\xcf\xb3\xa1\xed\x18\x9a}D\x89g\xd4\xf4\x80U\xcd\x83\x9eI\xe7\x93\x89\xd9u\x02\xa5\x8d\xd4\xe2\x85\n\x90\xd6\xd6\x0c\xf0\\\x07j\xc8t\xb6?3fc\xc3\x1c\x8eLyaM2\x05\xce\xb4\xb9I\n\xe0\xa24\x1bZ3\xc8\xa6\xb3\xb8L\xce\x93IR^CW\xd6d\xb9)/\xa0Ja\xd2\xac4qj\x0eN\x9e\x13\xa0Q2\xb1\xa6\xbc\x88Ks\x11\x17\xe6\xdc\xda\xd4\x0c\xb2\xf4\xca\xe6\xa5\x1d\x9a23\xb1\xd9\x97u\x86U\xe7E\x92\x8eMl\xbe\x8b\xcf\xedd\x9d`H\x8f\x00)\x8f\xd3b\x94\xe5S\xd3N"\x1b\x99V\xbfo\x8b\xe7\xd9p>\xb1-\xec\x01\xfa\xc7^\n[\xaeu`\x10\xa9)lI\x80ZC;\x8a\xe7\x93\xb2\x05=\xc3\xf8\\\xdf\xad)\xc2\x90\x85\xd6\xc2\x15T\x1fn\xf4\x99Q\xd4\x87y|\xc0\xcb\x1d\xfe\x8d<2H\xf6\xeaJs\xdd\x03/]\xc5\x93\xb9\xed\x02\xfd\x1a\x97\x9a\xe9\xf2\xd4v>3P\xe9\xb3\xb55\x11Le\xe6\xd0&\x8e\xc0\xd9\xd7s\xe8\x179\xcc\xae\xa6\x91\xea\x99\xd74\x89\x99\xbf}\xf6\xd9\xc6\x06\xceo\x9f(QlD\xb3t6\xdd\xf8\xb6\x98&\xe5\xc5\xf5cX\x9b\xc5\xb7_D[_D\x9b\x1b@\x18W\x8fkl`\x8d\x8daR\x94\xeb\x83\x9f\x8b\x8d$\x1d\xda_\xa3\x9f\x0b\xd4i,(\xfbP\xda\x1f\xfc\x0cB\x03\xf0%\x01\xdb\x06\x89\xd5\n`\xbe\xa7\xbe[m\x96\xa5\xdb"@Z\x81\xba\x05\x81(5\xa2\x1f\xcar\xb67//\x9ee\x83\x18uK\xcf\\e\xc9\xd0l\xfe\r\xa5I[\x84Q\xbbZQ`\x1bS-9k\xfdp\xb0\xf7\xf4\xe0\xb8\xf5\xda\xf4L\xeb\xc2\xc6C\x9b\xb7\x08\\S\xe5\x7f\xbc:8\xfe7\xd5\xfden\xf3k\xaez\xbb\xe6\x86QG\x124\xcd\xb2!\xdc\xdc\x02\xe3\xd4\x07:K~\xb4\xd7\xab\x0f\xb7V\xddQ\x94\x07R\xafp\xf7\xe0\x9b\xda\xacJ\x83Z[\xd4\xb9!%\xeauz\xa6\x81\x1e\x07\xe9p\x96%i\xf9\xea\xf8\xd9\xc9\xe0\xc2N\xc1\xf2j\x9e\xf9ZM?\xf5\xb5\xa2\xb3\xd6\x0f\xa7\xa7/y\xe6\xcbr\xe6\xe6}A\xcd\x13_\xb5h\x98\xf8Z\xabp\xbc\xf5\xe2\xc6\xa1\xeeM\xc6Y\x9e\x94\x17\xd3C\xb0<\x9a\x07\xa9\xea\xf8\xe1\xa9\x8fg\xad\xe7Ow\x08\xd9\xe9p\xc7\r+\xa8\xb1\x7f\xbc\xffd\x9b\xea\x0c\xf2\xc1\x93\xed%\xb5\xf6U\xb5As\xbd\x93\x1f\xf6\xb6\xa8Vq\x11o-\xac\xb3\xbd\xf3\xa5\xab\x05\x7f\x13\xdb\xeb\xd5\xa3p\x0c\xc9\xa7\x0b4\xe1\xc0\x84\x1a\xdbr\xff\xc2\x0e.\x8b\xf9t?KG\xc9x\x9e\x8b|h\xe7\xf3\xb4L\xa6\x96\xbe;{\x07V\xdb K\x8b\xd2\x0c\xb8\xa1\x83\x0f\x92\xef\xec\xb5\x88\x00\xb0O\x02\x10Qq\x11o\xef|\x89\x16\t\xcd\x8e\x9f\x02\xd3\x00-\x9a\xcd\x8b\x0b\x94\x9f\xd0\'\xfc\x17\xfb\x19\xee\x1a2U\xdc\xa2pX\x1c\x0e\xa3\x93\x1f\xf6\xb6w\xbe\x04\xe5"\xff\t\xae\xfb\x80y>\x1f\x94Y.\x10\x9apt-\xc1,$\x18`\xbd\xc0\x7f\xf5aM\x87;`\x90|\xd8!=\x7f\xba\xf3N\xe3\x99\x0ew\x96\x0c\x86\x9d\n\xd0Q\xf4_<\x1c\n?8\x82\xb6\x81\xecz\xaa\x16O\x16\xd6\x14\x8a\x19s\xebQ\x96\tpP\x0bv,\xa4gF\xa5^O\x81\x93\xa9\xa0O\xb7\xf4\x0f\xb0qn\x8blre\x05\xf5c\xcd\xb9\xe8\xe2L\x12\x9b\x96\x0b99`\x01\xf0Z\x18\xb41\x03\xd50\xaa\xe3\xd6^\x8bFY~\x10\x0f.\xda\xedZi\xb0d\x8c\t:9\xab\xd5\x8e\x14s\xb7\xd7@\xa7\xd6\xab\xc8\x17\xc5\xc5m\xcf\xa0\xee/&e\xd0a\x8ddc[>%\x83q_\x8dq\xa5\xe5\xcf\xf0\x17\xc9\x8ep\xd53V\xf5\xc9\xe2\xde\x83\xb9\xda\xc1\xc9BA\x14POF\xb4d\x9a\xdb\x03j\x16\x0c\xd4I\x87\xef\x13;\x19\xbe\xcc\x8ad\xa9\xf1\x13\xd4\xf2\x1c\x1f|>\x0b\x7fi#h\x13-!\xb6\x8a\x08\x0fc\xc2\xea\xe1\xaf\xd6\xe9\xf1\xde\xe136\xa1\xb6\xb0\xb5|\xe1a(\xeb(h\x1aJ\xf8\xb0\xa8*\xe3O\x9e\x1f\x9e\xfe\xf0\xef\xfe\xfe\xd1\x8b\xd3\x83\x7f\x9d\xf6\x7f<\xf8\xf76Xl\xfd>Y\xbf\xfdA\x96\x96\xf6W\x88\xd0\xc0Zt$;L\x93\x13\x8b\x81\x88\xd3\xeb\xd9b\xb3!\xac\xe6\x89\x16~?k\xbd<>\xfa\xfe\xf0\xd9\x01)\xb1Y\x9e\x81C\xe4\xb4]\xb5\xf2\xc9\xc9Q\xff\xe4\xe0\xe4\xe4\xf0\xe8\x05k\xbd"[/lQ$Y\xba\xb8\xd1\xc1\xf1O\x87\xfb\x07lk\x146\xbfJ\x06\xb6\xc9\xdc\x08{\x0bIY)\xd3\xb4t\x949\xb6\xbf\xccmQ\xfe\x10\xa7\xc3\x89\xcd\xd1\xe7\x1cd\x93\x856GsuO\xa9\xe6r2\xb1\xfa\x9b\xfd\xbf\x12\x05.\xcar\xb6\xb1\x19\xfd\xd5\r\x7fi\xb3\xad\xfe\xa6j\xb6\x15m\xde\xd9\xec\xf4\xe9I\xff+iU\x0e\x8b\x8d\xaf\\#me4\xf7\x1a\xd2pA\x9dFZ\xd6\x99\xd3\xf4L\xfd\xe3v\x859\xef\x92^K\xcb+\xb0Xy4\xc9#\xd3\x13\xd5\xd2T\xba\x03\x80n?\x03\x1b\xe1\x0e\x07s^&\x93\xf5i2\x1cN\xec\xdb8\xb7\xdf~\x11mG[O\x9a]\xcdJ\xdd\x15\x9dNX\xd2\xf7\xf0:+\x9d\xfc1\x84V\xf1DAK\xa3\x13\x8d$\xc5\xc8\xa2s\x98E\x87\xb1Az\x82N\xf9>I\xa5\xad-V\t \xa2P\'\xb0\xb8:ChQ\x9dU^#3\xde]\x0b\xd9\x91X\x01:N\xb3|\x1aO\x92\xdf \xd6|\x95\x0cm\xfe\x17\xe88Igs\xeaVl$\xb0\xff\xa0\xebld\xb0\x90\x02}\xe2?\xb7|\x90\x8du\x16V\xa2n\xc4p\x9e\xe5\xd94)\x92Qb\xc1Qy\x89\xbfl\xc4l\xc8]J\x0b\x86B\xc6\xaejH\xe5\xacU\x9dd\x1a\xdb2\xa0\x9e\xe9\x81\x85\x1f|\xda\xda\xa2\xa6\xaeMm\xe0\xa6\xd7@\x0ch\xb4\x9c\xd5\xe3\xb7\xc5z1\xbc|<\xc8r\xfb\xed\x93\xe8\xaf\x7fy\x12m\xff\xa5\xc2\xe2\\g\x03\xea\x10c\xdbb\xa3\x98\x9fKX&\x1e\x0c\xb2yZ\xae\'\xc3u\xcb\x8e\xeb\xc6\x1e};\x1c\x8a\x1b\x08\xb1A\xb4\x80\xe2\xb4, \x08#\xc4\x87\xb0S2\x8cK\xdb\xd8\xa4\x8dA)\x12\xbbL\xd5\xbd\xfd\xfd\xa3W/N\xfb\x87O\xfb\x07/\x9e\xbe<:|q\xda\x7f~\xf4\xf4\xa0\xff\xd3\xde\xb3W\x07\'Q\x92\x0e&\xf3\xa1-\xb8\xe9\xdf>\xbb\xc5\x80\xcf\xd3\x83\xef\xf7^=;\xed/j\xde1\x8bJ\x180\x05\xbb \xb8\xdfoD\xd5\x8d\x0e\x17\xb5-\xa6\x8b\xa3H\x9f\x8c\xea-g\xbf\xdfE\x0e06f\xb9\x1d\xd9<\xb7C\xd6Cw\x10\x08\x1c\xc9\xd60) @?lut\xfb\x8eiq\xc0m\xd8B_\xf3\xcf\xc5\x95\xa3d|LVj.\xf1A\x8a3\xf7A\xe4\xf6\xbd\x0e\xc0\x1d\x19pZ\x16q\xc0(\x19\xaf\xc0\'\xaa\xbf?\x1f\xb3(\xe4\xa2\x9f\x0b\xcf1\xcd\x14A\xfcq3\xa0]\r\xa9n\xb7%\xd0\xb7\xc2\xa2\x11u\xc2\x02u\t}\x9b%<E7n\x0c\x0b\xa3P\xf0\x98[\xd3#\xc1/\x12\x9a\xaa7V\x16U\x02\xfdlvx\xc3\xa1\xca\x08QM\x00\xaf\xb5\x1b\xa1\x99\xdd]s\xd7Z\xab\xfa\x80\xbc\xc9\x1a\x17E2NI\xb5tp;\x91\xdd\xfd&\xd9\xda5qq\x9d\x0e8\xc0"z\x0f\x1a\xb8\xa1\x1e\x0eA\x08\x9b\x9e\x89\xdf\xc6I\xd9L)\x19\xbcL\x07\xf5\x88\xbbV\xcb\xe5t<\x18\x10\xfc5o#S\xe3\xf2"\xcf\xde\x9a\xd4\xbe5\x07y\x9e\xe5\xed7\x87)\x82\xa2\xfd\x06\xdc\xd6h\xa4\\\xd7<\xbcqPo#\xf3\x13\xe8\tjT\x988\xb7]%S\xaa\xc2\xc6I\xa1\xe8\x8d#.`#\xf1 \xf8\x9b\xd5\x89\xebBX\xc3\xd7\x928\x12*\xecO#\xb1`[m\xc9Z8\x9a\x81k\x8c\xfa\x14\xcc!\x9b\xe7\x1d\xd3G\x82w\xcc\xc1\x8b\x9f\x96(\xbb\xfd\xa3\x17\xdf\x1f\xfe}I\x85\x17\xa0R\x17J|n~\xf4\xf2\xf4\xf0\xe8\xc5\x89\x12y\xab!\xfc\xe9\xa4\xdej\xf8\x85\x82\xefn\x95/\xcb\xc5\xe69(N\xe1\xf0\xc6\x99#\x16f\x95J\x93\x05\xa2fj\x8b"\x1e\xdb \x82R]:R\x87X\x95\xed\xc8e\xf3\x0c\xc8\xec\xfd\xf3d\xe1<2\x16w0\x03@\xe1%\xdaO\x86}1\xf2`\xbfM\xa2\x01\xf7\xe1\x16\x88\xd5qP\xd0\xa6WI\x9e\xa5S\x9b\x96?\xc5y\x02\x96\xc3\x89\x9dX\x8e\xf4\xda\xf4* \x87\xc82\xb4\tM\xcf\xd8\xf4\xeal\xd9\xe8]T\x9b\x02\xc0\xd4\xec\xd1#\xf3`\xb9(#\x933\x14c4Om\x9b\xe7J\x9exi\xc2\xb2\x04[\x8a\x1cqqT\x8aq}\x9f\x04c\xe3`\xca\xd2\xf1q\x9d\xb3;\xa6\xe7O2L\xde\xc9\xee\xde\xa9\xeep\xee?\xa1L\r\xf6\x81\x9b\xf8\x9a\xbd,\x8e)\xf7\xfb\xf4[\xf4{\xb0\x04\xb8*\xa9\xe7\x85\xd2\x92<\x13\xd9\xbb\xb8\xa3\x1a\x84\xdf\xef\x98q\x81tG5\x80t\x97\xed!\xa0\xee\xaa\x07\xb0\x96\xad5\x81\xb3\xac\x0e\xc0\xb8\x8f\xa0\x10\x98\xf7i\x03}\xdcmC\n\xe4\xbbk\x02\xbc\xa5\xe2B@-\xad\x84\xe1&\xd0\xd0h\t7\xf0\xdc\xa7S\x88\xb2\x1a\x94\xa1\xbfL\xdf)\xef@\x94\xde= … (740554 more bytes truncated)
2026-07-07T10:05:11.838 ERROR --- [et.reactor-3] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 0), invalid XML received:
b'{\n "Resources": {\n  "EventStream271A91DB": {\n   "Type": "AWS::Kinesis::Stream",\n   "Properties": {\n    "RetentionPeriodHours": 24,\n    "StreamEncryption": {\n     "Fn::If": [\n      "AwsCdkKinesisEncryptedStreamsUnsupportedRegions",\n      {\n       "Ref": "AWS::NoValue"\n      },\n      {\n       "EncryptionType": "KMS",\n       "KeyId": "alias/aws/kinesis"\n      }\n     ]\n    },\n    "StreamModeDetails": {\n     "StreamMode": "ON_DEMAND"\n    }\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventStream/Resource"\n   }\n  },\n  "EventTable3F3CD4B2": {\n   "Type": "AWS::DynamoDB::Table",\n   "Properties": {\n    "AttributeDefinitions": [\n     {\n      "AttributeName": "eventId",\n      "AttributeType": "S"\n     }\n    ],\n    "BillingMode": "PAY_PER_REQUEST",\n    "KeySchema": [\n     {\n      "AttributeName": "eventId",\n      "KeyType": "HASH"\n     }\n    ]\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventTable/Resource"\n   }\n  },\n  "ProcessorServiceRole5039D372": {\n   "Type": "AWS::IAM::Role",\n   "Properties": {\n    "AssumeRolePolicyDocument": {\n     "Statement": [\n      {\n       "Action": "sts:AssumeRole",\n       "Effect": "Allow",\n       "Principal": {\n        "Service": "lambda.amazonaws.com"\n       }\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "ManagedPolicyArns": [\n     {\n      "Fn::Join": [\n       "",\n       [\n        "arn:",\n        {\n         "Ref": "AWS::Partition"\n        },\n        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"\n       ]\n      ]\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/Resource"\n   }\n  },\n  "ProcessorServiceRoleDefaultPolicyDA9D4DBA": {\n   "Type": "AWS::IAM::Policy",\n   "Properties": {\n    "PolicyDocument": {\n     "Statement": [\n      {\n       "Action": [\n        "kinesis:DescribeStreamSummary",\n        "kinesis:GetRecords",\n        "kinesis:GetShardIterator",\n        "kinesis:ListShards",\n        "kinesis:SubscribeToShard",\n        "kinesis:DescribeStream",\n        "kinesis:ListStreams",\n        "kinesis:DescribeStreamConsumer"\n       ],\n       "Effect": "Allow",\n       "Resource": {\n        "Fn::GetAtt": [\n         "EventStream271A91DB",\n         "Arn"\n        ]\n       }\n      },\n      {\n       "Action": [\n        "dynamodb:BatchWriteItem",\n        "dynamodb:PutItem",\n        "dynamodb:UpdateItem",\n        "dynamodb:DeleteItem",\n        "dynamodb:DescribeTable"\n       ],\n       "Effect": "Allow",\n       "Resource": [\n        {\n         "Fn::GetAtt": [\n          "EventTable3F3CD4B2",\n          "Arn"\n         ]\n        }\n       ]\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "PolicyName": "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "Roles": [\n     {\n      "Ref": "ProcessorServiceRole5039D372"\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/DefaultPolicy/Resource"\n   }\n  },\n  "Processor60228016": {\n   "Type": "AWS::Lambda::Function",\n   "Properties": {\n    "Code": {\n     "S3Bucket": {\n      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"\n     },\n     "S3Key": "ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5.zip"\n    },\n    "Environment": {\n     "Variables": {\n      "TABLE_NAME": {\n       "Ref": "EventTable3F3CD4B2"\n      }\n     }\n    },\n    "Handler": "index.handler",\n    "Role": {\n     "Fn::GetAtt": [\n      "ProcessorServiceRole5039D372",\n      "Arn"\n     ]\n    },\n    "Runtime": "nodejs22.x"\n   },\n   "DependsOn": [\n    "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "ProcessorServiceRole5039D372"\n   ],\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/Resource",\n    "aws:asset:path": "asset.ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5",\n    "aws:asset:is-bundled": true,\n    "aws:asset:property": "Code"\n   }\n  },\n  "ProcessorKinesisEventSourcetest347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE378F1CA5": {\n   "Type": "AWS::Lambda::EventSourceMapping",\n   "Properties": {\n    "BatchSize": 10,\n    "EventSourceArn": {\n     "Fn::GetAtt": [\n      "EventStream271A91DB",\n      "Arn"\n     ]\n    },\n    "FilterCriteria": {\n     "Filters": [\n      {\n       "Pattern": "{\\"data\\":{\\"payload\\":{\\"type\\":[\\"purchase\\"]}}}"\n      }\n     ]\n    },\n    "FunctionName": {\n     "Ref": "Processor60228016"\n    },\n    "StartingPosition": "TRIM_HORIZON"\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/KinesisEventSource:test347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE/Resource"\n   }\n  },\n  "CDKMetadata": {\n   "Type": "AWS::CDK::Metadata",\n   "Properties": {\n    "Analytics": "v2:deflate64:H4sIAAAAAAAA/2VQu27DMAz8lu4y2zoZujZGu7UN7OwGLTGB/KAMU0oQGPr3QnLQpdMd73BHkCWU+zd4ecKbFNoMxWg7WBuPelB4k3YdLJNYSdpCOKnqzBuLytwZJ2c6WE/YjZSsTKIaceoMtuwM9QLfGT4Da28dK4sTrLXbAhmPbrT6nsaNRSW7FkXIC7wnULKDQ9AD+QMKPephrc781/pxJfaNC4umL5xny5fU91+NMemVY2NzribJtsqLGo+XR/Qn+Dn4qNIR0MvztdzDa/pUL9YWS2BvJ4J6w1+9mSJwRgEAAA=="\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/CDKMetadata/Default"\n   },\n   "Condition": "CDKMetadataAvailable"\n  }\n },\n "Conditions": {\n  "AwsCdkKinesisEncryptedStreamsUnsupportedRegions": {\n   "Fn::Or": [\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-north-1"\n     ]\n    },\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-northwest-1"\n     ]\n    }\n   ]\n  },\n  "CDKMetadataAvailable": {\n   "Fn::Or": [\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "af-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-3"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-3"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-4"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-west-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-north-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-northwest-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n          … (2916 more bytes truncated)
2026-07-07T10:05:11.892 ERROR --- [et.reactor-5] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 2), invalid XML received:
b'PK\x03\x04\x14\x00\x08\x00\x08\x00\x00\x00!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00index.js\xec\xbdk{\x1b7\xb2 \xfc=\xbf\x02\xe6z\xbdTL\xb5.\x8e2\x19N\x18E\x91\x95\x89Nl\xcb#\xc9\x99\x99\xd5x\xe9\x16\tR\x1d\x91\xddLwS\x8e\xa2\xe8\xbf\xbfO\xdd\x80Bw\x93\xa2\x1c_r\xde\xdd|\x88\xc5\x06P(\x14\nuC\x01h\xcd\x0bk\x8a2O\x06e\xebo\x9f]\xc5\xb9\xe9\xf7\x07\xb9\x8dKkz\xe6\xe8\xfcg;(#\xfa-\xa5C;z\x99g3_<\xb4\xa3$\xb5\xf0\xcd\xe6\xe5\xb5T\x1b\xdb\xf2\xe8m\n_\x9f\xdab\xe0k\xfb\xefP\x1b\xca\xf2dVfy\xbd\xdd\x8bxj\x8bE\r\xb1P\xb5y\x99gev4\n\xaa\xe3\xb7\xf2zf\x8fFR\xf3".\x18+_s\x06M\xa1Z\xe4K\xf5Hl15=\xd3\x1e\xa5\x1d\x93\xdbb\xcd\xf4\xbe1\xa3y:(\x93,5\xfd~\x92&e{\xcd\xdc|fLn\xcby\x9e\x9aQj\x1e=2\xed\x1c\x91oov\xcc(=\xeb\xf7\xfd\xb8\x11\xf5\xf6(];\xdb|\xfdz\xad=JM\xcfl\xae\xad!\xf4\xbf}v+\xa8\x0e\xb2\xe94K\xff\xeb\x04\xfa\x1e\x9cw\xcc4\x1bV\xfb\xce\xed/\xf3$\xb7a\xf7\xd3lh~\xff\xdd@\xc7\x83\xf3\x86\x8e\x07\xe7\xdcq\x1bj\xf6\xcc\x8d\xb1\xbf\xce\xb2\xbc,\xba\xe6\xe6\xd6\xdc\xaeE\xfc\x93z\xc4\xff\xcb\'\x85\x1dU\x02\xdc\xca8\x1f\xdb\xb2c\xe2\xc9\x04\xf1\x03J\x8c\xb2\xdc\xb4\x81\x99\xd2xjM\x92b\xe1g\xc6\x18\xd3\xef3\xff\xb8vP\xa5cn\xcc\xd8\x96]\xa8w\x06\x1f^w\x8cM\xe7S\x9b\xc7\xe7\x13\xdb5e>\xb7\xe6vM\xf5?\xc8f\xd7\xc0\\\xc0 \xed2\xeb\x98Q\x9eM;\xc6\xfe:\xb0\xb3\xb2c\x86\xb6\x188l\x92\x91iC1L\x0b\xccs6\xc2\xda\xa6\xd7\xeb\x99V\x86<\xde\x02\x92\xd5\xcad\x9a[4\xbf<\xae\x89-\xcd\xa5\xbd6\xd9\xc84Lk\x9eM\xd7\xd6p\xa8\xc6@\xc7\x0f\xfa}\xcfV\xd1 \x9eL\x10\xddK{\xbd\x06\xf8\x00\xa0\x07\xbd\x1e#.\r\x03:e\x1d\xa8\xe5H\xd4&.\xc8\xb3\xe9\xd9\xa5\xbd\xae\x10\xeaA\x1bFnz\x01f\xb0\xc8\x90\x00\x08hm\r\xc6\n\xd5"Ob$\xae1\xb7\x9e\x8b\xcbLQ\xbb\xcc\x0eN\x9e\x03\xa5\xa7\xd9\xb0c\x92\xe2E6\xb4\xcf\xb3\xa1\xed\x18\x9a}D\x89g\xd4\xf4\x80U\xcd\x83\x9eI\xe7\x93\x89\xd9u\x02\xa5\x8d\xd4\xe2\x85\n\x90\xd6\xd6\x0c\xf0\\\x07j\xc8t\xb6?3fc\xc3\x1c\x8eLyaM2\x05\xce\xb4\xb9I\n\xe0\xa24\x1bZ3\xc8\xa6\xb3\xb8L\xce\x93IR^CW\xd6d\xb9)/\xa0Ja\xd2\xac4qj\x0eN\x9e\x13\xa0Q2\xb1\xa6\xbc\x88Ks\x11\x17\xe6\xdc\xda\xd4\x0c\xb2\xf4\xca\xe6\xa5\x1d\x9a23\xb1\xd9\x97u\x86U\xe7E\x92\x8eMl\xbe\x8b\xcf\xedd\x9d`H\x8f\x00)\x8f\xd3b\x94\xe5S\xd3N"\x1b\x99V\xbfo\x8b\xe7\xd9p>\xb1-\xec\x01\xfa\xc7^\n[\xaeu`\x10\xa9)lI\x80ZC;\x8a\xe7\x93\xb2\x05=\xc3\xf8\\\xdf\xad)\xc2\x90\x85\xd6\xc2\x15T\x1fn\xf4\x99Q\xd4\x87y|\xc0\xcb\x1d\xfe\x8d<2H\xf6\xeaJs\xdd\x03/]\xc5\x93\xb9\xed\x02\xfd\x1a\x97\x9a\xe9\xf2\xd4v>3P\xe9\xb3\xb55\x11Le\xe6\xd0&\x8e\xc0\xd9\xd7s\xe8\x179\xcc\xae\xa6\x91\xea\x99\xd74\x89\x99\xbf}\xf6\xd9\xc6\x06\xceo\x9f(QlD\xb3t6\xdd\xf8\xb6\x98&\xe5\xc5\xf5cX\x9b\xc5\xb7_D[_D\x9b\x1b@\x18W\x8fkl`\x8d\x8daR\x94\xeb\x83\x9f\x8b\x8d$\x1d\xda_\xa3\x9f\x0b\xd4i,(\xfbP\xda\x1f\xfc\x0cB\x03\xf0%\x01\xdb\x06\x89\xd5\n`\xbe\xa7\xbe[m\x96\xa5\xdb"@Z\x81\xba\x05\x81(5\xa2\x1f\xcar\xb67//\x9ee\x83\x18uK\xcf\\e\xc9\xd0l\xfe\r\xa5I[\x84Q\xbbZQ`\x1bS-9k\xfdp\xb0\xf7\xf4\xe0\xb8\xf5\xda\xf4L\xeb\xc2\xc6C\x9b\xb7\x08\\S\xe5\x7f\xbc:8\xfe7\xd5\xfden\xf3k\xaez\xbb\xe6\x86QG\x124\xcd\xb2!\xdc\xdc\x02\xe3\xd4\x07:K~\xb4\xd7\xab\x0f\xb7V\xddQ\x94\x07R\xafp\xf7\xe0\x9b\xda\xacJ\x83Z[\xd4\xb9!%\xeauz\xa6\x81\x1e\x07\xe9p\x96%i\xf9\xea\xf8\xd9\xc9\xe0\xc2N\xc1\xf2j\x9e\xf9ZM?\xf5\xb5\xa2\xb3\xd6\x0f\xa7\xa7/y\xe6\xcbr\xe6\xe6}A\xcd\x13_\xb5h\x98\xf8Z\xabp\xbc\xf5\xe2\xc6\xa1\xeeM\xc6Y\x9e\x94\x17\xd3C\xb0<\x9a\x07\xa9\xea\xf8\xe1\xa9\x8fg\xad\xe7Ow\x08\xd9\xe9p\xc7\r+\xa8\xb1\x7f\xbc\xffd\x9b\xea\x0c\xf2\xc1\x93\xed%\xb5\xf6U\xb5As\xbd\x93\x1f\xf6\xb6\xa8Vq\x11o-\xac\xb3\xbd\xf3\xa5\xab\x05\x7f\x13\xdb\xeb\xd5\xa3p\x0c\xc9\xa7\x0b4\xe1\xc0\x84\x1a\xdbr\xff\xc2\x0e.\x8b\xf9t?KG\xc9x\x9e\x8b|h\xe7\xf3\xb4L\xa6\x96\xbe;{\x07V\xdb K\x8b\xd2\x0c\xb8\xa1\x83\x0f\x92\xef\xec\xb5\x88\x00\xb0O\x02\x10Qq\x11o\xef|\x89\x16\t\xcd\x8e\x9f\x02\xd3\x00-\x9a\xcd\x8b\x0b\x94\x9f\xd0\'\xfc\x17\xfb\x19\xee\x1a2U\xdc\xa2pX\x1c\x0e\xa3\x93\x1f\xf6\xb6w\xbe\x04\xe5"\xff\t\xae\xfb\x80y>\x1f\x94Y.\x10\x9apt-\xc1,$\x18`\xbd\xc0\x7f\xf5aM\x87;`\x90|\xd8!=\x7f\xba\xf3N\xe3\x99\x0ew\x96\x0c\x86\x9d\n\xd0Q\xf4_<\x1c\n?8\x82\xb6\x81\xecz\xaa\x16O\x16\xd6\x14\x8a\x19s\xebQ\x96\tpP\x0bv,\xa4gF\xa5^O\x81\x93\xa9\xa0O\xb7\xf4\x0f\xb0qn\x8blre\x05\xf5c\xcd\xb9\xe8\xe2L\x12\x9b\x96\x0b99`\x01\xf0Z\x18\xb41\x03\xd50\xaa\xe3\xd6^\x8bFY~\x10\x0f.\xda\xedZi\xb0d\x8c\t:9\xab\xd5\x8e\x14s\xb7\xd7@\xa7\xd6\xab\xc8\x17\xc5\xc5m\xcf\xa0\xee/&e\xd0a\x8ddc[>%\x83q_\x8dq\xa5\xe5\xcf\xf0\x17\xc9\x8ep\xd53V\xf5\xc9\xe2\xde\x83\xb9\xda\xc1\xc9BA\x14POF\xb4d\x9a\xdb\x03j\x16\x0c\xd4I\x87\xef\x13;\x19\xbe\xcc\x8ad\xa9\xf1\x13\xd4\xf2\x1c\x1f|>\x0b\x7fi#h\x13-!\xb6\x8a\x08\x0fc\xc2\xea\xe1\xaf\xd6\xe9\xf1\xde\xe136\xa1\xb6\xb0\xb5|\xe1a(\xeb(h\x1aJ\xf8\xb0\xa8*\xe3O\x9e\x1f\x9e\xfe\xf0\xef\xfe\xfe\xd1\x8b\xd3\x83\x7f\x9d\xf6\x7f<\xf8\xf76Xl\xfd>Y\xbf\xfdA\x96\x96\xf6W\x88\xd0\xc0Zt$;L\x93\x13\x8b\x81\x88\xd3\xeb\xd9b\xb3!\xac\xe6\x89\x16~?k\xbd<>\xfa\xfe\xf0\xd9\x01)\xb1Y\x9e\x81C\xe4\xb4]\xb5\xf2\xc9\xc9Q\xff\xe4\xe0\xe4\xe4\xf0\xe8\x05k\xbd"[/lQ$Y\xba\xb8\xd1\xc1\xf1O\x87\xfb\x07lk\x146\xbfJ\x06\xb6\xc9\xdc\x08{\x0bIY)\xd3\xb4t\x949\xb6\xbf\xccmQ\xfe\x10\xa7\xc3\x89\xcd\xd1\xe7\x1cd\x93\x856GsuO\xa9\xe6r2\xb1\xfa\x9b\xfd\xbf\x12\x05.\xcar\xb6\xb1\x19\xfd\xd5\r\x7fi\xb3\xad\xfe\xa6j\xb6\x15m\xde\xd9\xec\xf4\xe9I\xff+iU\x0e\x8b\x8d\xaf\\#me4\xf7\x1a\xd2pA\x9dFZ\xd6\x99\xd3\xf4L\xfd\xe3v\x859\xef\x92^K\xcb+\xb0Xy4\xc9#\xd3\x13\xd5\xd2T\xba\x03\x80n?\x03\x1b\xe1\x0e\x07s^&\x93\xf5i2\x1cN\xec\xdb8\xb7\xdf~\x11mG[O\x9a]\xcdJ\xdd\x15\x9dNX\xd2\xf7\xf0:+\x9d\xfc1\x84V\xf1DAK\xa3\x13\x8d$\xc5\xc8\xa2s\x98E\x87\xb1Az\x82N\xf9>I\xa5\xad-V\t \xa2P\'\xb0\xb8:ChQ\x9dU^#3\xde]\x0b\xd9\x91X\x01:N\xb3|\x1aO\x92\xdf \xd6|\x95\x0cm\xfe\x17\xe88Igs\xeaVl$\xb0\xff\xa0\xebld\xb0\x90\x02}\xe2?\xb7|\x90\x8du\x16V\xa2n\xc4p\x9e\xe5\xd94)\x92Qb\xc1Qy\x89\xbfl\xc4l\xc8]J\x0b\x86B\xc6\xaejH\xe5\xacU\x9dd\x1a\xdb2\xa0\x9e\xe9\x81\x85\x1f|\xda\xda\xa2\xa6\xaeMm\xe0\xa6\xd7@\x0ch\xb4\x9c\xd5\xe3\xb7\xc5z1\xbc|<\xc8r\xfb\xed\x93\xe8\xaf\x7fy\x12m\xff\xa5\xc2\xe2\\g\x03\xea\x10c\xdbb\xa3\x98\x9fKX&\x1e\x0c\xb2yZ\xae\'\xc3u\xcb\x8e\xeb\xc6\x1e};\x1c\x8a\x1b\x08\xb1A\xb4\x80\xe2\xb4, \x08#\xc4\x87\xb0S2\x8cK\xdb\xd8\xa4\x8dA)\x12\xbbL\xd5\xbd\xfd\xfd\xa3W/N\xfb\x87O\xfb\x07/\x9e\xbe<:|q\xda\x7f~\xf4\xf4\xa0\xff\xd3\xde\xb3W\x07\'Q\x92\x0e&\xf3\xa1-\xb8\xe9\xdf>\xbb\xc5\x80\xcf\xd3\x83\xef\xf7^=;\xed/j\xde1\x8bJ\x180\x05\xbb \xb8\xdfoD\xd5\x8d\x0e\x17\xb5-\xa6\x8b\xa3H\x9f\x8c\xea-g\xbf\xdfE\x0e06f\xb9\x1d\xd9<\xb7C\xd6Cw\x10\x08\x1c\xc9\xd60) @?lut\xfb\x8eiq\xc0m\xd8B_\xf3\xcf\xc5\x95\xa3d|LVj.\xf1A\x8a3\xf7A\xe4\xf6\xbd\x0e\xc0\x1d\x19pZ\x16q\xc0(\x19\xaf\xc0\'\xaa\xbf?\x1f\xb3(\xe4\xa2\x9f\x0b\xcf1\xcd\x14A\xfcq3\xa0]\r\xa9n\xb7%\xd0\xb7\xc2\xa2\x11u\xc2\x02u\t}\x9b%<E7n\x0c\x0b\xa3P\xf0\x98[\xd3#\xc1/\x12\x9a\xaa7V\x16U\x02\xfdlvx\xc3\xa1\xca\x08QM\x00\xaf\xb5\x1b\xa1\x99\xdd]s\xd7Z\xab\xfa\x80\xbc\xc9\x1a\x17E2NI\xb5tp;\x91\xdd\xfd&\xd9\xda5qq\x9d\x0e8\xc0"z\x0f\x1a\xb8\xa1\x1e\x0eA\x08\x9b\x9e\x89\xdf\xc6I\xd9L)\x19\xbcL\x07\xf5\x88\xbbV\xcb\xe5t<\x18\x10\xfc5o#S\xe3\xf2"\xcf\xde\x9a\xd4\xbe5\x07y\x9e\xe5\xed7\x87)\x82\xa2\xfd\x06\xdc\xd6h\xa4\\\xd7<\xbcqPo#\xf3\x13\xe8\tjT\x988\xb7]%S\xaa\xc2\xc6I\xa1\xe8\x8d#.`#\xf1 \xf8\x9b\xd5\x89\xebBX\xc3\xd7\x928\x12*\xecO#\xb1`[m\xc9Z8\x9a\x81k\x8c\xfa\x14\xcc!\x9b\xe7\x1d\xd3G\x82w\xcc\xc1\x8b\x9f\x96(\xbb\xfd\xa3\x17\xdf\x1f\xfe}I\x85\x17\xa0R\x17J|n~\xf4\xf2\xf4\xf0\xe8\xc5\x89\x12y\xab!\xfc\xe9\xa4\xdej\xf8\x85\x82\xefn\x95/\xcb\xc5\xe69(N\xe1\xf0\xc6\x99#\x16f\x95J\x93\x05\xa2fj\x8b"\x1e\xdb \x82R]:R\x87X\x95\xed\xc8e\xf3\x0c\xc8\xec\xfd\xf3d\xe1<2\x16w0\x03@\xe1%\xdaO\x86}1\xf2`\xbfM\xa2\x01\xf7\xe1\x16\x88\xd5qP\xd0\xa6WI\x9e\xa5S\x9b\x96?\xc5y\x02\x96\xc3\x89\x9dX\x8e\xf4\xda\xf4* \x87\xc82\xb4\tM\xcf\xd8\xf4\xeal\xd9\xe8]T\x9b\x02\xc0\xd4\xec\xd1#\xf3`\xb9(#\x933\x14c4Om\x9b\xe7J\x9exi\xc2\xb2\x04[\x8a\x1cqqT\x8aq}\x9f\x04c\xe3`\xca\xd2\xf1q\x9d\xb3;\xa6\xe7O2L\xde\xc9\xee\xde\xa9\xeep\xee?\xa1L\r\xf6\x81\x9b\xf8\x9a\xbd,\x8e)\xf7\xfb\xf4[\xf4{\xb0\x04\xb8*\xa9\xe7\x85\xd2\x92<\x13\xd9\xbb\xb8\xa3\x1a\x84\xdf\xef\x98q\x81tG5\x80t\x97\xed!\xa0\xee\xaa\x07\xb0\x96\xad5\x81\xb3\xac\x0e\xc0\xb8\x8f\xa0\x10\x98\xf7i\x03}\xdcmC\n\xe4\xbbk\x02\xbc\xa5\xe2B@-\xad\x84\xe1&\xd0\xd0h\t7\xf0\xdc\xa7S\x88\xb2\x1a\x94\xa1\xbfL\xdf)\xef@\x94\xde= … (740554 more bytes truncated)
2026-07-07T10:05:13.052 ERROR --- [et.reactor-2] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 0), invalid XML received:
b'{\n "Resources": {\n  "EventStream271A91DB": {\n   "Type": "AWS::Kinesis::Stream",\n   "Properties": {\n    "RetentionPeriodHours": 24,\n    "StreamEncryption": {\n     "Fn::If": [\n      "AwsCdkKinesisEncryptedStreamsUnsupportedRegions",\n      {\n       "Ref": "AWS::NoValue"\n      },\n      {\n       "EncryptionType": "KMS",\n       "KeyId": "alias/aws/kinesis"\n      }\n     ]\n    },\n    "StreamModeDetails": {\n     "StreamMode": "ON_DEMAND"\n    }\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventStream/Resource"\n   }\n  },\n  "EventTable3F3CD4B2": {\n   "Type": "AWS::DynamoDB::Table",\n   "Properties": {\n    "AttributeDefinitions": [\n     {\n      "AttributeName": "eventId",\n      "AttributeType": "S"\n     }\n    ],\n    "BillingMode": "PAY_PER_REQUEST",\n    "KeySchema": [\n     {\n      "AttributeName": "eventId",\n      "KeyType": "HASH"\n     }\n    ]\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventTable/Resource"\n   }\n  },\n  "ProcessorServiceRole5039D372": {\n   "Type": "AWS::IAM::Role",\n   "Properties": {\n    "AssumeRolePolicyDocument": {\n     "Statement": [\n      {\n       "Action": "sts:AssumeRole",\n       "Effect": "Allow",\n       "Principal": {\n        "Service": "lambda.amazonaws.com"\n       }\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "ManagedPolicyArns": [\n     {\n      "Fn::Join": [\n       "",\n       [\n        "arn:",\n        {\n         "Ref": "AWS::Partition"\n        },\n        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"\n       ]\n      ]\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/Resource"\n   }\n  },\n  "ProcessorServiceRoleDefaultPolicyDA9D4DBA": {\n   "Type": "AWS::IAM::Policy",\n   "Properties": {\n    "PolicyDocument": {\n     "Statement": [\n      {\n       "Action": [\n        "kinesis:DescribeStreamSummary",\n        "kinesis:GetRecords",\n        "kinesis:GetShardIterator",\n        "kinesis:ListShards",\n        "kinesis:SubscribeToShard",\n        "kinesis:DescribeStream",\n        "kinesis:ListStreams",\n        "kinesis:DescribeStreamConsumer"\n       ],\n       "Effect": "Allow",\n       "Resource": {\n        "Fn::GetAtt": [\n         "EventStream271A91DB",\n         "Arn"\n        ]\n       }\n      },\n      {\n       "Action": [\n        "dynamodb:BatchWriteItem",\n        "dynamodb:PutItem",\n        "dynamodb:UpdateItem",\n        "dynamodb:DeleteItem",\n        "dynamodb:DescribeTable"\n       ],\n       "Effect": "Allow",\n       "Resource": [\n        {\n         "Fn::GetAtt": [\n          "EventTable3F3CD4B2",\n          "Arn"\n         ]\n        }\n       ]\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "PolicyName": "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "Roles": [\n     {\n      "Ref": "ProcessorServiceRole5039D372"\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/DefaultPolicy/Resource"\n   }\n  },\n  "Processor60228016": {\n   "Type": "AWS::Lambda::Function",\n   "Properties": {\n    "Code": {\n     "S3Bucket": {\n      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"\n     },\n     "S3Key": "ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5.zip"\n    },\n    "Environment": {\n     "Variables": {\n      "TABLE_NAME": {\n       "Ref": "EventTable3F3CD4B2"\n      }\n     }\n    },\n    "Handler": "index.handler",\n    "Role": {\n     "Fn::GetAtt": [\n      "ProcessorServiceRole5039D372",\n      "Arn"\n     ]\n    },\n    "Runtime": "nodejs22.x"\n   },\n   "DependsOn": [\n    "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "ProcessorServiceRole5039D372"\n   ],\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/Resource",\n    "aws:asset:path": "asset.ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5",\n    "aws:asset:is-bundled": true,\n    "aws:asset:property": "Code"\n   }\n  },\n  "ProcessorKinesisEventSourcetest347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE378F1CA5": {\n   "Type": "AWS::Lambda::EventSourceMapping",\n   "Properties": {\n    "BatchSize": 10,\n    "EventSourceArn": {\n     "Fn::GetAtt": [\n      "EventStream271A91DB",\n      "Arn"\n     ]\n    },\n    "FilterCriteria": {\n     "Filters": [\n      {\n       "Pattern": "{\\"data\\":{\\"payload\\":{\\"type\\":[\\"purchase\\"]}}}"\n      }\n     ]\n    },\n    "FunctionName": {\n     "Ref": "Processor60228016"\n    },\n    "StartingPosition": "TRIM_HORIZON"\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/KinesisEventSource:test347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE/Resource"\n   }\n  },\n  "CDKMetadata": {\n   "Type": "AWS::CDK::Metadata",\n   "Properties": {\n    "Analytics": "v2:deflate64:H4sIAAAAAAAA/2VQu27DMAz8lu4y2zoZujZGu7UN7OwGLTGB/KAMU0oQGPr3QnLQpdMd73BHkCWU+zd4ecKbFNoMxWg7WBuPelB4k3YdLJNYSdpCOKnqzBuLytwZJ2c6WE/YjZSsTKIaceoMtuwM9QLfGT4Da28dK4sTrLXbAhmPbrT6nsaNRSW7FkXIC7wnULKDQ9AD+QMKPephrc781/pxJfaNC4umL5xny5fU91+NMemVY2NzribJtsqLGo+XR/Qn+Dn4qNIR0MvztdzDa/pUL9YWS2BvJ4J6w1+9mSJwRgEAAA=="\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/CDKMetadata/Default"\n   },\n   "Condition": "CDKMetadataAvailable"\n  }\n },\n "Conditions": {\n  "AwsCdkKinesisEncryptedStreamsUnsupportedRegions": {\n   "Fn::Or": [\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-north-1"\n     ]\n    },\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-northwest-1"\n     ]\n    }\n   ]\n  },\n  "CDKMetadataAvailable": {\n   "Fn::Or": [\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "af-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-3"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-3"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-4"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-west-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-north-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-northwest-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n          … (2916 more bytes truncated)
2026-07-07T10:05:13.179 ERROR --- [et.reactor-1] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 2), invalid XML received:
b'PK\x03\x04\x14\x00\x08\x00\x08\x00\x00\x00!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00index.js\xec\xbdk{\x1b7\xb2 \xfc=\xbf\x02\xe6z\xbdTL\xb5.\x8e2\x19N\x18E\x91\x95\x89Nl\xcb#\xc9\x99\x99\xd5x\xe9\x16\tR\x1d\x91\xddLwS\x8e\xa2\xe8\xbf\xbfO\xdd\x80Bw\x93\xa2\x1c_r\xde\xdd|\x88\xc5\x06P(\x14\nuC\x01h\xcd\x0bk\x8a2O\x06e\xebo\x9f]\xc5\xb9\xe9\xf7\x07\xb9\x8dKkz\xe6\xe8\xfcg;(#\xfa-\xa5C;z\x99g3_<\xb4\xa3$\xb5\xf0\xcd\xe6\xe5\xb5T\x1b\xdb\xf2\xe8m\n_\x9f\xdab\xe0k\xfb\xefP\x1b\xca\xf2dVfy\xbd\xdd\x8bxj\x8bE\r\xb1P\xb5y\x99gev4\n\xaa\xe3\xb7\xf2zf\x8fFR\xf3".\x18+_s\x06M\xa1Z\xe4K\xf5Hl15=\xd3\x1e\xa5\x1d\x93\xdbb\xcd\xf4\xbe1\xa3y:(\x93,5\xfd~\x92&e{\xcd\xdc|fLn\xcby\x9e\x9aQj\x1e=2\xed\x1c\x91oov\xcc(=\xeb\xf7\xfd\xb8\x11\xf5\xf6(];\xdb|\xfdz\xad=JM\xcfl\xae\xad!\xf4\xbf}v+\xa8\x0e\xb2\xe94K\xff\xeb\x04\xfa\x1e\x9cw\xcc4\x1bV\xfb\xce\xed/\xf3$\xb7a\xf7\xd3lh~\xff\xdd@\xc7\x83\xf3\x86\x8e\x07\xe7\xdcq\x1bj\xf6\xcc\x8d\xb1\xbf\xce\xb2\xbc,\xba\xe6\xe6\xd6\xdc\xaeE\xfc\x93z\xc4\xff\xcb\'\x85\x1dU\x02\xdc\xca8\x1f\xdb\xb2c\xe2\xc9\x04\xf1\x03J\x8c\xb2\xdc\xb4\x81\x99\xd2xjM\x92b\xe1g\xc6\x18\xd3\xef3\xff\xb8vP\xa5cn\xcc\xd8\x96]\xa8w\x06\x1f^w\x8cM\xe7S\x9b\xc7\xe7\x13\xdb5e>\xb7\xe6vM\xf5?\xc8f\xd7\xc0\\\xc0 \xed2\xeb\x98Q\x9eM;\xc6\xfe:\xb0\xb3\xb2c\x86\xb6\x188l\x92\x91iC1L\x0b\xccs6\xc2\xda\xa6\xd7\xeb\x99V\x86<\xde\x02\x92\xd5\xcad\x9a[4\xbf<\xae\x89-\xcd\xa5\xbd6\xd9\xc84Lk\x9eM\xd7\xd6p\xa8\xc6@\xc7\x0f\xfa}\xcfV\xd1 \x9eL\x10\xddK{\xbd\x06\xf8\x00\xa0\x07\xbd\x1e#.\r\x03:e\x1d\xa8\xe5H\xd4&.\xc8\xb3\xe9\xd9\xa5\xbd\xae\x10\xeaA\x1bFnz\x01f\xb0\xc8\x90\x00\x08hm\r\xc6\n\xd5"Ob$\xae1\xb7\x9e\x8b\xcbLQ\xbb\xcc\x0eN\x9e\x03\xa5\xa7\xd9\xb0c\x92\xe2E6\xb4\xcf\xb3\xa1\xed\x18\x9a}D\x89g\xd4\xf4\x80U\xcd\x83\x9eI\xe7\x93\x89\xd9u\x02\xa5\x8d\xd4\xe2\x85\n\x90\xd6\xd6\x0c\xf0\\\x07j\xc8t\xb6?3fc\xc3\x1c\x8eLyaM2\x05\xce\xb4\xb9I\n\xe0\xa24\x1bZ3\xc8\xa6\xb3\xb8L\xce\x93IR^CW\xd6d\xb9)/\xa0Ja\xd2\xac4qj\x0eN\x9e\x13\xa0Q2\xb1\xa6\xbc\x88Ks\x11\x17\xe6\xdc\xda\xd4\x0c\xb2\xf4\xca\xe6\xa5\x1d\x9a23\xb1\xd9\x97u\x86U\xe7E\x92\x8eMl\xbe\x8b\xcf\xedd\x9d`H\x8f\x00)\x8f\xd3b\x94\xe5S\xd3N"\x1b\x99V\xbfo\x8b\xe7\xd9p>\xb1-\xec\x01\xfa\xc7^\n[\xaeu`\x10\xa9)lI\x80ZC;\x8a\xe7\x93\xb2\x05=\xc3\xf8\\\xdf\xad)\xc2\x90\x85\xd6\xc2\x15T\x1fn\xf4\x99Q\xd4\x87y|\xc0\xcb\x1d\xfe\x8d<2H\xf6\xeaJs\xdd\x03/]\xc5\x93\xb9\xed\x02\xfd\x1a\x97\x9a\xe9\xf2\xd4v>3P\xe9\xb3\xb55\x11Le\xe6\xd0&\x8e\xc0\xd9\xd7s\xe8\x179\xcc\xae\xa6\x91\xea\x99\xd74\x89\x99\xbf}\xf6\xd9\xc6\x06\xceo\x9f(QlD\xb3t6\xdd\xf8\xb6\x98&\xe5\xc5\xf5cX\x9b\xc5\xb7_D[_D\x9b\x1b@\x18W\x8fkl`\x8d\x8daR\x94\xeb\x83\x9f\x8b\x8d$\x1d\xda_\xa3\x9f\x0b\xd4i,(\xfbP\xda\x1f\xfc\x0cB\x03\xf0%\x01\xdb\x06\x89\xd5\n`\xbe\xa7\xbe[m\x96\xa5\xdb"@Z\x81\xba\x05\x81(5\xa2\x1f\xcar\xb67//\x9ee\x83\x18uK\xcf\\e\xc9\xd0l\xfe\r\xa5I[\x84Q\xbbZQ`\x1bS-9k\xfdp\xb0\xf7\xf4\xe0\xb8\xf5\xda\xf4L\xeb\xc2\xc6C\x9b\xb7\x08\\S\xe5\x7f\xbc:8\xfe7\xd5\xfden\xf3k\xaez\xbb\xe6\x86QG\x124\xcd\xb2!\xdc\xdc\x02\xe3\xd4\x07:K~\xb4\xd7\xab\x0f\xb7V\xddQ\x94\x07R\xafp\xf7\xe0\x9b\xda\xacJ\x83Z[\xd4\xb9!%\xeauz\xa6\x81\x1e\x07\xe9p\x96%i\xf9\xea\xf8\xd9\xc9\xe0\xc2N\xc1\xf2j\x9e\xf9ZM?\xf5\xb5\xa2\xb3\xd6\x0f\xa7\xa7/y\xe6\xcbr\xe6\xe6}A\xcd\x13_\xb5h\x98\xf8Z\xabp\xbc\xf5\xe2\xc6\xa1\xeeM\xc6Y\x9e\x94\x17\xd3C\xb0<\x9a\x07\xa9\xea\xf8\xe1\xa9\x8fg\xad\xe7Ow\x08\xd9\xe9p\xc7\r+\xa8\xb1\x7f\xbc\xffd\x9b\xea\x0c\xf2\xc1\x93\xed%\xb5\xf6U\xb5As\xbd\x93\x1f\xf6\xb6\xa8Vq\x11o-\xac\xb3\xbd\xf3\xa5\xab\x05\x7f\x13\xdb\xeb\xd5\xa3p\x0c\xc9\xa7\x0b4\xe1\xc0\x84\x1a\xdbr\xff\xc2\x0e.\x8b\xf9t?KG\xc9x\x9e\x8b|h\xe7\xf3\xb4L\xa6\x96\xbe;{\x07V\xdb K\x8b\xd2\x0c\xb8\xa1\x83\x0f\x92\xef\xec\xb5\x88\x00\xb0O\x02\x10Qq\x11o\xef|\x89\x16\t\xcd\x8e\x9f\x02\xd3\x00-\x9a\xcd\x8b\x0b\x94\x9f\xd0\'\xfc\x17\xfb\x19\xee\x1a2U\xdc\xa2pX\x1c\x0e\xa3\x93\x1f\xf6\xb6w\xbe\x04\xe5"\xff\t\xae\xfb\x80y>\x1f\x94Y.\x10\x9apt-\xc1,$\x18`\xbd\xc0\x7f\xf5aM\x87;`\x90|\xd8!=\x7f\xba\xf3N\xe3\x99\x0ew\x96\x0c\x86\x9d\n\xd0Q\xf4_<\x1c\n?8\x82\xb6\x81\xecz\xaa\x16O\x16\xd6\x14\x8a\x19s\xebQ\x96\tpP\x0bv,\xa4gF\xa5^O\x81\x93\xa9\xa0O\xb7\xf4\x0f\xb0qn\x8blre\x05\xf5c\xcd\xb9\xe8\xe2L\x12\x9b\x96\x0b99`\x01\xf0Z\x18\xb41\x03\xd50\xaa\xe3\xd6^\x8bFY~\x10\x0f.\xda\xedZi\xb0d\x8c\t:9\xab\xd5\x8e\x14s\xb7\xd7@\xa7\xd6\xab\xc8\x17\xc5\xc5m\xcf\xa0\xee/&e\xd0a\x8ddc[>%\x83q_\x8dq\xa5\xe5\xcf\xf0\x17\xc9\x8ep\xd53V\xf5\xc9\xe2\xde\x83\xb9\xda\xc1\xc9BA\x14POF\xb4d\x9a\xdb\x03j\x16\x0c\xd4I\x87\xef\x13;\x19\xbe\xcc\x8ad\xa9\xf1\x13\xd4\xf2\x1c\x1f|>\x0b\x7fi#h\x13-!\xb6\x8a\x08\x0fc\xc2\xea\xe1\xaf\xd6\xe9\xf1\xde\xe136\xa1\xb6\xb0\xb5|\xe1a(\xeb(h\x1aJ\xf8\xb0\xa8*\xe3O\x9e\x1f\x9e\xfe\xf0\xef\xfe\xfe\xd1\x8b\xd3\x83\x7f\x9d\xf6\x7f<\xf8\xf76Xl\xfd>Y\xbf\xfdA\x96\x96\xf6W\x88\xd0\xc0Zt$;L\x93\x13\x8b\x81\x88\xd3\xeb\xd9b\xb3!\xac\xe6\x89\x16~?k\xbd<>\xfa\xfe\xf0\xd9\x01)\xb1Y\x9e\x81C\xe4\xb4]\xb5\xf2\xc9\xc9Q\xff\xe4\xe0\xe4\xe4\xf0\xe8\x05k\xbd"[/lQ$Y\xba\xb8\xd1\xc1\xf1O\x87\xfb\x07lk\x146\xbfJ\x06\xb6\xc9\xdc\x08{\x0bIY)\xd3\xb4t\x949\xb6\xbf\xccmQ\xfe\x10\xa7\xc3\x89\xcd\xd1\xe7\x1cd\x93\x856GsuO\xa9\xe6r2\xb1\xfa\x9b\xfd\xbf\x12\x05.\xcar\xb6\xb1\x19\xfd\xd5\r\x7fi\xb3\xad\xfe\xa6j\xb6\x15m\xde\xd9\xec\xf4\xe9I\xff+iU\x0e\x8b\x8d\xaf\\#me4\xf7\x1a\xd2pA\x9dFZ\xd6\x99\xd3\xf4L\xfd\xe3v\x859\xef\x92^K\xcb+\xb0Xy4\xc9#\xd3\x13\xd5\xd2T\xba\x03\x80n?\x03\x1b\xe1\x0e\x07s^&\x93\xf5i2\x1cN\xec\xdb8\xb7\xdf~\x11mG[O\x9a]\xcdJ\xdd\x15\x9dNX\xd2\xf7\xf0:+\x9d\xfc1\x84V\xf1DAK\xa3\x13\x8d$\xc5\xc8\xa2s\x98E\x87\xb1Az\x82N\xf9>I\xa5\xad-V\t \xa2P\'\xb0\xb8:ChQ\x9dU^#3\xde]\x0b\xd9\x91X\x01:N\xb3|\x1aO\x92\xdf \xd6|\x95\x0cm\xfe\x17\xe88Igs\xeaVl$\xb0\xff\xa0\xebld\xb0\x90\x02}\xe2?\xb7|\x90\x8du\x16V\xa2n\xc4p\x9e\xe5\xd94)\x92Qb\xc1Qy\x89\xbfl\xc4l\xc8]J\x0b\x86B\xc6\xaejH\xe5\xacU\x9dd\x1a\xdb2\xa0\x9e\xe9\x81\x85\x1f|\xda\xda\xa2\xa6\xaeMm\xe0\xa6\xd7@\x0ch\xb4\x9c\xd5\xe3\xb7\xc5z1\xbc|<\xc8r\xfb\xed\x93\xe8\xaf\x7fy\x12m\xff\xa5\xc2\xe2\\g\x03\xea\x10c\xdbb\xa3\x98\x9fKX&\x1e\x0c\xb2yZ\xae\'\xc3u\xcb\x8e\xeb\xc6\x1e};\x1c\x8a\x1b\x08\xb1A\xb4\x80\xe2\xb4, \x08#\xc4\x87\xb0S2\x8cK\xdb\xd8\xa4\x8dA)\x12\xbbL\xd5\xbd\xfd\xfd\xa3W/N\xfb\x87O\xfb\x07/\x9e\xbe<:|q\xda\x7f~\xf4\xf4\xa0\xff\xd3\xde\xb3W\x07\'Q\x92\x0e&\xf3\xa1-\xb8\xe9\xdf>\xbb\xc5\x80\xcf\xd3\x83\xef\xf7^=;\xed/j\xde1\x8bJ\x180\x05\xbb \xb8\xdfoD\xd5\x8d\x0e\x17\xb5-\xa6\x8b\xa3H\x9f\x8c\xea-g\xbf\xdfE\x0e06f\xb9\x1d\xd9<\xb7C\xd6Cw\x10\x08\x1c\xc9\xd60) @?lut\xfb\x8eiq\xc0m\xd8B_\xf3\xcf\xc5\x95\xa3d|LVj.\xf1A\x8a3\xf7A\xe4\xf6\xbd\x0e\xc0\x1d\x19pZ\x16q\xc0(\x19\xaf\xc0\'\xaa\xbf?\x1f\xb3(\xe4\xa2\x9f\x0b\xcf1\xcd\x14A\xfcq3\xa0]\r\xa9n\xb7%\xd0\xb7\xc2\xa2\x11u\xc2\x02u\t}\x9b%<E7n\x0c\x0b\xa3P\xf0\x98[\xd3#\xc1/\x12\x9a\xaa7V\x16U\x02\xfdlvx\xc3\xa1\xca\x08QM\x00\xaf\xb5\x1b\xa1\x99\xdd]s\xd7Z\xab\xfa\x80\xbc\xc9\x1a\x17E2NI\xb5tp;\x91\xdd\xfd&\xd9\xda5qq\x9d\x0e8\xc0"z\x0f\x1a\xb8\xa1\x1e\x0eA\x08\x9b\x9e\x89\xdf\xc6I\xd9L)\x19\xbcL\x07\xf5\x88\xbbV\xcb\xe5t<\x18\x10\xfc5o#S\xe3\xf2"\xcf\xde\x9a\xd4\xbe5\x07y\x9e\xe5\xed7\x87)\x82\xa2\xfd\x06\xdc\xd6h\xa4\\\xd7<\xbcqPo#\xf3\x13\xe8\tjT\x988\xb7]%S\xaa\xc2\xc6I\xa1\xe8\x8d#.`#\xf1 \xf8\x9b\xd5\x89\xebBX\xc3\xd7\x928\x12*\xecO#\xb1`[m\xc9Z8\x9a\x81k\x8c\xfa\x14\xcc!\x9b\xe7\x1d\xd3G\x82w\xcc\xc1\x8b\x9f\x96(\xbb\xfd\xa3\x17\xdf\x1f\xfe}I\x85\x17\xa0R\x17J|n~\xf4\xf2\xf4\xf0\xe8\xc5\x89\x12y\xab!\xfc\xe9\xa4\xdej\xf8\x85\x82\xefn\x95/\xcb\xc5\xe69(N\xe1\xf0\xc6\x99#\x16f\x95J\x93\x05\xa2fj\x8b"\x1e\xdb \x82R]:R\x87X\x95\xed\xc8e\xf3\x0c\xc8\xec\xfd\xf3d\xe1<2\x16w0\x03@\xe1%\xdaO\x86}1\xf2`\xbfM\xa2\x01\xf7\xe1\x16\x88\xd5qP\xd0\xa6WI\x9e\xa5S\x9b\x96?\xc5y\x02\x96\xc3\x89\x9dX\x8e\xf4\xda\xf4* \x87\xc82\xb4\tM\xcf\xd8\xf4\xeal\xd9\xe8]T\x9b\x02\xc0\xd4\xec\xd1#\xf3`\xb9(#\x933\x14c4Om\x9b\xe7J\x9exi\xc2\xb2\x04[\x8a\x1cqqT\x8aq}\x9f\x04c\xe3`\xca\xd2\xf1q\x9d\xb3;\xa6\xe7O2L\xde\xc9\xee\xde\xa9\xeep\xee?\xa1L\r\xf6\x81\x9b\xf8\x9a\xbd,\x8e)\xf7\xfb\xf4[\xf4{\xb0\x04\xb8*\xa9\xe7\x85\xd2\x92<\x13\xd9\xbb\xb8\xa3\x1a\x84\xdf\xef\x98q\x81tG5\x80t\x97\xed!\xa0\xee\xaa\x07\xb0\x96\xad5\x81\xb3\xac\x0e\xc0\xb8\x8f\xa0\x10\x98\xf7i\x03}\xdcmC\n\xe4\xbbk\x02\xbc\xa5\xe2B@-\xad\x84\xe1&\xd0\xd0h\t7\xf0\xdc\xa7S\x88\xb2\x1a\x94\xa1\xbfL\xdf)\xef@\x94\xde= … (740554 more bytes truncated)
2026-07-07T10:05:15.466 ERROR --- [et.reactor-3] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 0), invalid XML received:
b'{\n "Resources": {\n  "EventStream271A91DB": {\n   "Type": "AWS::Kinesis::Stream",\n   "Properties": {\n    "RetentionPeriodHours": 24,\n    "StreamEncryption": {\n     "Fn::If": [\n      "AwsCdkKinesisEncryptedStreamsUnsupportedRegions",\n      {\n       "Ref": "AWS::NoValue"\n      },\n      {\n       "EncryptionType": "KMS",\n       "KeyId": "alias/aws/kinesis"\n      }\n     ]\n    },\n    "StreamModeDetails": {\n     "StreamMode": "ON_DEMAND"\n    }\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventStream/Resource"\n   }\n  },\n  "EventTable3F3CD4B2": {\n   "Type": "AWS::DynamoDB::Table",\n   "Properties": {\n    "AttributeDefinitions": [\n     {\n      "AttributeName": "eventId",\n      "AttributeType": "S"\n     }\n    ],\n    "BillingMode": "PAY_PER_REQUEST",\n    "KeySchema": [\n     {\n      "AttributeName": "eventId",\n      "KeyType": "HASH"\n     }\n    ]\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventTable/Resource"\n   }\n  },\n  "ProcessorServiceRole5039D372": {\n   "Type": "AWS::IAM::Role",\n   "Properties": {\n    "AssumeRolePolicyDocument": {\n     "Statement": [\n      {\n       "Action": "sts:AssumeRole",\n       "Effect": "Allow",\n       "Principal": {\n        "Service": "lambda.amazonaws.com"\n       }\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "ManagedPolicyArns": [\n     {\n      "Fn::Join": [\n       "",\n       [\n        "arn:",\n        {\n         "Ref": "AWS::Partition"\n        },\n        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"\n       ]\n      ]\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/Resource"\n   }\n  },\n  "ProcessorServiceRoleDefaultPolicyDA9D4DBA": {\n   "Type": "AWS::IAM::Policy",\n   "Properties": {\n    "PolicyDocument": {\n     "Statement": [\n      {\n       "Action": [\n        "kinesis:DescribeStreamSummary",\n        "kinesis:GetRecords",\n        "kinesis:GetShardIterator",\n        "kinesis:ListShards",\n        "kinesis:SubscribeToShard",\n        "kinesis:DescribeStream",\n        "kinesis:ListStreams",\n        "kinesis:DescribeStreamConsumer"\n       ],\n       "Effect": "Allow",\n       "Resource": {\n        "Fn::GetAtt": [\n         "EventStream271A91DB",\n         "Arn"\n        ]\n       }\n      },\n      {\n       "Action": [\n        "dynamodb:BatchWriteItem",\n        "dynamodb:PutItem",\n        "dynamodb:UpdateItem",\n        "dynamodb:DeleteItem",\n        "dynamodb:DescribeTable"\n       ],\n       "Effect": "Allow",\n       "Resource": [\n        {\n         "Fn::GetAtt": [\n          "EventTable3F3CD4B2",\n          "Arn"\n         ]\n        }\n       ]\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "PolicyName": "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "Roles": [\n     {\n      "Ref": "ProcessorServiceRole5039D372"\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/DefaultPolicy/Resource"\n   }\n  },\n  "Processor60228016": {\n   "Type": "AWS::Lambda::Function",\n   "Properties": {\n    "Code": {\n     "S3Bucket": {\n      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"\n     },\n     "S3Key": "ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5.zip"\n    },\n    "Environment": {\n     "Variables": {\n      "TABLE_NAME": {\n       "Ref": "EventTable3F3CD4B2"\n      }\n     }\n    },\n    "Handler": "index.handler",\n    "Role": {\n     "Fn::GetAtt": [\n      "ProcessorServiceRole5039D372",\n      "Arn"\n     ]\n    },\n    "Runtime": "nodejs22.x"\n   },\n   "DependsOn": [\n    "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "ProcessorServiceRole5039D372"\n   ],\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/Resource",\n    "aws:asset:path": "asset.ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5",\n    "aws:asset:is-bundled": true,\n    "aws:asset:property": "Code"\n   }\n  },\n  "ProcessorKinesisEventSourcetest347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE378F1CA5": {\n   "Type": "AWS::Lambda::EventSourceMapping",\n   "Properties": {\n    "BatchSize": 10,\n    "EventSourceArn": {\n     "Fn::GetAtt": [\n      "EventStream271A91DB",\n      "Arn"\n     ]\n    },\n    "FilterCriteria": {\n     "Filters": [\n      {\n       "Pattern": "{\\"data\\":{\\"payload\\":{\\"type\\":[\\"purchase\\"]}}}"\n      }\n     ]\n    },\n    "FunctionName": {\n     "Ref": "Processor60228016"\n    },\n    "StartingPosition": "TRIM_HORIZON"\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/KinesisEventSource:test347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE/Resource"\n   }\n  },\n  "CDKMetadata": {\n   "Type": "AWS::CDK::Metadata",\n   "Properties": {\n    "Analytics": "v2:deflate64:H4sIAAAAAAAA/2VQu27DMAz8lu4y2zoZujZGu7UN7OwGLTGB/KAMU0oQGPr3QnLQpdMd73BHkCWU+zd4ecKbFNoMxWg7WBuPelB4k3YdLJNYSdpCOKnqzBuLytwZJ2c6WE/YjZSsTKIaceoMtuwM9QLfGT4Da28dK4sTrLXbAhmPbrT6nsaNRSW7FkXIC7wnULKDQ9AD+QMKPephrc781/pxJfaNC4umL5xny5fU91+NMemVY2NzribJtsqLGo+XR/Qn+Dn4qNIR0MvztdzDa/pUL9YWS2BvJ4J6w1+9mSJwRgEAAA=="\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/CDKMetadata/Default"\n   },\n   "Condition": "CDKMetadataAvailable"\n  }\n },\n "Conditions": {\n  "AwsCdkKinesisEncryptedStreamsUnsupportedRegions": {\n   "Fn::Or": [\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-north-1"\n     ]\n    },\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-northwest-1"\n     ]\n    }\n   ]\n  },\n  "CDKMetadataAvailable": {\n   "Fn::Or": [\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "af-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-3"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-3"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-4"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-west-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-north-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-northwest-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n          … (2916 more bytes truncated)
2026-07-07T10:05:15.653 ERROR --- [et.reactor-5] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 2), invalid XML received:
b'PK\x03\x04\x14\x00\x08\x00\x08\x00\x00\x00!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00index.js\xec\xbdk{\x1b7\xb2 \xfc=\xbf\x02\xe6z\xbdTL\xb5.\x8e2\x19N\x18E\x91\x95\x89Nl\xcb#\xc9\x99\x99\xd5x\xe9\x16\tR\x1d\x91\xddLwS\x8e\xa2\xe8\xbf\xbfO\xdd\x80Bw\x93\xa2\x1c_r\xde\xdd|\x88\xc5\x06P(\x14\nuC\x01h\xcd\x0bk\x8a2O\x06e\xebo\x9f]\xc5\xb9\xe9\xf7\x07\xb9\x8dKkz\xe6\xe8\xfcg;(#\xfa-\xa5C;z\x99g3_<\xb4\xa3$\xb5\xf0\xcd\xe6\xe5\xb5T\x1b\xdb\xf2\xe8m\n_\x9f\xdab\xe0k\xfb\xefP\x1b\xca\xf2dVfy\xbd\xdd\x8bxj\x8bE\r\xb1P\xb5y\x99gev4\n\xaa\xe3\xb7\xf2zf\x8fFR\xf3".\x18+_s\x06M\xa1Z\xe4K\xf5Hl15=\xd3\x1e\xa5\x1d\x93\xdbb\xcd\xf4\xbe1\xa3y:(\x93,5\xfd~\x92&e{\xcd\xdc|fLn\xcby\x9e\x9aQj\x1e=2\xed\x1c\x91oov\xcc(=\xeb\xf7\xfd\xb8\x11\xf5\xf6(];\xdb|\xfdz\xad=JM\xcfl\xae\xad!\xf4\xbf}v+\xa8\x0e\xb2\xe94K\xff\xeb\x04\xfa\x1e\x9cw\xcc4\x1bV\xfb\xce\xed/\xf3$\xb7a\xf7\xd3lh~\xff\xdd@\xc7\x83\xf3\x86\x8e\x07\xe7\xdcq\x1bj\xf6\xcc\x8d\xb1\xbf\xce\xb2\xbc,\xba\xe6\xe6\xd6\xdc\xaeE\xfc\x93z\xc4\xff\xcb\'\x85\x1dU\x02\xdc\xca8\x1f\xdb\xb2c\xe2\xc9\x04\xf1\x03J\x8c\xb2\xdc\xb4\x81\x99\xd2xjM\x92b\xe1g\xc6\x18\xd3\xef3\xff\xb8vP\xa5cn\xcc\xd8\x96]\xa8w\x06\x1f^w\x8cM\xe7S\x9b\xc7\xe7\x13\xdb5e>\xb7\xe6vM\xf5?\xc8f\xd7\xc0\\\xc0 \xed2\xeb\x98Q\x9eM;\xc6\xfe:\xb0\xb3\xb2c\x86\xb6\x188l\x92\x91iC1L\x0b\xccs6\xc2\xda\xa6\xd7\xeb\x99V\x86<\xde\x02\x92\xd5\xcad\x9a[4\xbf<\xae\x89-\xcd\xa5\xbd6\xd9\xc84Lk\x9eM\xd7\xd6p\xa8\xc6@\xc7\x0f\xfa}\xcfV\xd1 \x9eL\x10\xddK{\xbd\x06\xf8\x00\xa0\x07\xbd\x1e#.\r\x03:e\x1d\xa8\xe5H\xd4&.\xc8\xb3\xe9\xd9\xa5\xbd\xae\x10\xeaA\x1bFnz\x01f\xb0\xc8\x90\x00\x08hm\r\xc6\n\xd5"Ob$\xae1\xb7\x9e\x8b\xcbLQ\xbb\xcc\x0eN\x9e\x03\xa5\xa7\xd9\xb0c\x92\xe2E6\xb4\xcf\xb3\xa1\xed\x18\x9a}D\x89g\xd4\xf4\x80U\xcd\x83\x9eI\xe7\x93\x89\xd9u\x02\xa5\x8d\xd4\xe2\x85\n\x90\xd6\xd6\x0c\xf0\\\x07j\xc8t\xb6?3fc\xc3\x1c\x8eLyaM2\x05\xce\xb4\xb9I\n\xe0\xa24\x1bZ3\xc8\xa6\xb3\xb8L\xce\x93IR^CW\xd6d\xb9)/\xa0Ja\xd2\xac4qj\x0eN\x9e\x13\xa0Q2\xb1\xa6\xbc\x88Ks\x11\x17\xe6\xdc\xda\xd4\x0c\xb2\xf4\xca\xe6\xa5\x1d\x9a23\xb1\xd9\x97u\x86U\xe7E\x92\x8eMl\xbe\x8b\xcf\xedd\x9d`H\x8f\x00)\x8f\xd3b\x94\xe5S\xd3N"\x1b\x99V\xbfo\x8b\xe7\xd9p>\xb1-\xec\x01\xfa\xc7^\n[\xaeu`\x10\xa9)lI\x80ZC;\x8a\xe7\x93\xb2\x05=\xc3\xf8\\\xdf\xad)\xc2\x90\x85\xd6\xc2\x15T\x1fn\xf4\x99Q\xd4\x87y|\xc0\xcb\x1d\xfe\x8d<2H\xf6\xeaJs\xdd\x03/]\xc5\x93\xb9\xed\x02\xfd\x1a\x97\x9a\xe9\xf2\xd4v>3P\xe9\xb3\xb55\x11Le\xe6\xd0&\x8e\xc0\xd9\xd7s\xe8\x179\xcc\xae\xa6\x91\xea\x99\xd74\x89\x99\xbf}\xf6\xd9\xc6\x06\xceo\x9f(QlD\xb3t6\xdd\xf8\xb6\x98&\xe5\xc5\xf5cX\x9b\xc5\xb7_D[_D\x9b\x1b@\x18W\x8fkl`\x8d\x8daR\x94\xeb\x83\x9f\x8b\x8d$\x1d\xda_\xa3\x9f\x0b\xd4i,(\xfbP\xda\x1f\xfc\x0cB\x03\xf0%\x01\xdb\x06\x89\xd5\n`\xbe\xa7\xbe[m\x96\xa5\xdb"@Z\x81\xba\x05\x81(5\xa2\x1f\xcar\xb67//\x9ee\x83\x18uK\xcf\\e\xc9\xd0l\xfe\r\xa5I[\x84Q\xbbZQ`\x1bS-9k\xfdp\xb0\xf7\xf4\xe0\xb8\xf5\xda\xf4L\xeb\xc2\xc6C\x9b\xb7\x08\\S\xe5\x7f\xbc:8\xfe7\xd5\xfden\xf3k\xaez\xbb\xe6\x86QG\x124\xcd\xb2!\xdc\xdc\x02\xe3\xd4\x07:K~\xb4\xd7\xab\x0f\xb7V\xddQ\x94\x07R\xafp\xf7\xe0\x9b\xda\xacJ\x83Z[\xd4\xb9!%\xeauz\xa6\x81\x1e\x07\xe9p\x96%i\xf9\xea\xf8\xd9\xc9\xe0\xc2N\xc1\xf2j\x9e\xf9ZM?\xf5\xb5\xa2\xb3\xd6\x0f\xa7\xa7/y\xe6\xcbr\xe6\xe6}A\xcd\x13_\xb5h\x98\xf8Z\xabp\xbc\xf5\xe2\xc6\xa1\xeeM\xc6Y\x9e\x94\x17\xd3C\xb0<\x9a\x07\xa9\xea\xf8\xe1\xa9\x8fg\xad\xe7Ow\x08\xd9\xe9p\xc7\r+\xa8\xb1\x7f\xbc\xffd\x9b\xea\x0c\xf2\xc1\x93\xed%\xb5\xf6U\xb5As\xbd\x93\x1f\xf6\xb6\xa8Vq\x11o-\xac\xb3\xbd\xf3\xa5\xab\x05\x7f\x13\xdb\xeb\xd5\xa3p\x0c\xc9\xa7\x0b4\xe1\xc0\x84\x1a\xdbr\xff\xc2\x0e.\x8b\xf9t?KG\xc9x\x9e\x8b|h\xe7\xf3\xb4L\xa6\x96\xbe;{\x07V\xdb K\x8b\xd2\x0c\xb8\xa1\x83\x0f\x92\xef\xec\xb5\x88\x00\xb0O\x02\x10Qq\x11o\xef|\x89\x16\t\xcd\x8e\x9f\x02\xd3\x00-\x9a\xcd\x8b\x0b\x94\x9f\xd0\'\xfc\x17\xfb\x19\xee\x1a2U\xdc\xa2pX\x1c\x0e\xa3\x93\x1f\xf6\xb6w\xbe\x04\xe5"\xff\t\xae\xfb\x80y>\x1f\x94Y.\x10\x9apt-\xc1,$\x18`\xbd\xc0\x7f\xf5aM\x87;`\x90|\xd8!=\x7f\xba\xf3N\xe3\x99\x0ew\x96\x0c\x86\x9d\n\xd0Q\xf4_<\x1c\n?8\x82\xb6\x81\xecz\xaa\x16O\x16\xd6\x14\x8a\x19s\xebQ\x96\tpP\x0bv,\xa4gF\xa5^O\x81\x93\xa9\xa0O\xb7\xf4\x0f\xb0qn\x8blre\x05\xf5c\xcd\xb9\xe8\xe2L\x12\x9b\x96\x0b99`\x01\xf0Z\x18\xb41\x03\xd50\xaa\xe3\xd6^\x8bFY~\x10\x0f.\xda\xedZi\xb0d\x8c\t:9\xab\xd5\x8e\x14s\xb7\xd7@\xa7\xd6\xab\xc8\x17\xc5\xc5m\xcf\xa0\xee/&e\xd0a\x8ddc[>%\x83q_\x8dq\xa5\xe5\xcf\xf0\x17\xc9\x8ep\xd53V\xf5\xc9\xe2\xde\x83\xb9\xda\xc1\xc9BA\x14POF\xb4d\x9a\xdb\x03j\x16\x0c\xd4I\x87\xef\x13;\x19\xbe\xcc\x8ad\xa9\xf1\x13\xd4\xf2\x1c\x1f|>\x0b\x7fi#h\x13-!\xb6\x8a\x08\x0fc\xc2\xea\xe1\xaf\xd6\xe9\xf1\xde\xe136\xa1\xb6\xb0\xb5|\xe1a(\xeb(h\x1aJ\xf8\xb0\xa8*\xe3O\x9e\x1f\x9e\xfe\xf0\xef\xfe\xfe\xd1\x8b\xd3\x83\x7f\x9d\xf6\x7f<\xf8\xf76Xl\xfd>Y\xbf\xfdA\x96\x96\xf6W\x88\xd0\xc0Zt$;L\x93\x13\x8b\x81\x88\xd3\xeb\xd9b\xb3!\xac\xe6\x89\x16~?k\xbd<>\xfa\xfe\xf0\xd9\x01)\xb1Y\x9e\x81C\xe4\xb4]\xb5\xf2\xc9\xc9Q\xff\xe4\xe0\xe4\xe4\xf0\xe8\x05k\xbd"[/lQ$Y\xba\xb8\xd1\xc1\xf1O\x87\xfb\x07lk\x146\xbfJ\x06\xb6\xc9\xdc\x08{\x0bIY)\xd3\xb4t\x949\xb6\xbf\xccmQ\xfe\x10\xa7\xc3\x89\xcd\xd1\xe7\x1cd\x93\x856GsuO\xa9\xe6r2\xb1\xfa\x9b\xfd\xbf\x12\x05.\xcar\xb6\xb1\x19\xfd\xd5\r\x7fi\xb3\xad\xfe\xa6j\xb6\x15m\xde\xd9\xec\xf4\xe9I\xff+iU\x0e\x8b\x8d\xaf\\#me4\xf7\x1a\xd2pA\x9dFZ\xd6\x99\xd3\xf4L\xfd\xe3v\x859\xef\x92^K\xcb+\xb0Xy4\xc9#\xd3\x13\xd5\xd2T\xba\x03\x80n?\x03\x1b\xe1\x0e\x07s^&\x93\xf5i2\x1cN\xec\xdb8\xb7\xdf~\x11mG[O\x9a]\xcdJ\xdd\x15\x9dNX\xd2\xf7\xf0:+\x9d\xfc1\x84V\xf1DAK\xa3\x13\x8d$\xc5\xc8\xa2s\x98E\x87\xb1Az\x82N\xf9>I\xa5\xad-V\t \xa2P\'\xb0\xb8:ChQ\x9dU^#3\xde]\x0b\xd9\x91X\x01:N\xb3|\x1aO\x92\xdf \xd6|\x95\x0cm\xfe\x17\xe88Igs\xeaVl$\xb0\xff\xa0\xebld\xb0\x90\x02}\xe2?\xb7|\x90\x8du\x16V\xa2n\xc4p\x9e\xe5\xd94)\x92Qb\xc1Qy\x89\xbfl\xc4l\xc8]J\x0b\x86B\xc6\xaejH\xe5\xacU\x9dd\x1a\xdb2\xa0\x9e\xe9\x81\x85\x1f|\xda\xda\xa2\xa6\xaeMm\xe0\xa6\xd7@\x0ch\xb4\x9c\xd5\xe3\xb7\xc5z1\xbc|<\xc8r\xfb\xed\x93\xe8\xaf\x7fy\x12m\xff\xa5\xc2\xe2\\g\x03\xea\x10c\xdbb\xa3\x98\x9fKX&\x1e\x0c\xb2yZ\xae\'\xc3u\xcb\x8e\xeb\xc6\x1e};\x1c\x8a\x1b\x08\xb1A\xb4\x80\xe2\xb4, \x08#\xc4\x87\xb0S2\x8cK\xdb\xd8\xa4\x8dA)\x12\xbbL\xd5\xbd\xfd\xfd\xa3W/N\xfb\x87O\xfb\x07/\x9e\xbe<:|q\xda\x7f~\xf4\xf4\xa0\xff\xd3\xde\xb3W\x07\'Q\x92\x0e&\xf3\xa1-\xb8\xe9\xdf>\xbb\xc5\x80\xcf\xd3\x83\xef\xf7^=;\xed/j\xde1\x8bJ\x180\x05\xbb \xb8\xdfoD\xd5\x8d\x0e\x17\xb5-\xa6\x8b\xa3H\x9f\x8c\xea-g\xbf\xdfE\x0e06f\xb9\x1d\xd9<\xb7C\xd6Cw\x10\x08\x1c\xc9\xd60) @?lut\xfb\x8eiq\xc0m\xd8B_\xf3\xcf\xc5\x95\xa3d|LVj.\xf1A\x8a3\xf7A\xe4\xf6\xbd\x0e\xc0\x1d\x19pZ\x16q\xc0(\x19\xaf\xc0\'\xaa\xbf?\x1f\xb3(\xe4\xa2\x9f\x0b\xcf1\xcd\x14A\xfcq3\xa0]\r\xa9n\xb7%\xd0\xb7\xc2\xa2\x11u\xc2\x02u\t}\x9b%<E7n\x0c\x0b\xa3P\xf0\x98[\xd3#\xc1/\x12\x9a\xaa7V\x16U\x02\xfdlvx\xc3\xa1\xca\x08QM\x00\xaf\xb5\x1b\xa1\x99\xdd]s\xd7Z\xab\xfa\x80\xbc\xc9\x1a\x17E2NI\xb5tp;\x91\xdd\xfd&\xd9\xda5qq\x9d\x0e8\xc0"z\x0f\x1a\xb8\xa1\x1e\x0eA\x08\x9b\x9e\x89\xdf\xc6I\xd9L)\x19\xbcL\x07\xf5\x88\xbbV\xcb\xe5t<\x18\x10\xfc5o#S\xe3\xf2"\xcf\xde\x9a\xd4\xbe5\x07y\x9e\xe5\xed7\x87)\x82\xa2\xfd\x06\xdc\xd6h\xa4\\\xd7<\xbcqPo#\xf3\x13\xe8\tjT\x988\xb7]%S\xaa\xc2\xc6I\xa1\xe8\x8d#.`#\xf1 \xf8\x9b\xd5\x89\xebBX\xc3\xd7\x928\x12*\xecO#\xb1`[m\xc9Z8\x9a\x81k\x8c\xfa\x14\xcc!\x9b\xe7\x1d\xd3G\x82w\xcc\xc1\x8b\x9f\x96(\xbb\xfd\xa3\x17\xdf\x1f\xfe}I\x85\x17\xa0R\x17J|n~\xf4\xf2\xf4\xf0\xe8\xc5\x89\x12y\xab!\xfc\xe9\xa4\xdej\xf8\x85\x82\xefn\x95/\xcb\xc5\xe69(N\xe1\xf0\xc6\x99#\x16f\x95J\x93\x05\xa2fj\x8b"\x1e\xdb \x82R]:R\x87X\x95\xed\xc8e\xf3\x0c\xc8\xec\xfd\xf3d\xe1<2\x16w0\x03@\xe1%\xdaO\x86}1\xf2`\xbfM\xa2\x01\xf7\xe1\x16\x88\xd5qP\xd0\xa6WI\x9e\xa5S\x9b\x96?\xc5y\x02\x96\xc3\x89\x9dX\x8e\xf4\xda\xf4* \x87\xc82\xb4\tM\xcf\xd8\xf4\xeal\xd9\xe8]T\x9b\x02\xc0\xd4\xec\xd1#\xf3`\xb9(#\x933\x14c4Om\x9b\xe7J\x9exi\xc2\xb2\x04[\x8a\x1cqqT\x8aq}\x9f\x04c\xe3`\xca\xd2\xf1q\x9d\xb3;\xa6\xe7O2L\xde\xc9\xee\xde\xa9\xeep\xee?\xa1L\r\xf6\x81\x9b\xf8\x9a\xbd,\x8e)\xf7\xfb\xf4[\xf4{\xb0\x04\xb8*\xa9\xe7\x85\xd2\x92<\x13\xd9\xbb\xb8\xa3\x1a\x84\xdf\xef\x98q\x81tG5\x80t\x97\xed!\xa0\xee\xaa\x07\xb0\x96\xad5\x81\xb3\xac\x0e\xc0\xb8\x8f\xa0\x10\x98\xf7i\x03}\xdcmC\n\xe4\xbbk\x02\xbc\xa5\xe2B@-\xad\x84\xe1&\xd0\xd0h\t7\xf0\xdc\xa7S\x88\xb2\x1a\x94\xa1\xbfL\xdf)\xef@\x94\xde= … (740554 more bytes truncated)
2026-07-07T10:05:20.280 ERROR --- [et.reactor-1] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 0), invalid XML received:
b'{\n "Resources": {\n  "EventStream271A91DB": {\n   "Type": "AWS::Kinesis::Stream",\n   "Properties": {\n    "RetentionPeriodHours": 24,\n    "StreamEncryption": {\n     "Fn::If": [\n      "AwsCdkKinesisEncryptedStreamsUnsupportedRegions",\n      {\n       "Ref": "AWS::NoValue"\n      },\n      {\n       "EncryptionType": "KMS",\n       "KeyId": "alias/aws/kinesis"\n      }\n     ]\n    },\n    "StreamModeDetails": {\n     "StreamMode": "ON_DEMAND"\n    }\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventStream/Resource"\n   }\n  },\n  "EventTable3F3CD4B2": {\n   "Type": "AWS::DynamoDB::Table",\n   "Properties": {\n    "AttributeDefinitions": [\n     {\n      "AttributeName": "eventId",\n      "AttributeType": "S"\n     }\n    ],\n    "BillingMode": "PAY_PER_REQUEST",\n    "KeySchema": [\n     {\n      "AttributeName": "eventId",\n      "KeyType": "HASH"\n     }\n    ]\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventTable/Resource"\n   }\n  },\n  "ProcessorServiceRole5039D372": {\n   "Type": "AWS::IAM::Role",\n   "Properties": {\n    "AssumeRolePolicyDocument": {\n     "Statement": [\n      {\n       "Action": "sts:AssumeRole",\n       "Effect": "Allow",\n       "Principal": {\n        "Service": "lambda.amazonaws.com"\n       }\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "ManagedPolicyArns": [\n     {\n      "Fn::Join": [\n       "",\n       [\n        "arn:",\n        {\n         "Ref": "AWS::Partition"\n        },\n        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"\n       ]\n      ]\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/Resource"\n   }\n  },\n  "ProcessorServiceRoleDefaultPolicyDA9D4DBA": {\n   "Type": "AWS::IAM::Policy",\n   "Properties": {\n    "PolicyDocument": {\n     "Statement": [\n      {\n       "Action": [\n        "kinesis:DescribeStreamSummary",\n        "kinesis:GetRecords",\n        "kinesis:GetShardIterator",\n        "kinesis:ListShards",\n        "kinesis:SubscribeToShard",\n        "kinesis:DescribeStream",\n        "kinesis:ListStreams",\n        "kinesis:DescribeStreamConsumer"\n       ],\n       "Effect": "Allow",\n       "Resource": {\n        "Fn::GetAtt": [\n         "EventStream271A91DB",\n         "Arn"\n        ]\n       }\n      },\n      {\n       "Action": [\n        "dynamodb:BatchWriteItem",\n        "dynamodb:PutItem",\n        "dynamodb:UpdateItem",\n        "dynamodb:DeleteItem",\n        "dynamodb:DescribeTable"\n       ],\n       "Effect": "Allow",\n       "Resource": [\n        {\n         "Fn::GetAtt": [\n          "EventTable3F3CD4B2",\n          "Arn"\n         ]\n        }\n       ]\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "PolicyName": "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "Roles": [\n     {\n      "Ref": "ProcessorServiceRole5039D372"\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/DefaultPolicy/Resource"\n   }\n  },\n  "Processor60228016": {\n   "Type": "AWS::Lambda::Function",\n   "Properties": {\n    "Code": {\n     "S3Bucket": {\n      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"\n     },\n     "S3Key": "ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5.zip"\n    },\n    "Environment": {\n     "Variables": {\n      "TABLE_NAME": {\n       "Ref": "EventTable3F3CD4B2"\n      }\n     }\n    },\n    "Handler": "index.handler",\n    "Role": {\n     "Fn::GetAtt": [\n      "ProcessorServiceRole5039D372",\n      "Arn"\n     ]\n    },\n    "Runtime": "nodejs22.x"\n   },\n   "DependsOn": [\n    "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "ProcessorServiceRole5039D372"\n   ],\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/Resource",\n    "aws:asset:path": "asset.ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5",\n    "aws:asset:is-bundled": true,\n    "aws:asset:property": "Code"\n   }\n  },\n  "ProcessorKinesisEventSourcetest347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE378F1CA5": {\n   "Type": "AWS::Lambda::EventSourceMapping",\n   "Properties": {\n    "BatchSize": 10,\n    "EventSourceArn": {\n     "Fn::GetAtt": [\n      "EventStream271A91DB",\n      "Arn"\n     ]\n    },\n    "FilterCriteria": {\n     "Filters": [\n      {\n       "Pattern": "{\\"data\\":{\\"payload\\":{\\"type\\":[\\"purchase\\"]}}}"\n      }\n     ]\n    },\n    "FunctionName": {\n     "Ref": "Processor60228016"\n    },\n    "StartingPosition": "TRIM_HORIZON"\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/KinesisEventSource:test347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE/Resource"\n   }\n  },\n  "CDKMetadata": {\n   "Type": "AWS::CDK::Metadata",\n   "Properties": {\n    "Analytics": "v2:deflate64:H4sIAAAAAAAA/2VQu27DMAz8lu4y2zoZujZGu7UN7OwGLTGB/KAMU0oQGPr3QnLQpdMd73BHkCWU+zd4ecKbFNoMxWg7WBuPelB4k3YdLJNYSdpCOKnqzBuLytwZJ2c6WE/YjZSsTKIaceoMtuwM9QLfGT4Da28dK4sTrLXbAhmPbrT6nsaNRSW7FkXIC7wnULKDQ9AD+QMKPephrc781/pxJfaNC4umL5xny5fU91+NMemVY2NzribJtsqLGo+XR/Qn+Dn4qNIR0MvztdzDa/pUL9YWS2BvJ4J6w1+9mSJwRgEAAA=="\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/CDKMetadata/Default"\n   },\n   "Condition": "CDKMetadataAvailable"\n  }\n },\n "Conditions": {\n  "AwsCdkKinesisEncryptedStreamsUnsupportedRegions": {\n   "Fn::Or": [\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-north-1"\n     ]\n    },\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-northwest-1"\n     ]\n    }\n   ]\n  },\n  "CDKMetadataAvailable": {\n   "Fn::Or": [\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "af-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-3"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-3"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-4"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-west-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-north-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-northwest-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n          … (2916 more bytes truncated)
2026-07-07T10:05:20.537 ERROR --- [et.reactor-4] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 2), invalid XML received:
b'PK\x03\x04\x14\x00\x08\x00\x08\x00\x00\x00!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00index.js\xec\xbdk{\x1b7\xb2 \xfc=\xbf\x02\xe6z\xbdTL\xb5.\x8e2\x19N\x18E\x91\x95\x89Nl\xcb#\xc9\x99\x99\xd5x\xe9\x16\tR\x1d\x91\xddLwS\x8e\xa2\xe8\xbf\xbfO\xdd\x80Bw\x93\xa2\x1c_r\xde\xdd|\x88\xc5\x06P(\x14\nuC\x01h\xcd\x0bk\x8a2O\x06e\xebo\x9f]\xc5\xb9\xe9\xf7\x07\xb9\x8dKkz\xe6\xe8\xfcg;(#\xfa-\xa5C;z\x99g3_<\xb4\xa3$\xb5\xf0\xcd\xe6\xe5\xb5T\x1b\xdb\xf2\xe8m\n_\x9f\xdab\xe0k\xfb\xefP\x1b\xca\xf2dVfy\xbd\xdd\x8bxj\x8bE\r\xb1P\xb5y\x99gev4\n\xaa\xe3\xb7\xf2zf\x8fFR\xf3".\x18+_s\x06M\xa1Z\xe4K\xf5Hl15=\xd3\x1e\xa5\x1d\x93\xdbb\xcd\xf4\xbe1\xa3y:(\x93,5\xfd~\x92&e{\xcd\xdc|fLn\xcby\x9e\x9aQj\x1e=2\xed\x1c\x91oov\xcc(=\xeb\xf7\xfd\xb8\x11\xf5\xf6(];\xdb|\xfdz\xad=JM\xcfl\xae\xad!\xf4\xbf}v+\xa8\x0e\xb2\xe94K\xff\xeb\x04\xfa\x1e\x9cw\xcc4\x1bV\xfb\xce\xed/\xf3$\xb7a\xf7\xd3lh~\xff\xdd@\xc7\x83\xf3\x86\x8e\x07\xe7\xdcq\x1bj\xf6\xcc\x8d\xb1\xbf\xce\xb2\xbc,\xba\xe6\xe6\xd6\xdc\xaeE\xfc\x93z\xc4\xff\xcb\'\x85\x1dU\x02\xdc\xca8\x1f\xdb\xb2c\xe2\xc9\x04\xf1\x03J\x8c\xb2\xdc\xb4\x81\x99\xd2xjM\x92b\xe1g\xc6\x18\xd3\xef3\xff\xb8vP\xa5cn\xcc\xd8\x96]\xa8w\x06\x1f^w\x8cM\xe7S\x9b\xc7\xe7\x13\xdb5e>\xb7\xe6vM\xf5?\xc8f\xd7\xc0\\\xc0 \xed2\xeb\x98Q\x9eM;\xc6\xfe:\xb0\xb3\xb2c\x86\xb6\x188l\x92\x91iC1L\x0b\xccs6\xc2\xda\xa6\xd7\xeb\x99V\x86<\xde\x02\x92\xd5\xcad\x9a[4\xbf<\xae\x89-\xcd\xa5\xbd6\xd9\xc84Lk\x9eM\xd7\xd6p\xa8\xc6@\xc7\x0f\xfa}\xcfV\xd1 \x9eL\x10\xddK{\xbd\x06\xf8\x00\xa0\x07\xbd\x1e#.\r\x03:e\x1d\xa8\xe5H\xd4&.\xc8\xb3\xe9\xd9\xa5\xbd\xae\x10\xeaA\x1bFnz\x01f\xb0\xc8\x90\x00\x08hm\r\xc6\n\xd5"Ob$\xae1\xb7\x9e\x8b\xcbLQ\xbb\xcc\x0eN\x9e\x03\xa5\xa7\xd9\xb0c\x92\xe2E6\xb4\xcf\xb3\xa1\xed\x18\x9a}D\x89g\xd4\xf4\x80U\xcd\x83\x9eI\xe7\x93\x89\xd9u\x02\xa5\x8d\xd4\xe2\x85\n\x90\xd6\xd6\x0c\xf0\\\x07j\xc8t\xb6?3fc\xc3\x1c\x8eLyaM2\x05\xce\xb4\xb9I\n\xe0\xa24\x1bZ3\xc8\xa6\xb3\xb8L\xce\x93IR^CW\xd6d\xb9)/\xa0Ja\xd2\xac4qj\x0eN\x9e\x13\xa0Q2\xb1\xa6\xbc\x88Ks\x11\x17\xe6\xdc\xda\xd4\x0c\xb2\xf4\xca\xe6\xa5\x1d\x9a23\xb1\xd9\x97u\x86U\xe7E\x92\x8eMl\xbe\x8b\xcf\xedd\x9d`H\x8f\x00)\x8f\xd3b\x94\xe5S\xd3N"\x1b\x99V\xbfo\x8b\xe7\xd9p>\xb1-\xec\x01\xfa\xc7^\n[\xaeu`\x10\xa9)lI\x80ZC;\x8a\xe7\x93\xb2\x05=\xc3\xf8\\\xdf\xad)\xc2\x90\x85\xd6\xc2\x15T\x1fn\xf4\x99Q\xd4\x87y|\xc0\xcb\x1d\xfe\x8d<2H\xf6\xeaJs\xdd\x03/]\xc5\x93\xb9\xed\x02\xfd\x1a\x97\x9a\xe9\xf2\xd4v>3P\xe9\xb3\xb55\x11Le\xe6\xd0&\x8e\xc0\xd9\xd7s\xe8\x179\xcc\xae\xa6\x91\xea\x99\xd74\x89\x99\xbf}\xf6\xd9\xc6\x06\xceo\x9f(QlD\xb3t6\xdd\xf8\xb6\x98&\xe5\xc5\xf5cX\x9b\xc5\xb7_D[_D\x9b\x1b@\x18W\x8fkl`\x8d\x8daR\x94\xeb\x83\x9f\x8b\x8d$\x1d\xda_\xa3\x9f\x0b\xd4i,(\xfbP\xda\x1f\xfc\x0cB\x03\xf0%\x01\xdb\x06\x89\xd5\n`\xbe\xa7\xbe[m\x96\xa5\xdb"@Z\x81\xba\x05\x81(5\xa2\x1f\xcar\xb67//\x9ee\x83\x18uK\xcf\\e\xc9\xd0l\xfe\r\xa5I[\x84Q\xbbZQ`\x1bS-9k\xfdp\xb0\xf7\xf4\xe0\xb8\xf5\xda\xf4L\xeb\xc2\xc6C\x9b\xb7\x08\\S\xe5\x7f\xbc:8\xfe7\xd5\xfden\xf3k\xaez\xbb\xe6\x86QG\x124\xcd\xb2!\xdc\xdc\x02\xe3\xd4\x07:K~\xb4\xd7\xab\x0f\xb7V\xddQ\x94\x07R\xafp\xf7\xe0\x9b\xda\xacJ\x83Z[\xd4\xb9!%\xeauz\xa6\x81\x1e\x07\xe9p\x96%i\xf9\xea\xf8\xd9\xc9\xe0\xc2N\xc1\xf2j\x9e\xf9ZM?\xf5\xb5\xa2\xb3\xd6\x0f\xa7\xa7/y\xe6\xcbr\xe6\xe6}A\xcd\x13_\xb5h\x98\xf8Z\xabp\xbc\xf5\xe2\xc6\xa1\xeeM\xc6Y\x9e\x94\x17\xd3C\xb0<\x9a\x07\xa9\xea\xf8\xe1\xa9\x8fg\xad\xe7Ow\x08\xd9\xe9p\xc7\r+\xa8\xb1\x7f\xbc\xffd\x9b\xea\x0c\xf2\xc1\x93\xed%\xb5\xf6U\xb5As\xbd\x93\x1f\xf6\xb6\xa8Vq\x11o-\xac\xb3\xbd\xf3\xa5\xab\x05\x7f\x13\xdb\xeb\xd5\xa3p\x0c\xc9\xa7\x0b4\xe1\xc0\x84\x1a\xdbr\xff\xc2\x0e.\x8b\xf9t?KG\xc9x\x9e\x8b|h\xe7\xf3\xb4L\xa6\x96\xbe;{\x07V\xdb K\x8b\xd2\x0c\xb8\xa1\x83\x0f\x92\xef\xec\xb5\x88\x00\xb0O\x02\x10Qq\x11o\xef|\x89\x16\t\xcd\x8e\x9f\x02\xd3\x00-\x9a\xcd\x8b\x0b\x94\x9f\xd0\'\xfc\x17\xfb\x19\xee\x1a2U\xdc\xa2pX\x1c\x0e\xa3\x93\x1f\xf6\xb6w\xbe\x04\xe5"\xff\t\xae\xfb\x80y>\x1f\x94Y.\x10\x9apt-\xc1,$\x18`\xbd\xc0\x7f\xf5aM\x87;`\x90|\xd8!=\x7f\xba\xf3N\xe3\x99\x0ew\x96\x0c\x86\x9d\n\xd0Q\xf4_<\x1c\n?8\x82\xb6\x81\xecz\xaa\x16O\x16\xd6\x14\x8a\x19s\xebQ\x96\tpP\x0bv,\xa4gF\xa5^O\x81\x93\xa9\xa0O\xb7\xf4\x0f\xb0qn\x8blre\x05\xf5c\xcd\xb9\xe8\xe2L\x12\x9b\x96\x0b99`\x01\xf0Z\x18\xb41\x03\xd50\xaa\xe3\xd6^\x8bFY~\x10\x0f.\xda\xedZi\xb0d\x8c\t:9\xab\xd5\x8e\x14s\xb7\xd7@\xa7\xd6\xab\xc8\x17\xc5\xc5m\xcf\xa0\xee/&e\xd0a\x8ddc[>%\x83q_\x8dq\xa5\xe5\xcf\xf0\x17\xc9\x8ep\xd53V\xf5\xc9\xe2\xde\x83\xb9\xda\xc1\xc9BA\x14POF\xb4d\x9a\xdb\x03j\x16\x0c\xd4I\x87\xef\x13;\x19\xbe\xcc\x8ad\xa9\xf1\x13\xd4\xf2\x1c\x1f|>\x0b\x7fi#h\x13-!\xb6\x8a\x08\x0fc\xc2\xea\xe1\xaf\xd6\xe9\xf1\xde\xe136\xa1\xb6\xb0\xb5|\xe1a(\xeb(h\x1aJ\xf8\xb0\xa8*\xe3O\x9e\x1f\x9e\xfe\xf0\xef\xfe\xfe\xd1\x8b\xd3\x83\x7f\x9d\xf6\x7f<\xf8\xf76Xl\xfd>Y\xbf\xfdA\x96\x96\xf6W\x88\xd0\xc0Zt$;L\x93\x13\x8b\x81\x88\xd3\xeb\xd9b\xb3!\xac\xe6\x89\x16~?k\xbd<>\xfa\xfe\xf0\xd9\x01)\xb1Y\x9e\x81C\xe4\xb4]\xb5\xf2\xc9\xc9Q\xff\xe4\xe0\xe4\xe4\xf0\xe8\x05k\xbd"[/lQ$Y\xba\xb8\xd1\xc1\xf1O\x87\xfb\x07lk\x146\xbfJ\x06\xb6\xc9\xdc\x08{\x0bIY)\xd3\xb4t\x949\xb6\xbf\xccmQ\xfe\x10\xa7\xc3\x89\xcd\xd1\xe7\x1cd\x93\x856GsuO\xa9\xe6r2\xb1\xfa\x9b\xfd\xbf\x12\x05.\xcar\xb6\xb1\x19\xfd\xd5\r\x7fi\xb3\xad\xfe\xa6j\xb6\x15m\xde\xd9\xec\xf4\xe9I\xff+iU\x0e\x8b\x8d\xaf\\#me4\xf7\x1a\xd2pA\x9dFZ\xd6\x99\xd3\xf4L\xfd\xe3v\x859\xef\x92^K\xcb+\xb0Xy4\xc9#\xd3\x13\xd5\xd2T\xba\x03\x80n?\x03\x1b\xe1\x0e\x07s^&\x93\xf5i2\x1cN\xec\xdb8\xb7\xdf~\x11mG[O\x9a]\xcdJ\xdd\x15\x9dNX\xd2\xf7\xf0:+\x9d\xfc1\x84V\xf1DAK\xa3\x13\x8d$\xc5\xc8\xa2s\x98E\x87\xb1Az\x82N\xf9>I\xa5\xad-V\t \xa2P\'\xb0\xb8:ChQ\x9dU^#3\xde]\x0b\xd9\x91X\x01:N\xb3|\x1aO\x92\xdf \xd6|\x95\x0cm\xfe\x17\xe88Igs\xeaVl$\xb0\xff\xa0\xebld\xb0\x90\x02}\xe2?\xb7|\x90\x8du\x16V\xa2n\xc4p\x9e\xe5\xd94)\x92Qb\xc1Qy\x89\xbfl\xc4l\xc8]J\x0b\x86B\xc6\xaejH\xe5\xacU\x9dd\x1a\xdb2\xa0\x9e\xe9\x81\x85\x1f|\xda\xda\xa2\xa6\xaeMm\xe0\xa6\xd7@\x0ch\xb4\x9c\xd5\xe3\xb7\xc5z1\xbc|<\xc8r\xfb\xed\x93\xe8\xaf\x7fy\x12m\xff\xa5\xc2\xe2\\g\x03\xea\x10c\xdbb\xa3\x98\x9fKX&\x1e\x0c\xb2yZ\xae\'\xc3u\xcb\x8e\xeb\xc6\x1e};\x1c\x8a\x1b\x08\xb1A\xb4\x80\xe2\xb4, \x08#\xc4\x87\xb0S2\x8cK\xdb\xd8\xa4\x8dA)\x12\xbbL\xd5\xbd\xfd\xfd\xa3W/N\xfb\x87O\xfb\x07/\x9e\xbe<:|q\xda\x7f~\xf4\xf4\xa0\xff\xd3\xde\xb3W\x07\'Q\x92\x0e&\xf3\xa1-\xb8\xe9\xdf>\xbb\xc5\x80\xcf\xd3\x83\xef\xf7^=;\xed/j\xde1\x8bJ\x180\x05\xbb \xb8\xdfoD\xd5\x8d\x0e\x17\xb5-\xa6\x8b\xa3H\x9f\x8c\xea-g\xbf\xdfE\x0e06f\xb9\x1d\xd9<\xb7C\xd6Cw\x10\x08\x1c\xc9\xd60) @?lut\xfb\x8eiq\xc0m\xd8B_\xf3\xcf\xc5\x95\xa3d|LVj.\xf1A\x8a3\xf7A\xe4\xf6\xbd\x0e\xc0\x1d\x19pZ\x16q\xc0(\x19\xaf\xc0\'\xaa\xbf?\x1f\xb3(\xe4\xa2\x9f\x0b\xcf1\xcd\x14A\xfcq3\xa0]\r\xa9n\xb7%\xd0\xb7\xc2\xa2\x11u\xc2\x02u\t}\x9b%<E7n\x0c\x0b\xa3P\xf0\x98[\xd3#\xc1/\x12\x9a\xaa7V\x16U\x02\xfdlvx\xc3\xa1\xca\x08QM\x00\xaf\xb5\x1b\xa1\x99\xdd]s\xd7Z\xab\xfa\x80\xbc\xc9\x1a\x17E2NI\xb5tp;\x91\xdd\xfd&\xd9\xda5qq\x9d\x0e8\xc0"z\x0f\x1a\xb8\xa1\x1e\x0eA\x08\x9b\x9e\x89\xdf\xc6I\xd9L)\x19\xbcL\x07\xf5\x88\xbbV\xcb\xe5t<\x18\x10\xfc5o#S\xe3\xf2"\xcf\xde\x9a\xd4\xbe5\x07y\x9e\xe5\xed7\x87)\x82\xa2\xfd\x06\xdc\xd6h\xa4\\\xd7<\xbcqPo#\xf3\x13\xe8\tjT\x988\xb7]%S\xaa\xc2\xc6I\xa1\xe8\x8d#.`#\xf1 \xf8\x9b\xd5\x89\xebBX\xc3\xd7\x928\x12*\xecO#\xb1`[m\xc9Z8\x9a\x81k\x8c\xfa\x14\xcc!\x9b\xe7\x1d\xd3G\x82w\xcc\xc1\x8b\x9f\x96(\xbb\xfd\xa3\x17\xdf\x1f\xfe}I\x85\x17\xa0R\x17J|n~\xf4\xf2\xf4\xf0\xe8\xc5\x89\x12y\xab!\xfc\xe9\xa4\xdej\xf8\x85\x82\xefn\x95/\xcb\xc5\xe69(N\xe1\xf0\xc6\x99#\x16f\x95J\x93\x05\xa2fj\x8b"\x1e\xdb \x82R]:R\x87X\x95\xed\xc8e\xf3\x0c\xc8\xec\xfd\xf3d\xe1<2\x16w0\x03@\xe1%\xdaO\x86}1\xf2`\xbfM\xa2\x01\xf7\xe1\x16\x88\xd5qP\xd0\xa6WI\x9e\xa5S\x9b\x96?\xc5y\x02\x96\xc3\x89\x9dX\x8e\xf4\xda\xf4* \x87\xc82\xb4\tM\xcf\xd8\xf4\xeal\xd9\xe8]T\x9b\x02\xc0\xd4\xec\xd1#\xf3`\xb9(#\x933\x14c4Om\x9b\xe7J\x9exi\xc2\xb2\x04[\x8a\x1cqqT\x8aq}\x9f\x04c\xe3`\xca\xd2\xf1q\x9d\xb3;\xa6\xe7O2L\xde\xc9\xee\xde\xa9\xeep\xee?\xa1L\r\xf6\x81\x9b\xf8\x9a\xbd,\x8e)\xf7\xfb\xf4[\xf4{\xb0\x04\xb8*\xa9\xe7\x85\xd2\x92<\x13\xd9\xbb\xb8\xa3\x1a\x84\xdf\xef\x98q\x81tG5\x80t\x97\xed!\xa0\xee\xaa\x07\xb0\x96\xad5\x81\xb3\xac\x0e\xc0\xb8\x8f\xa0\x10\x98\xf7i\x03}\xdcmC\n\xe4\xbbk\x02\xbc\xa5\xe2B@-\xad\x84\xe1&\xd0\xd0h\t7\xf0\xdc\xa7S\x88\xb2\x1a\x94\xa1\xbfL\xdf)\xef@\x94\xde= … (740554 more bytes truncated)
2026-07-07T10:05:29.893 ERROR --- [et.reactor-5] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 0), invalid XML received:
b'{\n "Resources": {\n  "EventStream271A91DB": {\n   "Type": "AWS::Kinesis::Stream",\n   "Properties": {\n    "RetentionPeriodHours": 24,\n    "StreamEncryption": {\n     "Fn::If": [\n      "AwsCdkKinesisEncryptedStreamsUnsupportedRegions",\n      {\n       "Ref": "AWS::NoValue"\n      },\n      {\n       "EncryptionType": "KMS",\n       "KeyId": "alias/aws/kinesis"\n      }\n     ]\n    },\n    "StreamModeDetails": {\n     "StreamMode": "ON_DEMAND"\n    }\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventStream/Resource"\n   }\n  },\n  "EventTable3F3CD4B2": {\n   "Type": "AWS::DynamoDB::Table",\n   "Properties": {\n    "AttributeDefinitions": [\n     {\n      "AttributeName": "eventId",\n      "AttributeType": "S"\n     }\n    ],\n    "BillingMode": "PAY_PER_REQUEST",\n    "KeySchema": [\n     {\n      "AttributeName": "eventId",\n      "KeyType": "HASH"\n     }\n    ]\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventTable/Resource"\n   }\n  },\n  "ProcessorServiceRole5039D372": {\n   "Type": "AWS::IAM::Role",\n   "Properties": {\n    "AssumeRolePolicyDocument": {\n     "Statement": [\n      {\n       "Action": "sts:AssumeRole",\n       "Effect": "Allow",\n       "Principal": {\n        "Service": "lambda.amazonaws.com"\n       }\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "ManagedPolicyArns": [\n     {\n      "Fn::Join": [\n       "",\n       [\n        "arn:",\n        {\n         "Ref": "AWS::Partition"\n        },\n        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"\n       ]\n      ]\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/Resource"\n   }\n  },\n  "ProcessorServiceRoleDefaultPolicyDA9D4DBA": {\n   "Type": "AWS::IAM::Policy",\n   "Properties": {\n    "PolicyDocument": {\n     "Statement": [\n      {\n       "Action": [\n        "kinesis:DescribeStreamSummary",\n        "kinesis:GetRecords",\n        "kinesis:GetShardIterator",\n        "kinesis:ListShards",\n        "kinesis:SubscribeToShard",\n        "kinesis:DescribeStream",\n        "kinesis:ListStreams",\n        "kinesis:DescribeStreamConsumer"\n       ],\n       "Effect": "Allow",\n       "Resource": {\n        "Fn::GetAtt": [\n         "EventStream271A91DB",\n         "Arn"\n        ]\n       }\n      },\n      {\n       "Action": [\n        "dynamodb:BatchWriteItem",\n        "dynamodb:PutItem",\n        "dynamodb:UpdateItem",\n        "dynamodb:DeleteItem",\n        "dynamodb:DescribeTable"\n       ],\n       "Effect": "Allow",\n       "Resource": [\n        {\n         "Fn::GetAtt": [\n          "EventTable3F3CD4B2",\n          "Arn"\n         ]\n        }\n       ]\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "PolicyName": "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "Roles": [\n     {\n      "Ref": "ProcessorServiceRole5039D372"\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/DefaultPolicy/Resource"\n   }\n  },\n  "Processor60228016": {\n   "Type": "AWS::Lambda::Function",\n   "Properties": {\n    "Code": {\n     "S3Bucket": {\n      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"\n     },\n     "S3Key": "ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5.zip"\n    },\n    "Environment": {\n     "Variables": {\n      "TABLE_NAME": {\n       "Ref": "EventTable3F3CD4B2"\n      }\n     }\n    },\n    "Handler": "index.handler",\n    "Role": {\n     "Fn::GetAtt": [\n      "ProcessorServiceRole5039D372",\n      "Arn"\n     ]\n    },\n    "Runtime": "nodejs22.x"\n   },\n   "DependsOn": [\n    "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "ProcessorServiceRole5039D372"\n   ],\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/Resource",\n    "aws:asset:path": "asset.ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5",\n    "aws:asset:is-bundled": true,\n    "aws:asset:property": "Code"\n   }\n  },\n  "ProcessorKinesisEventSourcetest347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE378F1CA5": {\n   "Type": "AWS::Lambda::EventSourceMapping",\n   "Properties": {\n    "BatchSize": 10,\n    "EventSourceArn": {\n     "Fn::GetAtt": [\n      "EventStream271A91DB",\n      "Arn"\n     ]\n    },\n    "FilterCriteria": {\n     "Filters": [\n      {\n       "Pattern": "{\\"data\\":{\\"payload\\":{\\"type\\":[\\"purchase\\"]}}}"\n      }\n     ]\n    },\n    "FunctionName": {\n     "Ref": "Processor60228016"\n    },\n    "StartingPosition": "TRIM_HORIZON"\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/KinesisEventSource:test347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE/Resource"\n   }\n  },\n  "CDKMetadata": {\n   "Type": "AWS::CDK::Metadata",\n   "Properties": {\n    "Analytics": "v2:deflate64:H4sIAAAAAAAA/2VQu27DMAz8lu4y2zoZujZGu7UN7OwGLTGB/KAMU0oQGPr3QnLQpdMd73BHkCWU+zd4ecKbFNoMxWg7WBuPelB4k3YdLJNYSdpCOKnqzBuLytwZJ2c6WE/YjZSsTKIaceoMtuwM9QLfGT4Da28dK4sTrLXbAhmPbrT6nsaNRSW7FkXIC7wnULKDQ9AD+QMKPephrc781/pxJfaNC4umL5xny5fU91+NMemVY2NzribJtsqLGo+XR/Qn+Dn4qNIR0MvztdzDa/pUL9YWS2BvJ4J6w1+9mSJwRgEAAA=="\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/CDKMetadata/Default"\n   },\n   "Condition": "CDKMetadataAvailable"\n  }\n },\n "Conditions": {\n  "AwsCdkKinesisEncryptedStreamsUnsupportedRegions": {\n   "Fn::Or": [\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-north-1"\n     ]\n    },\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-northwest-1"\n     ]\n    }\n   ]\n  },\n  "CDKMetadataAvailable": {\n   "Fn::Or": [\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "af-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-3"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-3"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-4"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-west-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-north-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-northwest-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n          … (2916 more bytes truncated)
2026-07-07T10:05:30.213 ERROR --- [et.reactor-2] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 2), invalid XML received:
b'PK\x03\x04\x14\x00\x08\x00\x08\x00\x00\x00!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00index.js\xec\xbdk{\x1b7\xb2 \xfc=\xbf\x02\xe6z\xbdTL\xb5.\x8e2\x19N\x18E\x91\x95\x89Nl\xcb#\xc9\x99\x99\xd5x\xe9\x16\tR\x1d\x91\xddLwS\x8e\xa2\xe8\xbf\xbfO\xdd\x80Bw\x93\xa2\x1c_r\xde\xdd|\x88\xc5\x06P(\x14\nuC\x01h\xcd\x0bk\x8a2O\x06e\xebo\x9f]\xc5\xb9\xe9\xf7\x07\xb9\x8dKkz\xe6\xe8\xfcg;(#\xfa-\xa5C;z\x99g3_<\xb4\xa3$\xb5\xf0\xcd\xe6\xe5\xb5T\x1b\xdb\xf2\xe8m\n_\x9f\xdab\xe0k\xfb\xefP\x1b\xca\xf2dVfy\xbd\xdd\x8bxj\x8bE\r\xb1P\xb5y\x99gev4\n\xaa\xe3\xb7\xf2zf\x8fFR\xf3".\x18+_s\x06M\xa1Z\xe4K\xf5Hl15=\xd3\x1e\xa5\x1d\x93\xdbb\xcd\xf4\xbe1\xa3y:(\x93,5\xfd~\x92&e{\xcd\xdc|fLn\xcby\x9e\x9aQj\x1e=2\xed\x1c\x91oov\xcc(=\xeb\xf7\xfd\xb8\x11\xf5\xf6(];\xdb|\xfdz\xad=JM\xcfl\xae\xad!\xf4\xbf}v+\xa8\x0e\xb2\xe94K\xff\xeb\x04\xfa\x1e\x9cw\xcc4\x1bV\xfb\xce\xed/\xf3$\xb7a\xf7\xd3lh~\xff\xdd@\xc7\x83\xf3\x86\x8e\x07\xe7\xdcq\x1bj\xf6\xcc\x8d\xb1\xbf\xce\xb2\xbc,\xba\xe6\xe6\xd6\xdc\xaeE\xfc\x93z\xc4\xff\xcb\'\x85\x1dU\x02\xdc\xca8\x1f\xdb\xb2c\xe2\xc9\x04\xf1\x03J\x8c\xb2\xdc\xb4\x81\x99\xd2xjM\x92b\xe1g\xc6\x18\xd3\xef3\xff\xb8vP\xa5cn\xcc\xd8\x96]\xa8w\x06\x1f^w\x8cM\xe7S\x9b\xc7\xe7\x13\xdb5e>\xb7\xe6vM\xf5?\xc8f\xd7\xc0\\\xc0 \xed2\xeb\x98Q\x9eM;\xc6\xfe:\xb0\xb3\xb2c\x86\xb6\x188l\x92\x91iC1L\x0b\xccs6\xc2\xda\xa6\xd7\xeb\x99V\x86<\xde\x02\x92\xd5\xcad\x9a[4\xbf<\xae\x89-\xcd\xa5\xbd6\xd9\xc84Lk\x9eM\xd7\xd6p\xa8\xc6@\xc7\x0f\xfa}\xcfV\xd1 \x9eL\x10\xddK{\xbd\x06\xf8\x00\xa0\x07\xbd\x1e#.\r\x03:e\x1d\xa8\xe5H\xd4&.\xc8\xb3\xe9\xd9\xa5\xbd\xae\x10\xeaA\x1bFnz\x01f\xb0\xc8\x90\x00\x08hm\r\xc6\n\xd5"Ob$\xae1\xb7\x9e\x8b\xcbLQ\xbb\xcc\x0eN\x9e\x03\xa5\xa7\xd9\xb0c\x92\xe2E6\xb4\xcf\xb3\xa1\xed\x18\x9a}D\x89g\xd4\xf4\x80U\xcd\x83\x9eI\xe7\x93\x89\xd9u\x02\xa5\x8d\xd4\xe2\x85\n\x90\xd6\xd6\x0c\xf0\\\x07j\xc8t\xb6?3fc\xc3\x1c\x8eLyaM2\x05\xce\xb4\xb9I\n\xe0\xa24\x1bZ3\xc8\xa6\xb3\xb8L\xce\x93IR^CW\xd6d\xb9)/\xa0Ja\xd2\xac4qj\x0eN\x9e\x13\xa0Q2\xb1\xa6\xbc\x88Ks\x11\x17\xe6\xdc\xda\xd4\x0c\xb2\xf4\xca\xe6\xa5\x1d\x9a23\xb1\xd9\x97u\x86U\xe7E\x92\x8eMl\xbe\x8b\xcf\xedd\x9d`H\x8f\x00)\x8f\xd3b\x94\xe5S\xd3N"\x1b\x99V\xbfo\x8b\xe7\xd9p>\xb1-\xec\x01\xfa\xc7^\n[\xaeu`\x10\xa9)lI\x80ZC;\x8a\xe7\x93\xb2\x05=\xc3\xf8\\\xdf\xad)\xc2\x90\x85\xd6\xc2\x15T\x1fn\xf4\x99Q\xd4\x87y|\xc0\xcb\x1d\xfe\x8d<2H\xf6\xeaJs\xdd\x03/]\xc5\x93\xb9\xed\x02\xfd\x1a\x97\x9a\xe9\xf2\xd4v>3P\xe9\xb3\xb55\x11Le\xe6\xd0&\x8e\xc0\xd9\xd7s\xe8\x179\xcc\xae\xa6\x91\xea\x99\xd74\x89\x99\xbf}\xf6\xd9\xc6\x06\xceo\x9f(QlD\xb3t6\xdd\xf8\xb6\x98&\xe5\xc5\xf5cX\x9b\xc5\xb7_D[_D\x9b\x1b@\x18W\x8fkl`\x8d\x8daR\x94\xeb\x83\x9f\x8b\x8d$\x1d\xda_\xa3\x9f\x0b\xd4i,(\xfbP\xda\x1f\xfc\x0cB\x03\xf0%\x01\xdb\x06\x89\xd5\n`\xbe\xa7\xbe[m\x96\xa5\xdb"@Z\x81\xba\x05\x81(5\xa2\x1f\xcar\xb67//\x9ee\x83\x18uK\xcf\\e\xc9\xd0l\xfe\r\xa5I[\x84Q\xbbZQ`\x1bS-9k\xfdp\xb0\xf7\xf4\xe0\xb8\xf5\xda\xf4L\xeb\xc2\xc6C\x9b\xb7\x08\\S\xe5\x7f\xbc:8\xfe7\xd5\xfden\xf3k\xaez\xbb\xe6\x86QG\x124\xcd\xb2!\xdc\xdc\x02\xe3\xd4\x07:K~\xb4\xd7\xab\x0f\xb7V\xddQ\x94\x07R\xafp\xf7\xe0\x9b\xda\xacJ\x83Z[\xd4\xb9!%\xeauz\xa6\x81\x1e\x07\xe9p\x96%i\xf9\xea\xf8\xd9\xc9\xe0\xc2N\xc1\xf2j\x9e\xf9ZM?\xf5\xb5\xa2\xb3\xd6\x0f\xa7\xa7/y\xe6\xcbr\xe6\xe6}A\xcd\x13_\xb5h\x98\xf8Z\xabp\xbc\xf5\xe2\xc6\xa1\xeeM\xc6Y\x9e\x94\x17\xd3C\xb0<\x9a\x07\xa9\xea\xf8\xe1\xa9\x8fg\xad\xe7Ow\x08\xd9\xe9p\xc7\r+\xa8\xb1\x7f\xbc\xffd\x9b\xea\x0c\xf2\xc1\x93\xed%\xb5\xf6U\xb5As\xbd\x93\x1f\xf6\xb6\xa8Vq\x11o-\xac\xb3\xbd\xf3\xa5\xab\x05\x7f\x13\xdb\xeb\xd5\xa3p\x0c\xc9\xa7\x0b4\xe1\xc0\x84\x1a\xdbr\xff\xc2\x0e.\x8b\xf9t?KG\xc9x\x9e\x8b|h\xe7\xf3\xb4L\xa6\x96\xbe;{\x07V\xdb K\x8b\xd2\x0c\xb8\xa1\x83\x0f\x92\xef\xec\xb5\x88\x00\xb0O\x02\x10Qq\x11o\xef|\x89\x16\t\xcd\x8e\x9f\x02\xd3\x00-\x9a\xcd\x8b\x0b\x94\x9f\xd0\'\xfc\x17\xfb\x19\xee\x1a2U\xdc\xa2pX\x1c\x0e\xa3\x93\x1f\xf6\xb6w\xbe\x04\xe5"\xff\t\xae\xfb\x80y>\x1f\x94Y.\x10\x9apt-\xc1,$\x18`\xbd\xc0\x7f\xf5aM\x87;`\x90|\xd8!=\x7f\xba\xf3N\xe3\x99\x0ew\x96\x0c\x86\x9d\n\xd0Q\xf4_<\x1c\n?8\x82\xb6\x81\xecz\xaa\x16O\x16\xd6\x14\x8a\x19s\xebQ\x96\tpP\x0bv,\xa4gF\xa5^O\x81\x93\xa9\xa0O\xb7\xf4\x0f\xb0qn\x8blre\x05\xf5c\xcd\xb9\xe8\xe2L\x12\x9b\x96\x0b99`\x01\xf0Z\x18\xb41\x03\xd50\xaa\xe3\xd6^\x8bFY~\x10\x0f.\xda\xedZi\xb0d\x8c\t:9\xab\xd5\x8e\x14s\xb7\xd7@\xa7\xd6\xab\xc8\x17\xc5\xc5m\xcf\xa0\xee/&e\xd0a\x8ddc[>%\x83q_\x8dq\xa5\xe5\xcf\xf0\x17\xc9\x8ep\xd53V\xf5\xc9\xe2\xde\x83\xb9\xda\xc1\xc9BA\x14POF\xb4d\x9a\xdb\x03j\x16\x0c\xd4I\x87\xef\x13;\x19\xbe\xcc\x8ad\xa9\xf1\x13\xd4\xf2\x1c\x1f|>\x0b\x7fi#h\x13-!\xb6\x8a\x08\x0fc\xc2\xea\xe1\xaf\xd6\xe9\xf1\xde\xe136\xa1\xb6\xb0\xb5|\xe1a(\xeb(h\x1aJ\xf8\xb0\xa8*\xe3O\x9e\x1f\x9e\xfe\xf0\xef\xfe\xfe\xd1\x8b\xd3\x83\x7f\x9d\xf6\x7f<\xf8\xf76Xl\xfd>Y\xbf\xfdA\x96\x96\xf6W\x88\xd0\xc0Zt$;L\x93\x13\x8b\x81\x88\xd3\xeb\xd9b\xb3!\xac\xe6\x89\x16~?k\xbd<>\xfa\xfe\xf0\xd9\x01)\xb1Y\x9e\x81C\xe4\xb4]\xb5\xf2\xc9\xc9Q\xff\xe4\xe0\xe4\xe4\xf0\xe8\x05k\xbd"[/lQ$Y\xba\xb8\xd1\xc1\xf1O\x87\xfb\x07lk\x146\xbfJ\x06\xb6\xc9\xdc\x08{\x0bIY)\xd3\xb4t\x949\xb6\xbf\xccmQ\xfe\x10\xa7\xc3\x89\xcd\xd1\xe7\x1cd\x93\x856GsuO\xa9\xe6r2\xb1\xfa\x9b\xfd\xbf\x12\x05.\xcar\xb6\xb1\x19\xfd\xd5\r\x7fi\xb3\xad\xfe\xa6j\xb6\x15m\xde\xd9\xec\xf4\xe9I\xff+iU\x0e\x8b\x8d\xaf\\#me4\xf7\x1a\xd2pA\x9dFZ\xd6\x99\xd3\xf4L\xfd\xe3v\x859\xef\x92^K\xcb+\xb0Xy4\xc9#\xd3\x13\xd5\xd2T\xba\x03\x80n?\x03\x1b\xe1\x0e\x07s^&\x93\xf5i2\x1cN\xec\xdb8\xb7\xdf~\x11mG[O\x9a]\xcdJ\xdd\x15\x9dNX\xd2\xf7\xf0:+\x9d\xfc1\x84V\xf1DAK\xa3\x13\x8d$\xc5\xc8\xa2s\x98E\x87\xb1Az\x82N\xf9>I\xa5\xad-V\t \xa2P\'\xb0\xb8:ChQ\x9dU^#3\xde]\x0b\xd9\x91X\x01:N\xb3|\x1aO\x92\xdf \xd6|\x95\x0cm\xfe\x17\xe88Igs\xeaVl$\xb0\xff\xa0\xebld\xb0\x90\x02}\xe2?\xb7|\x90\x8du\x16V\xa2n\xc4p\x9e\xe5\xd94)\x92Qb\xc1Qy\x89\xbfl\xc4l\xc8]J\x0b\x86B\xc6\xaejH\xe5\xacU\x9dd\x1a\xdb2\xa0\x9e\xe9\x81\x85\x1f|\xda\xda\xa2\xa6\xaeMm\xe0\xa6\xd7@\x0ch\xb4\x9c\xd5\xe3\xb7\xc5z1\xbc|<\xc8r\xfb\xed\x93\xe8\xaf\x7fy\x12m\xff\xa5\xc2\xe2\\g\x03\xea\x10c\xdbb\xa3\x98\x9fKX&\x1e\x0c\xb2yZ\xae\'\xc3u\xcb\x8e\xeb\xc6\x1e};\x1c\x8a\x1b\x08\xb1A\xb4\x80\xe2\xb4, \x08#\xc4\x87\xb0S2\x8cK\xdb\xd8\xa4\x8dA)\x12\xbbL\xd5\xbd\xfd\xfd\xa3W/N\xfb\x87O\xfb\x07/\x9e\xbe<:|q\xda\x7f~\xf4\xf4\xa0\xff\xd3\xde\xb3W\x07\'Q\x92\x0e&\xf3\xa1-\xb8\xe9\xdf>\xbb\xc5\x80\xcf\xd3\x83\xef\xf7^=;\xed/j\xde1\x8bJ\x180\x05\xbb \xb8\xdfoD\xd5\x8d\x0e\x17\xb5-\xa6\x8b\xa3H\x9f\x8c\xea-g\xbf\xdfE\x0e06f\xb9\x1d\xd9<\xb7C\xd6Cw\x10\x08\x1c\xc9\xd60) @?lut\xfb\x8eiq\xc0m\xd8B_\xf3\xcf\xc5\x95\xa3d|LVj.\xf1A\x8a3\xf7A\xe4\xf6\xbd\x0e\xc0\x1d\x19pZ\x16q\xc0(\x19\xaf\xc0\'\xaa\xbf?\x1f\xb3(\xe4\xa2\x9f\x0b\xcf1\xcd\x14A\xfcq3\xa0]\r\xa9n\xb7%\xd0\xb7\xc2\xa2\x11u\xc2\x02u\t}\x9b%<E7n\x0c\x0b\xa3P\xf0\x98[\xd3#\xc1/\x12\x9a\xaa7V\x16U\x02\xfdlvx\xc3\xa1\xca\x08QM\x00\xaf\xb5\x1b\xa1\x99\xdd]s\xd7Z\xab\xfa\x80\xbc\xc9\x1a\x17E2NI\xb5tp;\x91\xdd\xfd&\xd9\xda5qq\x9d\x0e8\xc0"z\x0f\x1a\xb8\xa1\x1e\x0eA\x08\x9b\x9e\x89\xdf\xc6I\xd9L)\x19\xbcL\x07\xf5\x88\xbbV\xcb\xe5t<\x18\x10\xfc5o#S\xe3\xf2"\xcf\xde\x9a\xd4\xbe5\x07y\x9e\xe5\xed7\x87)\x82\xa2\xfd\x06\xdc\xd6h\xa4\\\xd7<\xbcqPo#\xf3\x13\xe8\tjT\x988\xb7]%S\xaa\xc2\xc6I\xa1\xe8\x8d#.`#\xf1 \xf8\x9b\xd5\x89\xebBX\xc3\xd7\x928\x12*\xecO#\xb1`[m\xc9Z8\x9a\x81k\x8c\xfa\x14\xcc!\x9b\xe7\x1d\xd3G\x82w\xcc\xc1\x8b\x9f\x96(\xbb\xfd\xa3\x17\xdf\x1f\xfe}I\x85\x17\xa0R\x17J|n~\xf4\xf2\xf4\xf0\xe8\xc5\x89\x12y\xab!\xfc\xe9\xa4\xdej\xf8\x85\x82\xefn\x95/\xcb\xc5\xe69(N\xe1\xf0\xc6\x99#\x16f\x95J\x93\x05\xa2fj\x8b"\x1e\xdb \x82R]:R\x87X\x95\xed\xc8e\xf3\x0c\xc8\xec\xfd\xf3d\xe1<2\x16w0\x03@\xe1%\xdaO\x86}1\xf2`\xbfM\xa2\x01\xf7\xe1\x16\x88\xd5qP\xd0\xa6WI\x9e\xa5S\x9b\x96?\xc5y\x02\x96\xc3\x89\x9dX\x8e\xf4\xda\xf4* \x87\xc82\xb4\tM\xcf\xd8\xf4\xeal\xd9\xe8]T\x9b\x02\xc0\xd4\xec\xd1#\xf3`\xb9(#\x933\x14c4Om\x9b\xe7J\x9exi\xc2\xb2\x04[\x8a\x1cqqT\x8aq}\x9f\x04c\xe3`\xca\xd2\xf1q\x9d\xb3;\xa6\xe7O2L\xde\xc9\xee\xde\xa9\xeep\xee?\xa1L\r\xf6\x81\x9b\xf8\x9a\xbd,\x8e)\xf7\xfb\xf4[\xf4{\xb0\x04\xb8*\xa9\xe7\x85\xd2\x92<\x13\xd9\xbb\xb8\xa3\x1a\x84\xdf\xef\x98q\x81tG5\x80t\x97\xed!\xa0\xee\xaa\x07\xb0\x96\xad5\x81\xb3\xac\x0e\xc0\xb8\x8f\xa0\x10\x98\xf7i\x03}\xdcmC\n\xe4\xbbk\x02\xbc\xa5\xe2B@-\xad\x84\xe1&\xd0\xd0h\t7\xf0\xdc\xa7S\x88\xb2\x1a\x94\xa1\xbfL\xdf)\xef@\x94\xde= … (740554 more bytes truncated)
2026-07-07T10:05:49.112 ERROR --- [et.reactor-3] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 0), invalid XML received:
b'{\n "Resources": {\n  "EventStream271A91DB": {\n   "Type": "AWS::Kinesis::Stream",\n   "Properties": {\n    "RetentionPeriodHours": 24,\n    "StreamEncryption": {\n     "Fn::If": [\n      "AwsCdkKinesisEncryptedStreamsUnsupportedRegions",\n      {\n       "Ref": "AWS::NoValue"\n      },\n      {\n       "EncryptionType": "KMS",\n       "KeyId": "alias/aws/kinesis"\n      }\n     ]\n    },\n    "StreamModeDetails": {\n     "StreamMode": "ON_DEMAND"\n    }\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventStream/Resource"\n   }\n  },\n  "EventTable3F3CD4B2": {\n   "Type": "AWS::DynamoDB::Table",\n   "Properties": {\n    "AttributeDefinitions": [\n     {\n      "AttributeName": "eventId",\n      "AttributeType": "S"\n     }\n    ],\n    "BillingMode": "PAY_PER_REQUEST",\n    "KeySchema": [\n     {\n      "AttributeName": "eventId",\n      "KeyType": "HASH"\n     }\n    ]\n   },\n   "UpdateReplacePolicy": "Delete",\n   "DeletionPolicy": "Delete",\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/EventTable/Resource"\n   }\n  },\n  "ProcessorServiceRole5039D372": {\n   "Type": "AWS::IAM::Role",\n   "Properties": {\n    "AssumeRolePolicyDocument": {\n     "Statement": [\n      {\n       "Action": "sts:AssumeRole",\n       "Effect": "Allow",\n       "Principal": {\n        "Service": "lambda.amazonaws.com"\n       }\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "ManagedPolicyArns": [\n     {\n      "Fn::Join": [\n       "",\n       [\n        "arn:",\n        {\n         "Ref": "AWS::Partition"\n        },\n        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"\n       ]\n      ]\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/Resource"\n   }\n  },\n  "ProcessorServiceRoleDefaultPolicyDA9D4DBA": {\n   "Type": "AWS::IAM::Policy",\n   "Properties": {\n    "PolicyDocument": {\n     "Statement": [\n      {\n       "Action": [\n        "kinesis:DescribeStreamSummary",\n        "kinesis:GetRecords",\n        "kinesis:GetShardIterator",\n        "kinesis:ListShards",\n        "kinesis:SubscribeToShard",\n        "kinesis:DescribeStream",\n        "kinesis:ListStreams",\n        "kinesis:DescribeStreamConsumer"\n       ],\n       "Effect": "Allow",\n       "Resource": {\n        "Fn::GetAtt": [\n         "EventStream271A91DB",\n         "Arn"\n        ]\n       }\n      },\n      {\n       "Action": [\n        "dynamodb:BatchWriteItem",\n        "dynamodb:PutItem",\n        "dynamodb:UpdateItem",\n        "dynamodb:DeleteItem",\n        "dynamodb:DescribeTable"\n       ],\n       "Effect": "Allow",\n       "Resource": [\n        {\n         "Fn::GetAtt": [\n          "EventTable3F3CD4B2",\n          "Arn"\n         ]\n        }\n       ]\n      }\n     ],\n     "Version": "2012-10-17"\n    },\n    "PolicyName": "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "Roles": [\n     {\n      "Ref": "ProcessorServiceRole5039D372"\n     }\n    ]\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/ServiceRole/DefaultPolicy/Resource"\n   }\n  },\n  "Processor60228016": {\n   "Type": "AWS::Lambda::Function",\n   "Properties": {\n    "Code": {\n     "S3Bucket": {\n      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"\n     },\n     "S3Key": "ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5.zip"\n    },\n    "Environment": {\n     "Variables": {\n      "TABLE_NAME": {\n       "Ref": "EventTable3F3CD4B2"\n      }\n     }\n    },\n    "Handler": "index.handler",\n    "Role": {\n     "Fn::GetAtt": [\n      "ProcessorServiceRole5039D372",\n      "Arn"\n     ]\n    },\n    "Runtime": "nodejs22.x"\n   },\n   "DependsOn": [\n    "ProcessorServiceRoleDefaultPolicyDA9D4DBA",\n    "ProcessorServiceRole5039D372"\n   ],\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/Resource",\n    "aws:asset:path": "asset.ced1f126d753bf3b76fedfd0120d45396e5b485731967aa82bd48433d53627b5",\n    "aws:asset:is-bundled": true,\n    "aws:asset:property": "Code"\n   }\n  },\n  "ProcessorKinesisEventSourcetest347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE378F1CA5": {\n   "Type": "AWS::Lambda::EventSourceMapping",\n   "Properties": {\n    "BatchSize": 10,\n    "EventSourceArn": {\n     "Fn::GetAtt": [\n      "EventStream271A91DB",\n      "Arn"\n     ]\n    },\n    "FilterCriteria": {\n     "Filters": [\n      {\n       "Pattern": "{\\"data\\":{\\"payload\\":{\\"type\\":[\\"purchase\\"]}}}"\n      }\n     ]\n    },\n    "FunctionName": {\n     "Ref": "Processor60228016"\n    },\n    "StartingPosition": "TRIM_HORIZON"\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/Processor/KinesisEventSource:test347c943e4b1743cfa55b2d91af6f4d8fEventStreamDD7842DE/Resource"\n   }\n  },\n  "CDKMetadata": {\n   "Type": "AWS::CDK::Metadata",\n   "Properties": {\n    "Analytics": "v2:deflate64:H4sIAAAAAAAA/2VQu27DMAz8lu4y2zoZujZGu7UN7OwGLTGB/KAMU0oQGPr3QnLQpdMd73BHkCWU+zd4ecKbFNoMxWg7WBuPelB4k3YdLJNYSdpCOKnqzBuLytwZJ2c6WE/YjZSsTKIaceoMtuwM9QLfGT4Da28dK4sTrLXbAhmPbrT6nsaNRSW7FkXIC7wnULKDQ9AD+QMKPephrc781/pxJfaNC4umL5xny5fU91+NMemVY2NzribJtsqLGo+XR/Qn+Dn4qNIR0MvztdzDa/pUL9YWS2BvJ4J6w1+9mSJwRgEAAA=="\n   },\n   "Metadata": {\n    "aws:cdk:path": "test-347c943e-4b17-43cf-a55b-2d91af6f4d8f/CDKMetadata/Default"\n   },\n   "Condition": "CDKMetadataAvailable"\n  }\n },\n "Conditions": {\n  "AwsCdkKinesisEncryptedStreamsUnsupportedRegions": {\n   "Fn::Or": [\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-north-1"\n     ]\n    },\n    {\n     "Fn::Equals": [\n      {\n       "Ref": "AWS::Region"\n      },\n      "cn-northwest-1"\n     ]\n    }\n   ]\n  },\n  "CDKMetadataAvailable": {\n   "Fn::Or": [\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "af-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-east-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-northeast-3"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-south-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-2"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-3"\n       ]\n      }\n     ]\n    },\n    {\n     "Fn::Or": [\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ap-southeast-4"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "ca-west-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-north-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "cn-northwest-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n         "Ref": "AWS::Region"\n        },\n        "eu-central-1"\n       ]\n      },\n      {\n       "Fn::Equals": [\n        {\n          … (2916 more bytes truncated)
2026-07-07T10:05:49.481 ERROR --- [et.reactor-5] l.aws.handlers.logging     : exception during call chain: Unable to parse request (not well-formed (invalid token): line 1, column 2), invalid XML received:
b'PK\x03\x04\x14\x00\x08\x00\x08\x00\x00\x00!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00index.js\xec\xbdk{\x1b7\xb2 \xfc=\xbf\x02\xe6z\xbdTL\xb5.\x8e2\x19N\x18E\x91\x95\x89Nl\xcb#\xc9\x99\x99\xd5x\xe9\x16\tR\x1d\x91\xddLwS\x8e\xa2\xe8\xbf\xbfO\xdd\x80Bw\x93\xa2\x1c_r\xde\xdd|\x88\xc5\x06P(\x14\nuC\x01h\xcd\x0bk\x8a2O\x06e\xebo\x9f]\xc5\xb9\xe9\xf7\x07\xb9\x8dKkz\xe6\xe8\xfcg;(#\xfa-\xa5C;z\x99g3_<\xb4\xa3$\xb5\xf0\xcd\xe6\xe5\xb5T\x1b\xdb\xf2\xe8m\n_\x9f\xdab\xe0k\xfb\xefP\x1b\xca\xf2dVfy\xbd\xdd\x8bxj\x8bE\r\xb1P\xb5y\x99gev4\n\xaa\xe3\xb7\xf2zf\x8fFR\xf3".\x18+_s\x06M\xa1Z\xe4K\xf5Hl15=\xd3\x1e\xa5\x1d\x93\xdbb\xcd\xf4\xbe1\xa3y:(\x93,5\xfd~\x92&e{\xcd\xdc|fLn\xcby\x9e\x9aQj\x1e=2\xed\x1c\x91oov\xcc(=\xeb\xf7\xfd\xb8\x11\xf5\xf6(];\xdb|\xfdz\xad=JM\xcfl\xae\xad!\xf4\xbf}v+\xa8\x0e\xb2\xe94K\xff\xeb\x04\xfa\x1e\x9cw\xcc4\x1bV\xfb\xce\xed/\xf3$\xb7a\xf7\xd3lh~\xff\xdd@\xc7\x83\xf3\x86\x8e\x07\xe7\xdcq\x1bj\xf6\xcc\x8d\xb1\xbf\xce\xb2\xbc,\xba\xe6\xe6\xd6\xdc\xaeE\xfc\x93z\xc4\xff\xcb\'\x85\x1dU\x02\xdc\xca8\x1f\xdb\xb2c\xe2\xc9\x04\xf1\x03J\x8c\xb2\xdc\xb4\x81\x99\xd2xjM\x92b\xe1g\xc6\x18\xd3\xef3\xff\xb8vP\xa5cn\xcc\xd8\x96]\xa8w\x06\x1f^w\x8cM\xe7S\x9b\xc7\xe7\x13\xdb5e>\xb7\xe6vM\xf5?\xc8f\xd7\xc0\\\xc0 \xed2\xeb\x98Q\x9eM;\xc6\xfe:\xb0\xb3\xb2c\x86\xb6\x188l\x92\x91iC1L\x0b\xccs6\xc2\xda\xa6\xd7\xeb\x99V\x86<\xde\x02\x92\xd5\xcad\x9a[4\xbf<\xae\x89-\xcd\xa5\xbd6\xd9\xc84Lk\x9eM\xd7\xd6p\xa8\xc6@\xc7\x0f\xfa}\xcfV\xd1 \x9eL\x10\xddK{\xbd\x06\xf8\x00\xa0\x07\xbd\x1e#.\r\x03:e\x1d\xa8\xe5H\xd4&.\xc8\xb3\xe9\xd9\xa5\xbd\xae\x10\xeaA\x1bFnz\x01f\xb0\xc8\x90\x00\x08hm\r\xc6\n\xd5"Ob$\xae1\xb7\x9e\x8b\xcbLQ\xbb\xcc\x0eN\x9e\x03\xa5\xa7\xd9\xb0c\x92\xe2E6\xb4\xcf\xb3\xa1\xed\x18\x9a}D\x89g\xd4\xf4\x80U\xcd\x83\x9eI\xe7\x93\x89\xd9u\x02\xa5\x8d\xd4\xe2\x85\n\x90\xd6\xd6\x0c\xf0\\\x07j\xc8t\xb6?3fc\xc3\x1c\x8eLyaM2\x05\xce\xb4\xb9I\n\xe0\xa24\x1bZ3\xc8\xa6\xb3\xb8L\xce\x93IR^CW\xd6d\xb9)/\xa0Ja\xd2\xac4qj\x0eN\x9e\x13\xa0Q2\xb1\xa6\xbc\x88Ks\x11\x17\xe6\xdc\xda\xd4\x0c\xb2\xf4\xca\xe6\xa5\x1d\x9a23\xb1\xd9\x97u\x86U\xe7E\x92\x8eMl\xbe\x8b\xcf\xedd\x9d`H\x8f\x00)\x8f\xd3b\x94\xe5S\xd3N"\x1b\x99V\xbfo\x8b\xe7\xd9p>\xb1-\xec\x01\xfa\xc7^\n[\xaeu`\x10\xa9)lI\x80ZC;\x8a\xe7\x93\xb2\x05=\xc3\xf8\\\xdf\xad)\xc2\x90\x85\xd6\xc2\x15T\x1fn\xf4\x99Q\xd4\x87y|\xc0\xcb\x1d\xfe\x8d<2H\xf6\xeaJs\xdd\x03/]\xc5\x93\xb9\xed\x02\xfd\x1a\x97\x9a\xe9\xf2\xd4v>3P\xe9\xb3\xb55\x11Le\xe6\xd0&\x8e\xc0\xd9\xd7s\xe8\x179\xcc\xae\xa6\x91\xea\x99\xd74\x89\x99\xbf}\xf6\xd9\xc6\x06\xceo\x9f(QlD\xb3t6\xdd\xf8\xb6\x98&\xe5\xc5\xf5cX\x9b\xc5\xb7_D[_D\x9b\x1b@\x18W\x8fkl`\x8d\x8daR\x94\xeb\x83\x9f\x8b\x8d$\x1d\xda_\xa3\x9f\x0b\xd4i,(\xfbP\xda\x1f\xfc\x0cB\x03\xf0%\x01\xdb\x06\x89\xd5\n`\xbe\xa7\xbe[m\x96\xa5\xdb"@Z\x81\xba\x05\x81(5\xa2\x1f\xcar\xb67//\x9ee\x83\x18uK\xcf\\e\xc9\xd0l\xfe\r\xa5I[\x84Q\xbbZQ`\x1bS-9k\xfdp\xb0\xf7\xf4\xe0\xb8\xf5\xda\xf4L\xeb\xc2\xc6C\x9b\xb7\x08\\S\xe5\x7f\xbc:8\xfe7\xd5\xfden\xf3k\xaez\xbb\xe6\x86QG\x124\xcd\xb2!\xdc\xdc\x02\xe3\xd4\x07:K~\xb4\xd7\xab\x0f\xb7V\xddQ\x94\x07R\xafp\xf7\xe0\x9b\xda\xacJ\x83Z[\xd4\xb9!%\xeauz\xa6\x81\x1e\x07\xe9p\x96%i\xf9\xea\xf8\xd9\xc9\xe0\xc2N\xc1\xf2j\x9e\xf9ZM?\xf5\xb5\xa2\xb3\xd6\x0f\xa7\xa7/y\xe6\xcbr\xe6\xe6}A\xcd\x13_\xb5h\x98\xf8Z\xabp\xbc\xf5\xe2\xc6\xa1\xeeM\xc6Y\x9e\x94\x17\xd3C\xb0<\x9a\x07\xa9\xea\xf8\xe1\xa9\x8fg\xad\xe7Ow\x08\xd9\xe9p\xc7\r+\xa8\xb1\x7f\xbc\xffd\x9b\xea\x0c\xf2\xc1\x93\xed%\xb5\xf6U\xb5As\xbd\x93\x1f\xf6\xb6\xa8Vq\x11o-\xac\xb3\xbd\xf3\xa5\xab\x05\x7f\x13\xdb\xeb\xd5\xa3p\x0c\xc9\xa7\x0b4\xe1\xc0\x84\x1a\xdbr\xff\xc2\x0e.\x8b\xf9t?KG\xc9x\x9e\x8b|h\xe7\xf3\xb4L\xa6\x96\xbe;{\x07V\xdb K\x8b\xd2\x0c\xb8\xa1\x83\x0f\x92\xef\xec\xb5\x88\x00\xb0O\x02\x10Qq\x11o\xef|\x89\x16\t\xcd\x8e\x9f\x02\xd3\x00-\x9a\xcd\x8b\x0b\x94\x9f\xd0\'\xfc\x17\xfb\x19\xee\x1a2U\xdc\xa2pX\x1c\x0e\xa3\x93\x1f\xf6\xb6w\xbe\x04\xe5"\xff\t\xae\xfb\x80y>\x1f\x94Y.\x10\x9apt-\xc1,$\x18`\xbd\xc0\x7f\xf5aM\x87;`\x90|\xd8!=\x7f\xba\xf3N\xe3\x99\x0ew\x96\x0c\x86\x9d\n\xd0Q\xf4_<\x1c\n?8\x82\xb6\x81\xecz\xaa\x16O\x16\xd6\x14\x8a\x19s\xebQ\x96\tpP\x0bv,\xa4gF\xa5^O\x81\x93\xa9\xa0O\xb7\xf4\x0f\xb0qn\x8blre\x05\xf5c\xcd\xb9\xe8\xe2L\x12\x9b\x96\x0b99`\x01\xf0Z\x18\xb41\x03\xd50\xaa\xe3\xd6^\x8bFY~\x10\x0f.\xda\xedZi\xb0d\x8c\t:9\xab\xd5\x8e\x14s\xb7\xd7@\xa7\xd6\xab\xc8\x17\xc5\xc5m\xcf\xa0\xee/&e\xd0a\x8ddc[>%\x83q_\x8dq\xa5\xe5\xcf\xf0\x17\xc9\x8ep\xd53V\xf5\xc9\xe2\xde\x83\xb9\xda\xc1\xc9BA\x14POF\xb4d\x9a\xdb\x03j\x16\x0c\xd4I\x87\xef\x13;\x19\xbe\xcc\x8ad\xa9\xf1\x13\xd4\xf2\x1c\x1f|>\x0b\x7fi#h\x13-!\xb6\x8a\x08\x0fc\xc2\xea\xe1\xaf\xd6\xe9\xf1\xde\xe136\xa1\xb6\xb0\xb5|\xe1a(\xeb(h\x1aJ\xf8\xb0\xa8*\xe3O\x9e\x1f\x9e\xfe\xf0\xef\xfe\xfe\xd1\x8b\xd3\x83\x7f\x9d\xf6\x7f<\xf8\xf76Xl\xfd>Y\xbf\xfdA\x96\x96\xf6W\x88\xd0\xc0Zt$;L\x93\x13\x8b\x81\x88\xd3\xeb\xd9b\xb3!\xac\xe6\x89\x16~?k\xbd<>\xfa\xfe\xf0\xd9\x01)\xb1Y\x9e\x81C\xe4\xb4]\xb5\xf2\xc9\xc9Q\xff\xe4\xe0\xe4\xe4\xf0\xe8\x05k\xbd"[/lQ$Y\xba\xb8\xd1\xc1\xf1O\x87\xfb\x07lk\x146\xbfJ\x06\xb6\xc9\xdc\x08{\x0bIY)\xd3\xb4t\x949\xb6\xbf\xccmQ\xfe\x10\xa7\xc3\x89\xcd\xd1\xe7\x1cd\x93\x856GsuO\xa9\xe6r2\xb1\xfa\x9b\xfd\xbf\x12\x05.\xcar\xb6\xb1\x19\xfd\xd5\r\x7fi\xb3\xad\xfe\xa6j\xb6\x15m\xde\xd9\xec\xf4\xe9I\xff+iU\x0e\x8b\x8d\xaf\\#me4\xf7\x1a\xd2pA\x9dFZ\xd6\x99\xd3\xf4L\xfd\xe3v\x859\xef\x92^K\xcb+\xb0Xy4\xc9#\xd3\x13\xd5\xd2T\xba\x03\x80n?\x03\x1b\xe1\x0e\x07s^&\x93\xf5i2\x1cN\xec\xdb8\xb7\xdf~\x11mG[O\x9a]\xcdJ\xdd\x15\x9dNX\xd2\xf7\xf0:+\x9d\xfc1\x84V\xf1DAK\xa3\x13\x8d$\xc5\xc8\xa2s\x98E\x87\xb1Az\x82N\xf9>I\xa5\xad-V\t \xa2P\'\xb0\xb8:ChQ\x9dU^#3\xde]\x0b\xd9\x91X\x01:N\xb3|\x1aO\x92\xdf \xd6|\x95\x0cm\xfe\x17\xe88Igs\xeaVl$\xb0\xff\xa0\xebld\xb0\x90\x02}\xe2?\xb7|\x90\x8du\x16V\xa2n\xc4p\x9e\xe5\xd94)\x92Qb\xc1Qy\x89\xbfl\xc4l\xc8]J\x0b\x86B\xc6\xaejH\xe5\xacU\x9dd\x1a\xdb2\xa0\x9e\xe9\x81\x85\x1f|\xda\xda\xa2\xa6\xaeMm\xe0\xa6\xd7@\x0ch\xb4\x9c\xd5\xe3\xb7\xc5z1\xbc|<\xc8r\xfb\xed\x93\xe8\xaf\x7fy\x12m\xff\xa5\xc2\xe2\\g\x03\xea\x10c\xdbb\xa3\x98\x9fKX&\x1e\x0c\xb2yZ\xae\'\xc3u\xcb\x8e\xeb\xc6\x1e};\x1c\x8a\x1b\x08\xb1A\xb4\x80\xe2\xb4, \x08#\xc4\x87\xb0S2\x8cK\xdb\xd8\xa4\x8dA)\x12\xbbL\xd5\xbd\xfd\xfd\xa3W/N\xfb\x87O\xfb\x07/\x9e\xbe<:|q\xda\x7f~\xf4\xf4\xa0\xff\xd3\xde\xb3W\x07\'Q\x92\x0e&\xf3\xa1-\xb8\xe9\xdf>\xbb\xc5\x80\xcf\xd3\x83\xef\xf7^=;\xed/j\xde1\x8bJ\x180\x05\xbb \xb8\xdfoD\xd5\x8d\x0e\x17\xb5-\xa6\x8b\xa3H\x9f\x8c\xea-g\xbf\xdfE\x0e06f\xb9\x1d\xd9<\xb7C\xd6Cw\x10\x08\x1c\xc9\xd60) @?lut\xfb\x8eiq\xc0m\xd8B_\xf3\xcf\xc5\x95\xa3d|LVj.\xf1A\x8a3\xf7A\xe4\xf6\xbd\x0e\xc0\x1d\x19pZ\x16q\xc0(\x19\xaf\xc0\'\xaa\xbf?\x1f\xb3(\xe4\xa2\x9f\x0b\xcf1\xcd\x14A\xfcq3\xa0]\r\xa9n\xb7%\xd0\xb7\xc2\xa2\x11u\xc2\x02u\t}\x9b%<E7n\x0c\x0b\xa3P\xf0\x98[\xd3#\xc1/\x12\x9a\xaa7V\x16U\x02\xfdlvx\xc3\xa1\xca\x08QM\x00\xaf\xb5\x1b\xa1\x99\xdd]s\xd7Z\xab\xfa\x80\xbc\xc9\x1a\x17E2NI\xb5tp;\x91\xdd\xfd&\xd9\xda5qq\x9d\x0e8\xc0"z\x0f\x1a\xb8\xa1\x1e\x0eA\x08\x9b\x9e\x89\xdf\xc6I\xd9L)\x19\xbcL\x07\xf5\x88\xbbV\xcb\xe5t<\x18\x10\xfc5o#S\xe3\xf2"\xcf\xde\x9a\xd4\xbe5\x07y\x9e\xe5\xed7\x87)\x82\xa2\xfd\x06\xdc\xd6h\xa4\\\xd7<\xbcqPo#\xf3\x13\xe8\tjT\x988\xb7]%S\xaa\xc2\xc6I\xa1\xe8\x8d#.`#\xf1 \xf8\x9b\xd5\x89\xebBX\xc3\xd7\x928\x12*\xecO#\xb1`[m\xc9Z8\x9a\x81k\x8c\xfa\x14\xcc!\x9b\xe7\x1d\xd3G\x82w\xcc\xc1\x8b\x9f\x96(\xbb\xfd\xa3\x17\xdf\x1f\xfe}I\x85\x17\xa0R\x17J|n~\xf4\xf2\xf4\xf0\xe8\xc5\x89\x12y\xab!\xfc\xe9\xa4\xdej\xf8\x85\x82\xefn\x95/\xcb\xc5\xe69(N\xe1\xf0\xc6\x99#\x16f\x95J\x93\x05\xa2fj\x8b"\x1e\xdb \x82R]:R\x87X\x95\xed\xc8e\xf3\x0c\xc8\xec\xfd\xf3d\xe1<2\x16w0\x03@\xe1%\xdaO\x86}1\xf2`\xbfM\xa2\x01\xf7\xe1\x16\x88\xd5qP\xd0\xa6WI\x9e\xa5S\x9b\x96?\xc5y\x02\x96\xc3\x89\x9dX\x8e\xf4\xda\xf4* \x87\xc82\xb4\tM\xcf\xd8\xf4\xeal\xd9\xe8]T\x9b\x02\xc0\xd4\xec\xd1#\xf3`\xb9(#\x933\x14c4Om\x9b\xe7J\x9exi\xc2\xb2\x04[\x8a\x1cqqT\x8aq}\x9f\x04c\xe3`\xca\xd2\xf1q\x9d\xb3;\xa6\xe7O2L\xde\xc9\xee\xde\xa9\xeep\xee?\xa1L\r\xf6\x81\x9b\xf8\x9a\xbd,\x8e)\xf7\xfb\xf4[\xf4{\xb0\x04\xb8*\xa9\xe7\x85\xd2\x92<\x13\xd9\xbb\xb8\xa3\x1a\x84\xdf\xef\x98q\x81tG5\x80t\x97\xed!\xa0\xee\xaa\x07\xb0\x96\xad5\x81\xb3\xac\x0e\xc0\xb8\x8f\xa0\x10\x98\xf7i\x03}\xdcmC\n\xe4\xbbk\x02\xbc\xa5\xe2B@-\xad\x84\xe1&\xd0\xd0h\t7\xf0\xdc\xa7S\x88\xb2\x1a\x94\xa1\xbfL\xdf)\xef@\x94\xde= … (740554 more bytes truncated)
2026-07-07T10:37:29.684  WARN --- [et.reactor-3] rolo.gateway.chain         : exception while running response handler: I/O operation on closed file.
```
</details>

Notes for reviewers:
- The binary/`\xNN` content and the trailing `rolo.gateway.chain` WARN are emulator-side (LocalStack logging a binary asset body / handling a disconnected response). lstk renders them faithfully; they are not produced by this change.
- A single oversized line is capped at **8 KB** before the truncation marker (2nd commit) — small enough to stay readable in a terminal instead of flooding scrollback with hundreds of KB of escaped bytes. Memory stays bounded regardless of line length; the reader buffer (64 KB) only paces how fast the discarded tail is drained.
- Rendering non-printable/control bytes nicely (and stripping stray ANSI like `5;214m`) is a separate concern, out of scope for DEVX-750 (specifically the crash). Real log lines are still fully emitted and interleaved between truncated blobs — verified on the live instance.


