### PR TITLE
fix: don't let LOCALSTACK_PATH clobber emulator PATH

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -82,11 +82,12 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 	tel := opts.Telemetry
 
 	hostEnv, droppedEnv := filterHostEnv(os.Environ())
-	for _, name := range droppedEnv {
-		sink.Emit(output.MessageEvent{
-			Severity: output.SeverityWarning,
-			Text:     fmt.Sprintf("Not forwarding %s to the emulator: it would override %s inside the emulator", name, strings.TrimPrefix(name, "LOCALSTACK_")),
-		})
+	for _, d := range droppedEnv {
+		text := fmt.Sprintf("Not forwarding %s to the emulator: it would override %s inside the emulator", d.name, d.overrides)
+		if d.overrides == "" {
+			text = fmt.Sprintf("Not forwarding %s to the emulator: its value contains line breaks", d.name)
+		}
+		sink.Emit(output.MessageEvent{Severity: output.SeverityWarning, Text: text})
 	}
 	agentEnvVars := agentEnv(caller.New().Classify())
 
@@ -880,25 +881,43 @@ func awaitStartup(ctx context.Context, rt runtime.Runtime, sink output.Sink, con
 	}
 }
 
+// droppedHostEnv is a host variable filterHostEnv refused to forward, so the
+// caller can warn the user. overrides names the critical variable the
+// entrypoint-stripped name would clobber inside the emulator; it is empty when
+// the entry was dropped for carrying a multi-line value instead.
+type droppedHostEnv struct {
+	name      string
+	overrides string
+}
+
 // filterHostEnv returns the subset of host environment entries that should be
 // forwarded to the emulator container. It keeps CI and LOCALSTACK_* variables
