### PR TITLE
Fix test-integration running against a stale binary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ This installs a [gitleaks](https://github.com/gitleaks/gitleaks) hook that scans
 ```bash
 make build              # Compiles to bin/lstk
 make test               # Run unit tests (cmd/ and internal/) via gotestsum
-make test-integration   # Run integration tests (builds first, requires Docker)
+make test-integration   # Run integration tests (rebuilds bin/lstk first, requires Docker)
 make lint               # Run golangci-lint
 make mock-generate      # Run go generate to regenerate mocks
 make clean              # Remove build artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ make build              # Compiles to bin/lstk
 
 ```bash
 make test               # Run unit tests (cmd/ and internal/) via gotestsum
-make test-integration   # Run integration tests (requires Docker)
+make test-integration   # Run integration tests (rebuilds bin/lstk first, requires Docker)
 make lint               # Run golangci-lint
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ export CGO_ENABLED=0
 
 .PHONY: build clean test test-integration lint mock-generate otel
 
-$(BUILD_DIR)/$(BINARY_NAME):
+# Always invoke `go build` and let Go's build cache handle incrementality; a
+# file target on bin/lstk would be skipped when the binary exists, even with
+# stale sources.
+build:
 	go build -o $(BUILD_DIR)/$(BINARY_NAME) .
-
-build: clean $(BUILD_DIR)/$(BINARY_NAME)
 
 clean:
 	rm -rf $(BUILD_DIR)
@@ -19,7 +20,7 @@ test:
 	@JUNIT=""; [ -n "$$CREATE_JUNIT_REPORT" ] && JUNIT="--junitfile test-results.xml"; \
 	go run gotest.tools/gotestsum@latest --format testname $$JUNIT -- ./cmd/... ./internal/...
 
-test-integration: $(BUILD_DIR)/$(BINARY_NAME)
+test-integration: build
 	@RUN="$(RUN)" ./scripts/test-integration.sh
 
 otel:


### PR DESCRIPTION
## Motivation

`make test-integration` depended on a `bin/lstk` file target with no prerequisites, so make skipped the build whenever the binary existed — the tests silently ran against stale sources after any code change unless you remembered to `make build` first.

## Changes

- Make `build` a phony target that always invokes `go build`, deferring incrementality to Go's build cache (a no-op-fast cache hit when nothing changed)
- Point `test-integration` at `build` so the binary is always fresh
- Drop the `clean` prerequisite from `build` — it only existed to defeat the old file target's existence check (and was a latent race under `make -j`); standalone `make clean` remains
- Update CLAUDE.md and CONTRIBUTING.md to document that `make test-integration` rebuilds the binary first

## Tests

Verified `make -n test-integration` runs `go build` before the test script, and ran `make build` + `make test-integration` end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)