### PR TITLE
Warn when multiple lstk installs are detected on PATH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Notes:
   - `terminal/` - Plain-mode terminal helpers (spinner, TTY detection)
   - `tracing/` - OpenTelemetry setup (`LSTK_OTEL=1`)
   - `ui/` - Bubble Tea views for interactive output
-  - `update/` - Self-update logic: version check via GitHub API, binary/Homebrew/npm update paths, archive extraction
+  - `update/` - Self-update logic: version check via GitHub API, binary/Homebrew/npm update paths, archive extraction; also detects multiple lstk installs on PATH (`FindInstalls`/`WarnMultipleInstalls`, warned on `lstk update` and the start-path update notification)
   - `version/` - Version info
   - `volume/` - `lstk volume` domain logic
 

--- a/internal/output/envelope_sink.go
+++ b/internal/output/envelope_sink.go
@@ -25,6 +25,10 @@ func NewEnvelopeSink(format Format) *EnvelopeSink {
 // which carries no machine-readable code of its own today.
 const warningCodeNotice = "NOTICE"
 
+// warningCodeMultipleInstalls flags that more than one distinct lstk install
+// was found on PATH.
+const warningCodeMultipleInstalls = "MULTIPLE_INSTALLS"
+
 func (s *EnvelopeSink) Emit(event Event) {
 	switch e := event.(type) {
 	case DeferredEvent:
@@ -35,6 +39,15 @@ func (s *EnvelopeSink) Emit(event Event) {
 		if e.Severity == SeverityWarning {
 			s.warnings = append(s.warnings, Warning{Code: warningCodeNotice, Message: e.Text})
 		}
+	case MultipleInstallsEvent:
+		paths := make([]string, len(e.Installs))
+		for i, in := range e.Installs {
+			paths[i] = in.Path
+		}
+		s.warnings = append(s.warnings, Warning{
+			Code:    warningCodeMultipleInstalls,
+			Message: "Multiple lstk installations found on PATH: " + strings.Join(paths, ", "),
+		})
 	case EmulatorStoppedEvent:
 		s.appendEmulator(JsonStoppedEmulator{
 			JsonEmulatorRef: JsonEmulatorRef{Type: e.Type, Name: e.Name},

--- a/internal/output/envelope_sink_test.go
+++ b/internal/output/envelope_sink_test.go
@@ -288,6 +288,29 @@ func TestEnvelopeSink_WarningsAccumulate(t *testing.T) {
 	}
 }
 
+func TestEnvelopeSink_MultipleInstallsBecomesWarning(t *testing.T) {
+	t.Parallel()
+
+	sink := NewEnvelopeSink(FormatJSON)
+	sink.Emit(MultipleInstallsEvent{Installs: []InstallLocation{
+		{Path: "/opt/homebrew/bin/lstk", Method: "homebrew", Running: true},
+		{Path: "/home/u/.nvm/versions/node/v22/bin/lstk", Method: "npm"},
+	}})
+
+	envelope := sink.Result("update", nil)
+	if len(envelope.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %+v", len(envelope.Warnings), envelope.Warnings)
+	}
+	w := envelope.Warnings[0]
+	if w.Code != warningCodeMultipleInstalls {
+		t.Fatalf("expected code %q, got %q", warningCodeMultipleInstalls, w.Code)
+	}
+	want := "Multiple lstk installations found on PATH: /opt/homebrew/bin/lstk, /home/u/.nvm/versions/node/v22/bin/lstk"
+	if w.Message != want {
+		t.Fatalf("unexpected message: %q", w.Message)
+	}
+}
+
 func TestEnvelopeSink_EmptyWarningsIsEmptySliceNotNil(t *testing.T) {
 	t.Parallel()
 

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -177,6 +177,20 @@ type UpdateAppliedEvent struct {
 	Method         string
 }
 
+// InstallLocation describes one lstk executable found on PATH.
+type InstallLocation struct {
+	Path    string // location as found on PATH (what a shell would execute)
+	Method  string // install method: "homebrew", "npm", or "binary"
+	Running bool   // whether this entry is the currently running executable
+}
+
+// MultipleInstallsEvent warns that more than one distinct lstk install was
+// found on PATH. Installs are in PATH order, so the first entry is the one a
+// shell resolves when the user types "lstk".
+type MultipleInstallsEvent struct {
+	Installs []InstallLocation
+}
+
 type AuthCompleteEvent struct{}
 
 // Event is a sealed marker — only event types in this package implement it,
@@ -201,6 +215,7 @@ func (EmulatorStoppedEvent) sealedEvent()     {}
 func (EmulatorResetEvent) sealedEvent()       {}
 func (UpdateCheckedEvent) sealedEvent()       {}
 func (UpdateAppliedEvent) sealedEvent()       {}
+func (MultipleInstallsEvent) sealedEvent()    {}
 func (ContainerStatusEvent) sealedEvent()     {}
 func (ProgressEvent) sealedEvent()            {}
 func (UserInputRequestEvent) sealedEvent()    {}

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -66,6 +66,8 @@ func FormatEventLine(event Event) (string, bool) {
 		return formatUpdateChecked(e), true
 	case UpdateAppliedEvent:
 		return formatUpdateApplied(e), true
+	case MultipleInstallsEvent:
+		return formatMultipleInstalls(e), true
 	default:
 		return "", false
 	}
@@ -181,6 +183,20 @@ func formatUpdateChecked(e UpdateCheckedEvent) string {
 
 func formatUpdateApplied(e UpdateAppliedEvent) string {
 	return SuccessMarker() + " " + fmt.Sprintf("Updated to %s", e.UpdatedVersion)
+}
+
+func formatMultipleInstalls(e MultipleInstallsEvent) string {
+	var sb strings.Builder
+	sb.WriteString("> Warning: Multiple lstk installations found on PATH:")
+	for _, in := range e.Installs {
+		sb.WriteString("\n  " + in.Path + " (" + in.Method)
+		if in.Running {
+			sb.WriteString(", currently running")
+		}
+		sb.WriteString(")")
+	}
+	sb.WriteString("\n  Your shell runs the first one; remove the others to avoid using a stale version.")
+	return sb.String()
 }
 
 func formatErrorEvent(e ErrorEvent) string {

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -218,6 +218,30 @@ func TestFormatEventLine(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name: "multiple installs event",
+			event: MultipleInstallsEvent{Installs: []InstallLocation{
+				{Path: "/opt/homebrew/bin/lstk", Method: "homebrew", Running: true},
+				{Path: "/home/u/.nvm/versions/node/v22/bin/lstk", Method: "npm"},
+			}},
+			want: "> Warning: Multiple lstk installations found on PATH:\n" +
+				"  /opt/homebrew/bin/lstk (homebrew, currently running)\n" +
+				"  /home/u/.nvm/versions/node/v22/bin/lstk (npm)\n" +
+				"  Your shell runs the first one; remove the others to avoid using a stale version.",
+			wantOK: true,
+		},
+		{
+			name: "multiple installs event no running marker",
+			event: MultipleInstallsEvent{Installs: []InstallLocation{
+				{Path: "/usr/local/bin/lstk", Method: "binary"},
+				{Path: "/opt/homebrew/bin/lstk", Method: "homebrew"},
+			}},
+			want: "> Warning: Multiple lstk installations found on PATH:\n" +
+				"  /usr/local/bin/lstk (binary)\n" +
+				"  /opt/homebrew/bin/lstk (homebrew)\n" +
+				"  Your shell runs the first one; remove the others to avoid using a stale version.",
+			wantOK: true,
+		},
+		{
 			name: "pod snapshot saved full",
 			event: PodSnapshotSavedEvent{
 				PodName:  "my-baseline",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -238,6 +238,19 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		msgCopy := msg
 		a.addLine(styledLine{text: components.RenderMessage(msg), message: &msgCopy})
 		return a, nil
+	case output.MultipleInstallsEvent:
+		if line, ok := output.FormatEventLine(msg); ok {
+			parts := strings.Split(line, "\n")
+			if len(parts) > 0 {
+				first := strings.Replace(parts[0], "> ", styles.Secondary.Render("> "), 1)
+				first = strings.Replace(first, "Warning:", styles.Warning.Render("Warning:"), 1)
+				a.addLine(styledLine{text: first})
+			}
+			for _, part := range parts[1:] {
+				a.addLine(styledLine{text: part, secondary: true})
+			}
+		}
+		return a, nil
 	case output.AuthEvent:
 		if msg.Preamble != "" {
 			a.lines = appendLine(a.lines, styledLine{text: "> " + msg.Preamble, secondary: true})

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -305,6 +305,54 @@ func TestAppSnapshotLoadedEventRendersGreen(t *testing.T) {
 	}
 }
 
+func TestAppMultipleInstallsEventRendersColoredWarning(t *testing.T) {
+	// Mutates the global lipgloss color profile, so it must not run in parallel.
+	original := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(original) })
+
+	app := NewApp("dev", "", "", nil)
+
+	model, _ := app.Update(output.MultipleInstallsEvent{Installs: []output.InstallLocation{
+		{Path: "/opt/homebrew/bin/lstk", Method: "homebrew", Running: true},
+		{Path: "/home/u/.nvm/versions/node/v22/bin/lstk", Method: "npm"},
+	}})
+	app = model.(App)
+
+	if len(app.lines) != 4 {
+		t.Fatalf("expected 4 lines (header + 2 installs + footer), got %d: %+v", len(app.lines), app.lines)
+	}
+
+	wantWarning := styles.Warning.Render("Warning:")
+	if !strings.Contains(app.lines[0].text, wantWarning) {
+		t.Fatalf("expected colored %q in header line, got: %q", wantWarning, app.lines[0].text)
+	}
+	if !strings.Contains(app.lines[0].text, "Multiple lstk installations found on PATH:") {
+		t.Fatalf("expected header text, got: %q", app.lines[0].text)
+	}
+
+	for i, want := range []string{
+		"/opt/homebrew/bin/lstk (homebrew, currently running)",
+		"/home/u/.nvm/versions/node/v22/bin/lstk (npm)",
+	} {
+		line := app.lines[i+1]
+		if !line.secondary {
+			t.Fatalf("expected install line %d to be styled secondary, got: %+v", i, line)
+		}
+		if !strings.Contains(line.text, want) {
+			t.Fatalf("expected install line %d to contain %q, got: %q", i, want, line.text)
+		}
+	}
+
+	footer := app.lines[3]
+	if !footer.secondary {
+		t.Fatalf("expected footer line to be styled secondary, got: %+v", footer)
+	}
+	if !strings.Contains(footer.text, "Your shell runs the first one; remove the others to avoid using a stale version.") {
+		t.Fatalf("expected footer text, got: %q", footer.text)
+	}
+}
+
 func TestAppMessageEventWrapsOnVisibleWidth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/update/installs.go
+++ b/internal/update/installs.go
@@ -1,0 +1,131 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/localstack/lstk/internal/output"
+)
+
+// binaryName is the executable name scanned for on PATH.
+const binaryName = "lstk"
+
+// Install describes one distinct lstk executable found on PATH.
+type Install struct {
+	Path         string // location as found on PATH (what a shell would execute)
+	ResolvedPath string // after symlink resolution
+	Method       InstallMethod
+	Running      bool // whether this entry is the currently running executable
+}
+
+// FindInstalls scans the directories in the PATH environment variable for
+// lstk executables. Entries that resolve to the same file (symlinks,
+// hardlinks, the same directory listed twice) are reported once. Results
+// follow PATH order, so the first entry is the one a shell would execute.
+func FindInstalls(getenv func(string) string) []Install {
+	runningInfo, runningResolved := runningExecutable()
+
+	var installs []Install
+	var seen []os.FileInfo
+	for _, dir := range filepath.SplitList(getenv("PATH")) {
+		// Relative and empty entries (cwd-dependent lookup) are skipped: they
+		// resolve differently per invocation and are not real install locations.
+		if dir == "" || !filepath.IsAbs(dir) {
+			continue
+		}
+		for _, candidate := range executableCandidates(dir, getenv) {
+			resolved, err := filepath.EvalSymlinks(candidate)
+			if err != nil {
+				resolved = candidate
+			}
+			info, err := os.Stat(resolved)
+			if err != nil {
+				continue
+			}
+			if isDuplicate(seen, info) {
+				continue
+			}
+			seen = append(seen, info)
+			installs = append(installs, Install{
+				Path:         candidate,
+				ResolvedPath: resolved,
+				Method:       classifyPath(resolved),
+				Running:      isRunning(info, resolved, runningInfo, runningResolved),
+			})
+		}
+	}
+	return installs
+}
+
+// WarnMultipleInstalls emits a warning when more than one distinct lstk
+// install is present on PATH (e.g. an old Homebrew install shadowing a fresh
+// npm one, so "lstk" keeps resolving to the stale binary).
+func WarnMultipleInstalls(sink output.Sink, getenv func(string) string) {
+	installs := FindInstalls(getenv)
+	if len(installs) < 2 {
+		return
+	}
+	locations := make([]output.InstallLocation, len(installs))
+	for i, in := range installs {
+		locations[i] = output.InstallLocation{
+			Path:    in.Path,
+			Method:  in.Method.String(),
+			Running: in.Running,
+		}
+	}
+	sink.Emit(output.MultipleInstallsEvent{Installs: locations})
+}
+
+func runningExecutable() (os.FileInfo, string) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, ""
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		resolved = exe
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return nil, resolved
+	}
+	return info, resolved
+}
+
+func isDuplicate(seen []os.FileInfo, info os.FileInfo) bool {
+	for _, s := range seen {
+		if os.SameFile(s, info) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRunning(info os.FileInfo, resolved string, runningInfo os.FileInfo, runningResolved string) bool {
+	if runningInfo != nil && os.SameFile(runningInfo, info) {
+		return true
+	}
+	// An npm install's PATH entry resolves to the Node launcher script while
+	// the running process is the Go binary from the platform package —
+	// different files inside the same node_modules tree.
+	return sameNodeModulesTree(resolved, runningResolved)
+}
+
+func sameNodeModulesTree(a, b string) bool {
+	rootA, okA := nodeModulesRoot(a)
+	rootB, okB := nodeModulesRoot(b)
+	return okA && okB && rootA == rootB
+}
+
+// nodeModulesRoot returns the path prefix up to and including the first
+// node_modules segment, or ok=false when the path has none.
+func nodeModulesRoot(p string) (string, bool) {
+	segments := strings.Split(filepath.Clean(p), string(os.PathSeparator))
+	for i, seg := range segments {
+		if strings.EqualFold(seg, "node_modules") {
+			return strings.Join(segments[:i+1], string(os.PathSeparator)), true
+		}
+	}
+	return "", false
+}

--- a/internal/update/installs_test.go
+++ b/internal/update/installs_test.go
@@ -1,0 +1,224 @@
+//go:build !windows
+
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/localstack/lstk/internal/output"
+)
+
+func writeFakeExecutable(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, binaryName)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func pathGetenv(dirs ...string) func(string) string {
+	return func(key string) string {
+		if key == "PATH" {
+			return strings.Join(dirs, string(os.PathListSeparator))
+		}
+		return ""
+	}
+}
+
+func TestFindInstallsReportsDistinctInstallsInPathOrder(t *testing.T) {
+	t.Parallel()
+	dirA, dirB := t.TempDir(), t.TempDir()
+	exeA := writeFakeExecutable(t, dirA)
+	exeB := writeFakeExecutable(t, dirB)
+
+	installs := FindInstalls(pathGetenv(dirA, dirB))
+
+	if len(installs) != 2 {
+		t.Fatalf("expected 2 installs, got %d: %+v", len(installs), installs)
+	}
+	if installs[0].Path != exeA || installs[1].Path != exeB {
+		t.Errorf("expected PATH order [%s %s], got [%s %s]", exeA, exeB, installs[0].Path, installs[1].Path)
+	}
+}
+
+func TestFindInstallsDeduplicatesSymlinkAliases(t *testing.T) {
+	t.Parallel()
+	dirA, dirB := t.TempDir(), t.TempDir()
+	exeA := writeFakeExecutable(t, dirA)
+	if err := os.Symlink(exeA, filepath.Join(dirB, binaryName)); err != nil {
+		t.Fatal(err)
+	}
+
+	installs := FindInstalls(pathGetenv(dirA, dirB))
+
+	if len(installs) != 1 {
+		t.Fatalf("expected 1 install, got %d: %+v", len(installs), installs)
+	}
+	if installs[0].Path != exeA {
+		t.Errorf("expected first PATH hit %s, got %s", exeA, installs[0].Path)
+	}
+}
+
+func TestFindInstallsDeduplicatesRepeatedPathDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFakeExecutable(t, dir)
+
+	installs := FindInstalls(pathGetenv(dir, dir))
+
+	if len(installs) != 1 {
+		t.Fatalf("expected 1 install, got %d: %+v", len(installs), installs)
+	}
+}
+
+func TestFindInstallsSkipsNonExecutableFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, binaryName), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if installs := FindInstalls(pathGetenv(dir)); len(installs) != 0 {
+		t.Fatalf("expected no installs, got %+v", installs)
+	}
+}
+
+func TestFindInstallsSkipsDirectoriesNamedLikeBinary(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, binaryName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if installs := FindInstalls(pathGetenv(dir)); len(installs) != 0 {
+		t.Fatalf("expected no installs, got %+v", installs)
+	}
+}
+
+func TestFindInstallsSkipsEmptyAndRelativePathEntries(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFakeExecutable(t, dir)
+
+	installs := FindInstalls(pathGetenv("", "relative/dir", dir))
+
+	if len(installs) != 1 {
+		t.Fatalf("expected 1 install, got %d: %+v", len(installs), installs)
+	}
+}
+
+func TestFindInstallsSkipsBrokenSymlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "gone"), filepath.Join(dir, binaryName)); err != nil {
+		t.Fatal(err)
+	}
+
+	if installs := FindInstalls(pathGetenv(dir)); len(installs) != 0 {
+		t.Fatalf("expected no installs, got %+v", installs)
+	}
+}
+
+func TestFindInstallsClassifiesInstallMethod(t *testing.T) {
+	t.Parallel()
+	brewDir := filepath.Join(t.TempDir(), "Caskroom", "lstk", "1.0", "bin")
+	npmDir := filepath.Join(t.TempDir(), "node_modules", ".bin")
+	for _, d := range []string{brewDir, npmDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFakeExecutable(t, d)
+	}
+
+	installs := FindInstalls(pathGetenv(brewDir, npmDir))
+
+	if len(installs) != 2 {
+		t.Fatalf("expected 2 installs, got %d: %+v", len(installs), installs)
+	}
+	if installs[0].Method != InstallHomebrew {
+		t.Errorf("expected homebrew, got %s", installs[0].Method)
+	}
+	if installs[1].Method != InstallNPM {
+		t.Errorf("expected npm, got %s", installs[1].Method)
+	}
+}
+
+func TestFindInstallsMarksRunningExecutable(t *testing.T) {
+	t.Parallel()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirA, dirB := t.TempDir(), t.TempDir()
+	if err := os.Symlink(exe, filepath.Join(dirA, binaryName)); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeExecutable(t, dirB)
+
+	installs := FindInstalls(pathGetenv(dirA, dirB))
+
+	if len(installs) != 2 {
+		t.Fatalf("expected 2 installs, got %d: %+v", len(installs), installs)
+	}
+	if !installs[0].Running {
+		t.Error("expected symlink to the test binary to be marked running")
+	}
+	if installs[1].Running {
+		t.Error("expected unrelated executable to not be marked running")
+	}
+}
+
+func TestSameNodeModulesTree(t *testing.T) {
+	t.Parallel()
+	launcher := "/home/u/.nvm/versions/node/v22/lib/node_modules/@localstack/lstk/launcher.js"
+	goBinary := "/home/u/.nvm/versions/node/v22/lib/node_modules/@localstack/lstk-linux-x64/bin/lstk"
+	otherTree := "/opt/other/node_modules/@localstack/lstk/launcher.js"
+	plain := "/usr/local/bin/lstk"
+
+	if !sameNodeModulesTree(launcher, goBinary) {
+		t.Error("expected launcher and platform binary in the same node_modules tree to match")
+	}
+	if sameNodeModulesTree(launcher, otherTree) {
+		t.Error("expected different node_modules trees to not match")
+	}
+	if sameNodeModulesTree(launcher, plain) {
+		t.Error("expected non-npm path to not match")
+	}
+}
+
+func TestWarnMultipleInstalls(t *testing.T) {
+	t.Parallel()
+	dirA, dirB := t.TempDir(), t.TempDir()
+	exeA := writeFakeExecutable(t, dirA)
+	writeFakeExecutable(t, dirB)
+
+	var events []output.Event
+	sink := output.SinkFunc(func(e output.Event) { events = append(events, e) })
+
+	WarnMultipleInstalls(sink, pathGetenv(dirA))
+	if len(events) != 0 {
+		t.Fatalf("expected no warning for a single install, got %+v", events)
+	}
+
+	WarnMultipleInstalls(sink, pathGetenv(dirA, dirB))
+	if len(events) != 1 {
+		t.Fatalf("expected exactly one warning event, got %d", len(events))
+	}
+	ev, ok := events[0].(output.MultipleInstallsEvent)
+	if !ok {
+		t.Fatalf("expected MultipleInstallsEvent, got %T", events[0])
+	}
+	if len(ev.Installs) != 2 {
+		t.Fatalf("expected 2 install locations, got %+v", ev.Installs)
+	}
+	if ev.Installs[0].Path != exeA {
+		t.Errorf("expected first location %s, got %s", exeA, ev.Installs[0].Path)
+	}
+	if ev.Installs[0].Method != "binary" {
+		t.Errorf("expected method binary, got %s", ev.Installs[0].Method)
+	}
+}

