### PR TITLE
fix: reject directory paths early in snapshot load

### DIFF
--- a/internal/snapshot/destination.go
+++ b/internal/snapshot/destination.go
@@ -205,15 +205,29 @@ func ParseSource(ref, home string) (Destination, error) {
 	return Destination{Kind: KindLocal, Value: resolved}, nil
 }
 
-// resolveSourcePath returns the first existing path among: abs as-is, then
-// abs+".snapshot", then abs+".zip" (legacy).
+// resolveSourcePath returns the first existing file among: abs as-is, then
+// abs+".snapshot", then abs+".zip" (legacy). A directory match is remembered but
+// skipped in favor of a later file match, so a directory error only surfaces when
+// no candidate resolves to an actual file.
 func resolveSourcePath(abs string) (string, error) {
 	withSnapshot := abs + snapshotExt
 	withZip := abs + legacySnapshotExt
+	var dirHit string
 	for _, candidate := range []string{abs, withSnapshot, withZip} {
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
 		}
+		if info.IsDir() {
+			if dirHit == "" {
+				dirHit = candidate
+			}
+			continue
+		}
+		return candidate, nil
+	}
+	if dirHit != "" {
+		return "", fmt.Errorf("%q is a directory, expected a snapshot file", dirHit)
 	}
 	return "", fmt.Errorf("snapshot file not found: %q (also tried %q and %q)", abs, withSnapshot, withZip)
 }

--- a/internal/snapshot/destination.go
+++ b/internal/snapshot/destination.go
@@ -227,7 +227,7 @@ func resolveSourcePath(abs string) (string, error) {
 		return candidate, nil
 	}
 	if dirHit != "" {
-		return "", fmt.Errorf("%q is a directory, expected a snapshot file", dirHit)
+		return "", fmt.Errorf("%q is a directory — specify a snapshot file, e.g. ./my-snapshot.snapshot", dirHit)
 	}
 	return "", fmt.Errorf("snapshot file not found: %q (also tried %q and %q)", abs, withSnapshot, withZip)
 }

--- a/internal/snapshot/destination_test.go
+++ b/internal/snapshot/destination_test.go
@@ -47,8 +47,6 @@ func TestParseShowable(t *testing.T) {
 
 func TestParseSource(t *testing.T) {
 	t.Parallel()
-	wd, err := os.Getwd()
-	require.NoError(t, err)
 	// Use a temp dir as home so the test doesn't depend on the real $HOME
 	// (e.g. under Nix's sandboxed build, $HOME is a non-existent placeholder).
 	home := t.TempDir()
@@ -64,6 +62,10 @@ func TestParseSource(t *testing.T) {
 	require.NoError(t, os.WriteFile(existingLegacyBare+".zip", []byte("data"), 0600))
 	existingNoExt := filepath.Join(dir, "noext") // no extension, no fallback counterpart either
 	require.NoError(t, os.WriteFile(existingNoExt, []byte("data"), 0600))
+	plainDir := filepath.Join(dir, "some-directory")
+	require.NoError(t, os.Mkdir(plainDir, 0o755))
+	snapshotExtDir := filepath.Join(dir, "looks-like-a-snapshot.snapshot")
+	require.NoError(t, os.Mkdir(snapshotExtDir, 0o755))
 
 	type testCase struct {
 		name          string
@@ -126,18 +128,26 @@ func TestParseSource(t *testing.T) {
 			wantErr: "snapshot file not found",
 		},
 		{
-			name:     "relative path resolved via cwd",
-			input:    ".",
-			wantKind: snapshot.KindLocal,
-			wantPath: wd,
+			name:    "directory instead of file returns clear error",
+			input:   plainDir,
+			wantErr: "is a directory",
+		},
+		{
+			name:    "directory with .snapshot extension returns clear error",
+			input:   snapshotExtDir,
+			wantErr: "is a directory",
+		},
+		{
+			name:    "relative path resolved via cwd is a directory",
+			input:   ".",
+			wantErr: "is a directory",
 		},
 
 		// --- tilde expansion ---
 		{
-			name:     "tilde expands to home",
-			input:    "~/.",
-			wantKind: snapshot.KindLocal,
-			wantPath: home,
+			name:    "tilde expands to home which is a directory",
+			input:   "~/.",
+			wantErr: "is a directory",
 		},
 
 		// --- pod sources ---

--- a/test/integration/snapshot_load_test.go
+++ b/test/integration/snapshot_load_test.go
@@ -175,6 +175,25 @@ func TestSnapshotLoadFileNotFound(t *testing.T) {
 	assert.Contains(t, stderr, "snapshot file not found")
 }
 
+// TestSnapshotLoadPathIsDirectory ensures passing a directory instead of a
+// snapshot file fails early with a clear message, instead of surfacing a
+// confusing HTTP-layer error once the directory reaches the upload code path.
+func TestSnapshotLoadPathIsDirectory(t *testing.T) {
+	t.Parallel()
+	ctx := testContext(t)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "some-directory")
+	require.NoError(t, os.Mkdir(target, 0o755))
+
+	_, stderr, err := runLstk(t, ctx, t.TempDir(),
+		testEnvWithHome(t.TempDir(), ""),
+		"--non-interactive", "snapshot", "load", target,
+	)
+	requireExitCode(t, 1, err)
+	assert.Contains(t, stderr, "is a directory")
+}
+
 // --- Docker required ---
 
 func TestSnapshotLoadLocalSuccess(t *testing.T) {


### PR DESCRIPTION
lstk snapshot load accepted a directory path and let it fall through to the upload code path, where it failed with a confusing HTTP-layer error. Now it returns a clear "<path>" is a directory, expected a snapshot file error when no file candidate resolves instead of silently treating a directory (e.g. . or ~/) as a valid local snapshot source.


| Before | After |
|---|---|
| <img width="1083" height="108" alt="imagen" src="https://github.com/user-attachments/assets/32ec4296-481f-4fc5-a4d5-98f8e2fcb5a1" /> | <img width="750" height="37" alt="imagen" src="https://github.com/user-attachments/assets/aac9aca9-50e4-4935-a9bc-da90935b1d95" /> | 

