### PR TITLE
ci: add Trivy vulnerability scanning

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,7 +38,7 @@ jobs:
       # Writes the SARIF report before honoring exit-code, so a red check (on
       # findings) and the always-run upload below are not mutually exclusive.
       - name: Run Trivy (fixable CRITICAL/HIGH)
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scanners: vuln
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run Trivy (all severities)
         id: trivy
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         # Don't abort the job on findings — the Slack + fail steps run after.
         continue-on-error: true
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -67,57 +67,29 @@ jobs:
 
   # Weekly full scan: every severity, including vulns with no fix yet. New CVEs
   # land against unchanged code, so this catches what the PR gate never sees.
-  # Reports to Slack only when something is found (no all-clear noise).
+  # Results go to the Security tab (code scanning) — watchers subscribed to
+  # security alerts get notified there, no Slack/webhook plumbing.
   scan-weekly:
-    name: Full Scan + Slack Report
+    name: Full Scan
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code scanning
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
       - name: Run Trivy (all severities)
-        id: trivy
         uses: aquasecurity/trivy-action@v0.36.0
-        # Don't abort the job on findings — the Slack + fail steps run after.
-        continue-on-error: true
         with:
           scan-type: fs
           scanners: vuln
-          exit-code: "1"
-          format: json
-          output: trivy.json
+          format: sarif
+          output: trivy-results.sarif
 
-      - name: Build Slack summary
-        id: summary
-        if: steps.trivy.outcome == 'failure'
-        run: |
-          TOTAL=$(jq '[.Results[]?.Vulnerabilities[]?] | length' trivy.json)
-          BREAKDOWN=$(jq -r '[.Results[]?.Vulnerabilities[]?.Severity]
-            | group_by(.) | map("\(.[0]): \(length)") | join("   ")' trivy.json)
-          LIST=$(jq -r '[.Results[]?.Vulnerabilities[]?]
-            | unique_by(.VulnerabilityID + .PkgName) | .[:15] | .[]
-            | "• `\(.PkgName)` \(.InstalledVersion) — \(.VulnerabilityID) (\(.Severity))"' trivy.json)
-          NOUN="vulnerabilities"
-          [ "$TOTAL" -eq 1 ] && NOUN="vulnerability"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MSG=":rotating_light: *lstk weekly Trivy scan* found ${TOTAL} ${NOUN}
-          *By severity:* ${BREAKDOWN}
-
-          ${LIST}
-
-          <${RUN_URL}|View full log>"
-          jq -n --arg t "$MSG" '{text: $t}' > slack-payload.json
-
-      - name: Notify Slack
-        if: steps.trivy.outcome == 'failure'
-        uses: slackapi/slack-github-action@v3.0.3
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload-file-path: slack-payload.json
-
-      - name: Mark run failed
-        if: steps.trivy.outcome == 'failure'
-        run: exit 1
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,114 @@
+name: Trivy Security Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly full scan, Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Cancel superseded PR runs; non-PR runs get a unique group so they are never
+# interrupted (mirrors ci.yml).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Blocking gate on PRs and pushes to main: fail only on fixable CRITICAL/HIGH
+  # vulnerabilities in Go dependencies, so a red check always has an actionable
+  # fix (bump the dependency). Vulns with no upstream fix don't wedge every PR.
+  scan-pr:
+    name: Dependency Scan
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code scanning
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Writes the SARIF report before honoring exit-code, so a red check (on
+      # findings) and the always-run upload below are not mutually exclusive.
+      - name: Run Trivy (fixable CRITICAL/HIGH)
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          scan-type: fs
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+          format: sarif
+          output: trivy-results.sarif
+
+      # Fork-PR tokens have no security-events:write, so skip the upload there
+      # (the scan + gate still run).
+      - name: Upload SARIF to code scanning
+        if: always() && github.event.pull_request.head.repo.fork != true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
+  # Weekly full scan: every severity, including vulns with no fix yet. New CVEs
+  # land against unchanged code, so this catches what the PR gate never sees.
+  # Reports to Slack only when something is found (no all-clear noise).
+  scan-weekly:
+    name: Full Scan + Slack Report
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Run Trivy (all severities)
+        id: trivy
+        uses: aquasecurity/trivy-action@0.36.0
+        # Don't abort the job on findings — the Slack + fail steps run after.
+        continue-on-error: true
+        with:
+          scan-type: fs
+          scanners: vuln
+          exit-code: "1"
+          format: json
+          output: trivy.json
+
+      - name: Build Slack summary
+        id: summary
+        if: steps.trivy.outcome == 'failure'
+        run: |
+          TOTAL=$(jq '[.Results[]?.Vulnerabilities[]?] | length' trivy.json)
+          BREAKDOWN=$(jq -r '[.Results[]?.Vulnerabilities[]?.Severity]
+            | group_by(.) | map("\(.[0]): \(length)") | join("   ")' trivy.json)
+          LIST=$(jq -r '[.Results[]?.Vulnerabilities[]?]
+            | unique_by(.VulnerabilityID + .PkgName) | .[:15] | .[]
+            | "• `\(.PkgName)` \(.InstalledVersion) — \(.VulnerabilityID) (\(.Severity))"' trivy.json)
+          NOUN="vulnerabilities"
+          [ "$TOTAL" -eq 1 ] && NOUN="vulnerability"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MSG=":rotating_light: *lstk weekly Trivy scan* found ${TOTAL} ${NOUN}
+          *By severity:* ${BREAKDOWN}
+
+          ${LIST}
+
+          <${RUN_URL}|View full log>"
+          jq -n --arg t "$MSG" '{text: $t}' > slack-payload.json
+
+      - name: Notify Slack
+        if: steps.trivy.outcome == 'failure'
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload-file-path: slack-payload.json
+
+      - name: Mark run failed
+        if: steps.trivy.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -35,16 +35,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      # Writes the SARIF report before honoring exit-code, so a red check (on
-      # findings) and the always-run upload below are not mutually exclusive.
-      - name: Run Trivy (fixable CRITICAL/HIGH)
+      # SARIF report for the Security tab covers all severities and never fails
+      # the job (the gate below owns pass/fail). trivy-action ignores severity
+      # filters when format is sarif, so this cannot double as the gate.
+      - name: Run Trivy (SARIF report)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scanners: vuln
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
           format: sarif
           output: trivy-results.sarif
 
@@ -55,6 +53,17 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
+
+      # The blocking gate: fail only on fixable CRITICAL/HIGH vulnerabilities.
+      - name: Run Trivy (fixable CRITICAL/HIGH gate)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+          format: table
 
   # Weekly full scan: every severity, including vulns with no fix yet. New CVEs
   # land against unchanged code, so this catches what the PR gate never sees.


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs [Trivy](https://trivy.dev) against the Go dependencies.

- **On PRs and pushes to main:** fails the check on fixable CRITICAL/HIGH vulnerabilities.
- **Weekly:** full scan across all severities.

Both upload results to the Security tab (code scanning), which annotates PRs inline and notifies watchers subscribed to security alerts.

Closes DEVX-837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)