--- a/internal/update/installs_unix.go
+++ b/internal/update/installs_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package update
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// executableCandidates returns the lstk executables present in dir. On Unix
+// that is the single file named lstk, when it is a regular file with an
+// execute bit set — the same test exec.LookPath applies. os.Stat follows
+// symlinks, so a symlink to an executable qualifies and a broken one is
+// skipped.
+func executableCandidates(dir string, _ func(string) string) []string {
+	path := filepath.Join(dir, binaryName)
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() || info.Mode()&0111 == 0 {
+		return nil
+	}
+	return []string{path}
+}

--- a/internal/update/installs_windows.go
+++ b/internal/update/installs_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// executableCandidates returns the lstk executables present in dir. On
+// Windows a command resolves through PATHEXT (lstk.exe from a binary or
+// scoop install, lstk.cmd from an npm shim), so each extension is probed.
+// A bare extensionless "lstk" file is not executable by cmd.exe and is
+// ignored, matching exec.LookPath. Lookups are case-insensitive on Windows
+// filesystems, so probing the lowercased name finds any casing.
+func executableCandidates(dir string, getenv func(string) string) []string {
+	pathext := getenv("PATHEXT")
+	if pathext == "" {
+		pathext = ".COM;.EXE;.BAT;.CMD"
+	}
+	var out []string
+	for ext := range strings.SplitSeq(pathext, ";") {
+		ext = strings.TrimSpace(ext)
+		if ext == "" {
+			continue
+		}
+		if !strings.HasPrefix(ext, ".") {
+			ext = "." + ext
+		}
+		path := filepath.Join(dir, binaryName+strings.ToLower(ext))
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
+}

--- a/internal/update/installs_windows_test.go
+++ b/internal/update/installs_windows_test.go
@@ -1,0 +1,78 @@
+//go:build windows
+
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func winGetenv(pathext string, dirs ...string) func(string) string {
+	return func(key string) string {
+		switch key {
+		case "PATH":
+			return strings.Join(dirs, string(os.PathListSeparator))
+		case "PATHEXT":
+			return pathext
+		}
+		return ""
+	}
+}
+
+func TestFindInstallsProbesPathext(t *testing.T) {
+	t.Parallel()
+	dirExe, dirCmd := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(dirExe, "lstk.exe"))
+	writeFile(t, filepath.Join(dirCmd, "lstk.cmd"))
+	// A bare extensionless file (npm's git-bash script) must not count.
+	writeFile(t, filepath.Join(dirCmd, "lstk"))
+
+	installs := FindInstalls(winGetenv(".COM;.EXE;.BAT;.CMD", dirExe, dirCmd))
+
+	if len(installs) != 2 {
+		t.Fatalf("expected 2 installs, got %d: %+v", len(installs), installs)
+	}
+	if !strings.HasSuffix(installs[0].Path, "lstk.exe") {
+		t.Errorf("expected lstk.exe first, got %s", installs[0].Path)
+	}
+	if !strings.HasSuffix(installs[1].Path, "lstk.cmd") {
+		t.Errorf("expected lstk.cmd second, got %s", installs[1].Path)
+	}
+}
+
+func TestFindInstallsDefaultPathextWhenUnset(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "lstk.exe"))
+
+	installs := FindInstalls(winGetenv("", dir))
+
+	if len(installs) != 1 {
+		t.Fatalf("expected 1 install, got %d: %+v", len(installs), installs)
+	}
+}
+
+func TestFindInstallsPathextOrderWithinDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "lstk.exe"))
+	writeFile(t, filepath.Join(dir, "lstk.cmd"))
+
+	installs := FindInstalls(winGetenv(".COM;.EXE;.BAT;.CMD", dir))
+
+	if len(installs) != 2 {
+		t.Fatalf("expected 2 installs, got %d: %+v", len(installs), installs)
+	}
+	if !strings.HasSuffix(installs[0].Path, "lstk.exe") {
+		t.Errorf("expected PATHEXT order to put lstk.exe first, got %s", installs[0].Path)
+	}
+}

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/localstack/lstk/internal/output"
@@ -47,6 +48,9 @@ func checkQuietlyWithVersion(ctx context.Context, githubToken string, currentVer
 }
 
 func NotifyUpdate(ctx context.Context, sink output.Sink, opts NotifyOptions) (exitAfter bool) {
+	// Piggyback on the per-start update notification: a stale shadowing
+	// install is exactly what makes updates appear to not take effect.
+	WarnMultipleInstalls(sink, os.Getenv)
 	return notifyUpdateWithVersion(ctx, sink, opts, version.Version(), fetchLatestVersion)
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -39,6 +40,7 @@ func Check(ctx context.Context, sink output.Sink, githubToken string) (string, b
 
 // Update checks for updates and applies the update if one is available.
 func Update(ctx context.Context, sink output.Sink, checkOnly bool, githubToken string) error {
+	WarnMultipleInstalls(sink, os.Getenv)
 	current := version.Version()
 	latest, available, err := Check(ctx, sink, githubToken)
 	if err != nil {

--- a/test/integration/multiple_installs_test.go
+++ b/test/integration/multiple_installs_test.go
@@ -1,0 +1,88 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/require"
+)
+
+// copyBinaryTo copies the built lstk binary into dir under the platform's
+// executable name, creating a distinct install (not a symlink, so it does not
+// deduplicate against the source).
+func copyBinaryTo(t *testing.T, dir string) string {
+	t.Helper()
+	src, err := filepath.Abs(binaryPath())
+	require.NoError(t, err)
+	data, err := os.ReadFile(src)
+	require.NoError(t, err)
+	name := "lstk"
+	if runtime.GOOS == "windows" {
+		name = "lstk.exe"
+	}
+	dst := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(dst, data, 0o755))
+	return dst
+}
+
+func TestUpdateCheckWarnsOnMultipleInstallsOnPath(t *testing.T) {
+	t.Parallel()
+	dirA, dirB := t.TempDir(), t.TempDir()
+	pathA := copyBinaryTo(t, dirA)
+	pathB := copyBinaryTo(t, dirB)
+
+	environ := env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.Path, dirA+string(os.PathListSeparator)+dirB)
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), environ, "update", "--check")
+	require.NoError(t, err, stderr)
+	require.Contains(t, stdout, "Multiple lstk installations found on PATH:")
+	require.Contains(t, stdout, pathA)
+	require.Contains(t, stdout, pathB)
+}
+
+func TestUpdateCheckDoesNotWarnOnSingleInstall(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	copyBinaryTo(t, dir)
+
+	environ := env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.Path, dir)
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), environ, "update", "--check")
+	require.NoError(t, err, stderr)
+	require.NotContains(t, stdout, "Multiple lstk installations found")
+}
+
+func TestUpdateCheckDoesNotWarnOnSymlinkedAliases(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks on Windows requires elevated privileges")
+	}
+	t.Parallel()
+	dirA, dirB := t.TempDir(), t.TempDir()
+	pathA := copyBinaryTo(t, dirA)
+	require.NoError(t, os.Symlink(pathA, filepath.Join(dirB, "lstk")))
+
+	environ := env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.Path, dirA+string(os.PathListSeparator)+dirB)
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), environ, "update", "--check")
+	require.NoError(t, err, stderr)
+	require.NotContains(t, stdout, "Multiple lstk installations found")
+}
+
+func TestUpdateCheckJSONReportsMultipleInstallsWarning(t *testing.T) {
+	t.Parallel()
+	dirA, dirB := t.TempDir(), t.TempDir()
+	copyBinaryTo(t, dirA)
+	copyBinaryTo(t, dirB)
+
+	environ := env.Environ(testEnvWithHome(t.TempDir(), "")).
+		With(env.Path, dirA+string(os.PathListSeparator)+dirB)
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), environ, "update", "--check", "--json")
+	require.NoError(t, err, stderr)
+	require.Contains(t, stdout, `"MULTIPLE_INSTALLS"`)
+}


