### PR TITLE
fix: search for colima socket under ~/.config

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -60,6 +60,7 @@ func NewDockerRuntime(dockerHost string) (*DockerRuntime, error) {
 func vmSocketPaths(home string) []string {
 	return []string{
 		filepath.Join(home, ".docker", "run", "docker.sock"),
+		filepath.Join(home, ".config", "colima", "default", "docker.sock"),
 		filepath.Join(home, ".colima", "default", "docker.sock"),
 		filepath.Join(home, ".colima", "docker.sock"),
 		filepath.Join(home, ".orbstack", "run", "docker.sock"),


### PR DESCRIPTION
On my system the colima socket path is at `~/.config/colima/default/docker.sock` which is not included in the `vmSocketPaths` list of search directories. This means I have to set `DOCKER_HOST=...` however I was getting an error 

```
✗ failed to start LocalStack: Error response from daemon: error while creating mount source path '/Users/simon/.config/colima/default/docker.sock': mkdir
  /Users/simon/.config/colima/default/docker.sock: operation not supported
```

I do not know the source of this error, however updating the search paths as shown in this PR correctly finds the docker socket, and does _not_ try to `mkdir` the socket location.