-// but explicitly drops LOCALSTACK_AUTH_TOKEN so the host value cannot overwrite
-// the token resolved by lstk (which may come from the keyring), and drops
-// variables whose prefix-stripped name would clobber a critical variable
-// inside the emulator (see stripsToCriticalVar). The names of the latter are
-// returned in dropped so callers can warn the user; the LOCALSTACK_AUTH_TOKEN
-// drop is silent because lstk forwards its own resolved token instead.
-func filterHostEnv(envList []string) (out, dropped []string) {
+// but drops entries that would corrupt the emulator environment:
+//   - LOCALSTACK_AUTH_TOKEN, so the host value cannot overwrite the token
+//     resolved by lstk (which may come from the keyring); this drop is silent
+//     because lstk forwards its own resolved token instead;
+//   - values containing a newline or carriage return: the entrypoint re-exports
+//     variables through a line-oriented `env | sed` pipeline, so an embedded
+//     line like "LOCALSTACK_PATH=" would inject a rogue export that blanks PATH;
+//   - variables whose prefix-stripped name would clobber a critical variable
+//     inside the emulator (see criticalContainerVar).
+//
+// The latter two are returned in dropped so callers can warn the user.
+func filterHostEnv(envList []string) (out []string, dropped []droppedHostEnv) {
 	for _, e := range envList {
-		if !strings.HasPrefix(e, "CI=") && !strings.HasPrefix(e, "LOCALSTACK_") {
+		key, value, ok := strings.Cut(e, "=")
+		if !ok || (key != "CI" && !strings.HasPrefix(key, "LOCALSTACK_")) {
 			continue
 		}
-		if strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=") {
+		if key == "LOCALSTACK_AUTH_TOKEN" {
 			continue
 		}
-		if stripsToCriticalVar(e) {
-			name, _, _ := strings.Cut(e, "=")
-			dropped = append(dropped, name)
+		if strings.ContainsAny(value, "\n\r") {
+			dropped = append(dropped, droppedHostEnv{name: key})
+			continue
+		}
+		if name := strings.TrimPrefix(key, "LOCALSTACK_"); name != key && criticalContainerVar(name) {
+			dropped = append(dropped, droppedHostEnv{name: key, overrides: name})
 			continue
 		}
 		out = append(out, e)
@@ -906,18 +925,17 @@ func filterHostEnv(envList []string) (out, dropped []string) {
 	return out, dropped
 }
 
-// stripsToCriticalVar reports whether forwarding the LOCALSTACK_* entry would
-// break the emulator: the image's docker-entrypoint.sh strips the LOCALSTACK_
-// prefix and re-exports the remainder (only LOCALSTACK_HOST/LOCALSTACK_HOSTNAME
-// are excluded), so e.g. a host LOCALSTACK_PATH becomes PATH inside the
-// emulator and startup dies with "mkdir: command not found" (DEVX-984).
-func stripsToCriticalVar(entry string) bool {
-	name, _, found := strings.Cut(strings.TrimPrefix(entry, "LOCALSTACK_"), "=")
-	if !found {
-		return false
-	}
+// criticalContainerVar reports whether a LOCALSTACK_* variable stripped to name
+// would break the emulator: the image's docker-entrypoint.sh strips the
+// LOCALSTACK_ prefix and re-exports the remainder (only LOCALSTACK_HOST and
+// LOCALSTACK_HOSTNAME are excluded), so e.g. a host LOCALSTACK_PATH becomes
+// PATH inside the emulator and startup dies with "mkdir: command not found"
+// (DEVX-984). IFS is included because the entrypoint sources the stripped
+// exports mid-script, corrupting its own word splitting.
+func criticalContainerVar(name string) bool {
 	switch name {
-	case "PATH", "HOME", "LD_PRELOAD", "LD_LIBRARY_PATH", "PYTHONPATH", "PYTHONHOME":
+	case "PATH", "HOME", "SHELL", "IFS", "ENV", "BASH_ENV",
+		"LD_PRELOAD", "LD_LIBRARY_PATH", "PYTHONPATH", "PYTHONHOME":
 		return true
 	}
 	return false

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -927,14 +927,18 @@ func filterHostEnv(envList []string) (out []string, dropped []droppedHostEnv) {
 
 // criticalContainerVar reports whether a LOCALSTACK_* variable stripped to name
 // would break the emulator: the image's docker-entrypoint.sh strips the
-// LOCALSTACK_ prefix and re-exports the remainder (only LOCALSTACK_HOST and
-// LOCALSTACK_HOSTNAME are excluded), so e.g. a host LOCALSTACK_PATH becomes
-// PATH inside the emulator and startup dies with "mkdir: command not found"
-// (DEVX-984). IFS is included because the entrypoint sources the stripped
-// exports mid-script, corrupting its own word splitting.
+// LOCALSTACK_ prefix and re-exports the remainder (skipping only LOCALSTACK_HOST*
+// and names starting with a digit), so e.g. a host LOCALSTACK_PATH becomes PATH
+// inside the emulator and startup dies with "mkdir: command not found" (DEVX-984).
+// Each entry has a verified failure mode in the image (localstack/lstk#378):
+// HOME redirects every ~-anchored path (plugin cache, ~/.localstack, ~/.aws);
+// IFS corrupts word splitting in the shell sourcing the re-exports; BASH_ENV
+// names a file every non-interactive bash executes (e.g. init hooks); LD_*
+// hijack the dynamic loader for every process; PYTHONHOME is fatal to the
+// interpreter and PYTHONPATH shadows the emulator's imports.
 func criticalContainerVar(name string) bool {
 	switch name {
-	case "PATH", "HOME", "SHELL", "IFS", "ENV", "BASH_ENV",
+	case "PATH", "HOME", "IFS", "BASH_ENV",
 		"LD_PRELOAD", "LD_LIBRARY_PATH", "PYTHONPATH", "PYTHONHOME":
 		return true
 	}

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -81,7 +81,13 @@ func Start(ctx context.Context, rt runtime.Runtime, sink output.Sink, opts Start
 
 	tel := opts.Telemetry
 
-	hostEnv := filterHostEnv(os.Environ())
+	hostEnv, droppedEnv := filterHostEnv(os.Environ())
+	for _, name := range droppedEnv {
+		sink.Emit(output.MessageEvent{
+			Severity: output.SeverityWarning,
+			Text:     fmt.Sprintf("Not forwarding %s to the emulator: it would override %s inside the emulator", name, strings.TrimPrefix(name, "LOCALSTACK_")),
+		})
+	}
 	agentEnvVars := agentEnv(caller.New().Classify())
 
 	containers := make([]runtime.ContainerConfig, len(opts.Containers))
@@ -877,16 +883,44 @@ func awaitStartup(ctx context.Context, rt runtime.Runtime, sink output.Sink, con
 // filterHostEnv returns the subset of host environment entries that should be
 // forwarded to the emulator container. It keeps CI and LOCALSTACK_* variables
 // but explicitly drops LOCALSTACK_AUTH_TOKEN so the host value cannot overwrite
-// the token resolved by lstk (which may come from the keyring).
-func filterHostEnv(envList []string) []string {
-	var out []string
+// the token resolved by lstk (which may come from the keyring), and drops
+// variables whose prefix-stripped name would clobber a critical variable
+// inside the emulator (see stripsToCriticalVar). The names of the latter are
+// returned in dropped so callers can warn the user; the LOCALSTACK_AUTH_TOKEN
+// drop is silent because lstk forwards its own resolved token instead.
+func filterHostEnv(envList []string) (out, dropped []string) {
 	for _, e := range envList {
-		if strings.HasPrefix(e, "CI=") ||
-			(strings.HasPrefix(e, "LOCALSTACK_") && !strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=")) {
-			out = append(out, e)
+		if !strings.HasPrefix(e, "CI=") && !strings.HasPrefix(e, "LOCALSTACK_") {
+			continue
 		}
+		if strings.HasPrefix(e, "LOCALSTACK_AUTH_TOKEN=") {
+			continue
+		}
+		if stripsToCriticalVar(e) {
+			name, _, _ := strings.Cut(e, "=")
+			dropped = append(dropped, name)
+			continue
+		}
+		out = append(out, e)
 	}
-	return out
+	return out, dropped
+}
+
+// stripsToCriticalVar reports whether forwarding the LOCALSTACK_* entry would
+// break the emulator: the image's docker-entrypoint.sh strips the LOCALSTACK_
+// prefix and re-exports the remainder (only LOCALSTACK_HOST/LOCALSTACK_HOSTNAME
+// are excluded), so e.g. a host LOCALSTACK_PATH becomes PATH inside the
+// emulator and startup dies with "mkdir: command not found" (DEVX-984).
+func stripsToCriticalVar(entry string) bool {
+	name, _, found := strings.Cut(strings.TrimPrefix(entry, "LOCALSTACK_"), "=")
+	if !found {
+		return false
+	}
+	switch name {
+	case "PATH", "HOME", "LD_PRELOAD", "LD_LIBRARY_PATH", "PYTHONPATH", "PYTHONHOME":
+		return true
+	}
+	return false
 }
 
 func envHasKey(env []string, key string) bool {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -390,12 +390,18 @@ func TestFilterHostEnv(t *testing.T) {
 		"LOCALSTACK_API_ENDPOINT=https://example.test",
 		"LOCALSTACK_AUTH_TOKEN=host-token",
 		"LOCALSTACK_PERSISTENCE=1",
+		"LOCALSTACK_PATH=/home/user/repos/localstack",
+		"LOCALSTACK_HOME=/root",
+		"LOCALSTACK_PYTHONPATH=/opt/code",
+		"LOCALSTACK_LD_PRELOAD=/lib/evil.so",
+		"LOCALSTACK_PATHFINDER=1",
+		"LOCALSTACK_HOSTNAME=custom.host",
 		"PATH=/usr/bin",
 		"HOME=/home/user",
 		"CI_PIPELINE=foo",
 	}
 
-	got := filterHostEnv(input)
+	got, dropped := filterHostEnv(input)
 
 	assert.Contains(t, got, "CI=true")
 	assert.Contains(t, got, "LOCALSTACK_DISABLE_EVENTS=1")
@@ -406,6 +412,16 @@ func TestFilterHostEnv(t *testing.T) {
 	assert.NotContains(t, got, "PATH=/usr/bin")
 	assert.NotContains(t, got, "HOME=/home/user")
 	assert.NotContains(t, got, "CI_PIPELINE=foo", "only exact CI= must be forwarded, not CI_*")
+	assert.NotContains(t, got, "LOCALSTACK_PATH=/home/user/repos/localstack",
+		"the emulator entrypoint strips the LOCALSTACK_ prefix, so forwarding this would override PATH inside the emulator and break startup (DEVX-984)")
+	assert.NotContains(t, got, "LOCALSTACK_HOME=/root")
+	assert.NotContains(t, got, "LOCALSTACK_PYTHONPATH=/opt/code")
+	assert.NotContains(t, got, "LOCALSTACK_LD_PRELOAD=/lib/evil.so")
+	assert.Contains(t, got, "LOCALSTACK_PATHFINDER=1", "only exact critical names are blocked after prefix stripping, not name prefixes")
+	assert.Contains(t, got, "LOCALSTACK_HOSTNAME=custom.host",
+		"the entrypoint excludes LOCALSTACK_HOSTNAME from prefix stripping, so it stays forwardable")
+	assert.Equal(t, []string{"LOCALSTACK_PATH", "LOCALSTACK_HOME", "LOCALSTACK_PYTHONPATH", "LOCALSTACK_LD_PRELOAD"}, dropped,
+		"dropped variable names are reported so start can warn the user; the intentional LOCALSTACK_AUTH_TOKEN drop is not warned about")
 }
 
 func TestAgentEnv(t *testing.T) {

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -395,6 +395,9 @@ func TestFilterHostEnv(t *testing.T) {
 		"LOCALSTACK_PYTHONPATH=/opt/code",
 		"LOCALSTACK_LD_PRELOAD=/lib/evil.so",
 		"LOCALSTACK_IFS=:",
+		"LOCALSTACK_BASH_ENV=/etc/os-release",
+		"LOCALSTACK_SHELL=/bin/zsh",
+		"LOCALSTACK_ENV=dev",
 		"LOCALSTACK_MULTILINE=a\nLOCALSTACK_PATH=",
 		"LOCALSTACK_PATHFINDER=1",
 		"LOCALSTACK_HOSTNAME=custom.host",
@@ -421,6 +424,12 @@ func TestFilterHostEnv(t *testing.T) {
 	assert.NotContains(t, got, "LOCALSTACK_LD_PRELOAD=/lib/evil.so")
 	assert.NotContains(t, got, "LOCALSTACK_IFS=:",
 		"the entrypoint sources the stripped exports mid-script, so IFS would corrupt its word splitting")
+	assert.NotContains(t, got, "LOCALSTACK_BASH_ENV=/etc/os-release",
+		"every non-interactive bash in the container executes the file BASH_ENV names, e.g. init hooks")
+	assert.Contains(t, got, "LOCALSTACK_SHELL=/bin/zsh",
+		"SHELL is deliberately forwarded: nothing in the image reads it")
+	assert.Contains(t, got, "LOCALSTACK_ENV=dev",
+		"ENV is deliberately forwarded: only interactive shells read it, and they never inherit the re-exported env")
 	assert.NotContains(t, got, "LOCALSTACK_MULTILINE=a\nLOCALSTACK_PATH=",
 		"a multi-line value is split by the entrypoint's line-oriented env pipeline and can inject rogue exports like a blank PATH")
 	assert.Contains(t, got, "LOCALSTACK_PATHFINDER=1", "only exact critical names are blocked after prefix stripping, not name prefixes")
@@ -432,6 +441,7 @@ func TestFilterHostEnv(t *testing.T) {
 		{name: "LOCALSTACK_PYTHONPATH", overrides: "PYTHONPATH"},
 		{name: "LOCALSTACK_LD_PRELOAD", overrides: "LD_PRELOAD"},
 		{name: "LOCALSTACK_IFS", overrides: "IFS"},
+		{name: "LOCALSTACK_BASH_ENV", overrides: "BASH_ENV"},
 		{name: "LOCALSTACK_MULTILINE"},
 	}, dropped,
 		"dropped variables are reported with the reason so start can warn the user; the intentional LOCALSTACK_AUTH_TOKEN drop is not warned about")

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -394,6 +394,8 @@ func TestFilterHostEnv(t *testing.T) {
 		"LOCALSTACK_HOME=/root",
 		"LOCALSTACK_PYTHONPATH=/opt/code",
 		"LOCALSTACK_LD_PRELOAD=/lib/evil.so",
+		"LOCALSTACK_IFS=:",
+		"LOCALSTACK_MULTILINE=a\nLOCALSTACK_PATH=",
 		"LOCALSTACK_PATHFINDER=1",
 		"LOCALSTACK_HOSTNAME=custom.host",
 		"PATH=/usr/bin",
@@ -417,11 +419,22 @@ func TestFilterHostEnv(t *testing.T) {
 	assert.NotContains(t, got, "LOCALSTACK_HOME=/root")
 	assert.NotContains(t, got, "LOCALSTACK_PYTHONPATH=/opt/code")
 	assert.NotContains(t, got, "LOCALSTACK_LD_PRELOAD=/lib/evil.so")
+	assert.NotContains(t, got, "LOCALSTACK_IFS=:",
+		"the entrypoint sources the stripped exports mid-script, so IFS would corrupt its word splitting")
+	assert.NotContains(t, got, "LOCALSTACK_MULTILINE=a\nLOCALSTACK_PATH=",
+		"a multi-line value is split by the entrypoint's line-oriented env pipeline and can inject rogue exports like a blank PATH")
 	assert.Contains(t, got, "LOCALSTACK_PATHFINDER=1", "only exact critical names are blocked after prefix stripping, not name prefixes")
 	assert.Contains(t, got, "LOCALSTACK_HOSTNAME=custom.host",
 		"the entrypoint excludes LOCALSTACK_HOSTNAME from prefix stripping, so it stays forwardable")
-	assert.Equal(t, []string{"LOCALSTACK_PATH", "LOCALSTACK_HOME", "LOCALSTACK_PYTHONPATH", "LOCALSTACK_LD_PRELOAD"}, dropped,
-		"dropped variable names are reported so start can warn the user; the intentional LOCALSTACK_AUTH_TOKEN drop is not warned about")
+	assert.Equal(t, []droppedHostEnv{
+		{name: "LOCALSTACK_PATH", overrides: "PATH"},
+		{name: "LOCALSTACK_HOME", overrides: "HOME"},
+		{name: "LOCALSTACK_PYTHONPATH", overrides: "PYTHONPATH"},
+		{name: "LOCALSTACK_LD_PRELOAD", overrides: "LD_PRELOAD"},
+		{name: "LOCALSTACK_IFS", overrides: "IFS"},
+		{name: "LOCALSTACK_MULTILINE"},
+	}, dropped,
+		"dropped variables are reported with the reason so start can warn the user; the intentional LOCALSTACK_AUTH_TOKEN drop is not warned about")
 }
 
 func TestAgentEnv(t *testing.T) {

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -661,12 +661,19 @@ func TestStartCommandPassesCIAndLocalStackEnvVars(t *testing.T) {
 	defer mockServer.Close()
 
 	ctx := testContext(t)
-	_, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL).
+	// LOCALSTACK_PATH must not reach the emulator: its entrypoint strips the
+	// LOCALSTACK_ prefix and re-exports the rest, so a forwarded LOCALSTACK_PATH
+	// overrides PATH inside the emulator and startup dies with
+	// "mkdir: command not found" (DEVX-984).
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.APIEndpoint, mockServer.URL).
 		With(env.CI, "true").
-		With(env.DisableEvents, "1"),
+		With(env.DisableEvents, "1").
+		With("LOCALSTACK_PATH", "/home/user/repos/localstack"),
 		"start")
 	require.NoError(t, err, "lstk start failed: %s", stderr)
 	requireExitCode(t, 0, err)
+	assert.Contains(t, stdout+stderr, "Not forwarding LOCALSTACK_PATH",
+		"dropping a critical-collision variable must be surfaced to the user")
 
 	inspect, err := dockerClient.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
 	require.NoError(t, err, "failed to inspect container")
@@ -676,6 +683,7 @@ func TestStartCommandPassesCIAndLocalStackEnvVars(t *testing.T) {
 	assert.Equal(t, "true", envVars["CI"])
 	assert.Equal(t, "1", envVars["LOCALSTACK_DISABLE_EVENTS"])
 	assert.NotEmpty(t, envVars["LOCALSTACK_AUTH_TOKEN"])
+	assert.NotContains(t, envVars, "LOCALSTACK_PATH")
 }
 
 func TestStartCommandPersistFlagSetsPersistenceEnv(t *testing.T) {


### PR DESCRIPTION
## Motivation

Reported in DEVX-984 (Slack, patrick.lafond): `lstk start` died with `/usr/local/bin/docker-entrypoint.sh: line 22: mkdir: command not found` on any config, tag, and lstk version, but only on one machine. **Root cause since confirmed by the reporter**: a `LOCALSTACK_PATH` var exported in his zsh config (pointing agents at a localstack source checkout); `env -u LOCALSTACK_PATH lstk` starts cleanly.

Why it breaks: since #161 lstk forwards every host `LOCALSTACK_*` env var into the emulator. The emulator image's `docker-entrypoint.sh` strips the `LOCALSTACK_` prefix and re-exports the remainder (excluded: `LOCALSTACK_HOST*` and names whose stripped remainder starts with a digit), so `LOCALSTACK_PATH=/home/user/repos/localstack` becomes `export PATH=/home/user/repos/localstack` inside the emulator. The entrypoint itself is started by absolute path, so the first command that needs `PATH` is `mkdir` — exactly the reported failure — and `set -eo pipefail` kills startup.

## Changes

- `filterHostEnv` drops `LOCALSTACK_*` vars whose prefix-stripped name collides with a critical runtime variable: `PATH`, `HOME`, `IFS`, `BASH_ENV`, `LD_PRELOAD`, `LD_LIBRARY_PATH`, `PYTHONPATH`, `PYTHONHOME` (`criticalContainerVar`). Every entry has a failure mode verified against the actual image: `HOME` silently redirects every `~`-anchored path (plugin cache, `~/.localstack`, `~/.aws`), `BASH_ENV` names a file every non-interactive bash executes (init hooks inherit it), `LD_*` hijack the dynamic loader for every process, `PYTHONHOME` is fatal to the interpreter, `PYTHONPATH` shadows emulator imports, and `IFS` corrupts word splitting in the shell sourcing the re-exports. Matching is on the exact stripped name, so near misses like `LOCALSTACK_PATHFINDER`, `LOCALSTACK_SHELL`, or `LOCALSTACK_ENV` still forward, and `LOCALSTACK_HOSTNAME` still forwards since the entrypoint excludes it from stripping.
- `filterHostEnv` also drops forwarded values containing a newline/CR: the entrypoint re-exports vars through a line-oriented `env | sed` pipeline, so an embedded line like `LOCALSTACK_PATH=` injects a rogue `export PATH=` that blanks `PATH` — a second, independent way to hit the same crash (adopted from #379).
- Dropped vars are returned as `droppedHostEnv{name, overrides}` and `Start` emits a warning for each, with the reason (`…it would override PATH inside the emulator` / `…its value contains line breaks`), so neither drop is silent. The long-standing `LOCALSTACK_AUTH_TOKEN` drop stays silent as before.

## Testing

- Extended `TestFilterHostEnv` unit test covering both drop reasons, the reported drop metadata, and the names that must keep forwarding (fails before the fix).
- Extended the `TestStartCommandPassesCIAndLocalStackEnvVars` integration test to start with `LOCALSTACK_PATH` set: before the fix the emulator dies exactly as reported; after it, start succeeds, the warning is printed, and the var is absent from the container env. Needs Docker + `LOCALSTACK_AUTH_TOKEN`, so it runs in CI.

Supersedes #379 (its multiline guard and wider reserved set are folded in here, with warnings added on top).

A follow-up worth filing separately: excluding `PATH` and friends from prefix-stripping in the image entrypoint itself, which would also protect compose users who export `LOCALSTACK_PATH` without lstk involved.

Fixes DEVX-984