### PR DESCRIPTION
## Motivation

A previous Homebrew installation can shadow a fresh npm install: `npm install` appears successful while `lstk` still resolves to the older binary. Detect this and tell the user.

## Changes

- Add `FindInstalls` (`internal/update/installs.go`): scans every absolute `PATH` directory for lstk executables, resolves symlinks, and deduplicates real duplicates via `os.SameFile` (symlink aliases like `/usr/local/bin` → Caskroom, hardlinks, repeated PATH dirs count once). Results follow PATH order, so the first entry is what a shell executes.
- Per-OS candidate probing: Unix checks for a regular `lstk` file with an execute bit (same test as `exec.LookPath`); Windows probes `PATHEXT` extensions (`lstk.exe` from binary/scoop installs, `lstk.cmd` from npm shims) and ignores bare extensionless files, matching cmd.exe resolution.
- Each install is labeled with the existing install-method classifier (homebrew/npm/binary) and flagged when it is the currently running executable — including the npm case where the PATH entry resolves to the Node launcher script while the process is the Go binary from the platform package (matched by shared `node_modules` root).
- `WarnMultipleInstalls` emits a new `MultipleInstallsEvent` when two or more distinct installs are found. Wired into `lstk update` (all modes) and the start-path update notification (`NotifyUpdate`), since a stale shadowing install is exactly what makes updates appear to not take effect.
- Event plumbing: plain-text formatter, TUI rendering via the existing `FormatEventLine` fallback, and a `MULTIPLE_INSTALLS` warning in the `--json` envelope.

Example output:

```
> Warning: Multiple lstk installations found on PATH:
  /opt/homebrew/bin/lstk (homebrew, currently running)
  /Users/me/.nvm/versions/node/v22/bin/lstk (npm)
  Your shell runs the first one; remove the others to avoid using a stale version.
```

## Tests

- Unit tests for the PATH scan: dedup of symlink aliases and repeated dirs, exec-bit and broken-symlink handling, install-method classification, running-executable marker, plus Windows-tagged `PATHEXT` tests (also cross-compiled with `GOOS=windows`).
- Format-parity tests for the new event (plain formatter and JSON envelope warning).
- Integration tests running the real binary: warns with two copies on PATH, stays silent with a single install or symlinked aliases, and reports the warning code in `--json`.

Closes DEVX-882