### PR TITLE
docs: update README and docs for v0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Running `lstk` will automatically handle configuration setup and start LocalStac
 - **Extensions** — Git-style `lstk-<name>` executables extend the CLI with new commands
 - **Self-update** — check for and install the latest `lstk` release with `lstk update`
 - **Shell completions** — bash, zsh, and fish completions included
+- **Structured JSON output** — pass `--json` to a supported command (`stop`, `reset`, `update` today, more planned) for a machine-readable envelope instead of formatted text; see [docs/structured-output.md](docs/structured-output.md)
 
 ## Authentication
 
@@ -223,7 +224,7 @@ volumes = ["/data:/var/lib/localstack"]
 `lstk start` degrades gracefully when the common enterprise blockers (Docker Hub unreachable, a forward proxy, TLS interception, or an unreachable license server) make a network request fail:
 
 - If the image cannot be pulled but is already present locally, `lstk` warns and starts the local image instead of failing.
-- If the license server cannot be reached, `lstk` skips its pre-flight check and lets the emulator validate the license at startup. A definitive rejection from the server (e.g. an invalid token) stays fatal.
+- If the license server cannot be reached, or it rejects the configured image tag as unrecognized (e.g. a `dev` nightly or a custom enterprise-mirror tag), `lstk` skips its pre-flight check and lets the emulator validate the license at startup. A definitive rejection from the server (e.g. an invalid token) stays fatal.
 
 Pair this with a custom `image` in the config to point at a locally loaded image or an internal-registry mirror.
 


### PR DESCRIPTION
## Summary

Full documentation audit for the v0.17.0 release (docs were last updated for v0.16.0 in #377). Reviewed every source change since then (#361, #374, #383, #385) against README.md, CLAUDE.md/AGENTS.md, and all files under docs/.

Most of the delta was already documented in-PR: #374 shipped `docs/structured-output.md` alongside its code, and #385 updated CLAUDE.md's and README's offline/enterprise-license sections directly. #361 (log wrapping) and #383 (colima socket path) are internal implementation details with no user-facing doc surface.

Two README gaps remained after cross-checking against `--help` output and source:

- **README.md**: the offline/enterprise-environments bullet only described the "license server unreachable" degradation; #385 added a second, distinct case (server reachable but rejects the tag *format*, e.g. `dev` nightlies or custom enterprise-mirror tags) that also degrades gracefully. Extended the bullet to cover both.
- **README.md**: the `--json` flag (visible in `lstk --help`, documented in full in `docs/structured-output.md`) had no mention anywhere in the README. Added a one-line Features entry linking to the doc.

## Needs a human decision

- The `--json` Features bullet is new public messaging. `docs/structured-output.md` explicitly frames the feature as an early, partial rollout (only `stop`/`reset`/`update` support it; the rest is a "first-draft proposal"). Please sanity-check whether surfacing it in the README's Features list is desired yet, or if it's too early relative to the rollout stage.

## Test plan

- [x] `make build` succeeds
- [x] Cross-checked `lstk --help` and per-command `--help` output against README/CLAUDE.md command lists and descriptions
- [x] Verified `docs/extensions-authoring.md` and `docs/structured-output.md` against `internal/extension/`, `cmd/extension.go`, and `internal/output/error_code.go` (no drift found)
- [x] Verified `docs/RELEASING.md` workflow names/files against `.github/workflows/`
