### PR TITLE
Add LSTK_MERGE_STRATEGY env var for snapshot load default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Environment variables:
 - `LOCALSTACK_AUTH_TOKEN` - Auth token (skips browser login if set)
 - `LSTK_STARTUP_TIMEOUT` - Startup readiness deadline for `lstk start` (Go duration). Zero/unset uses the per-mode default resolved in `resolveStartupTimeout` (`internal/container/start.go`): 20s interactive (deadline only shows a recoverable keep-waiting/stop prompt, re-armed by "keep waiting"), 60s non-interactive (fatal; the container is left running for inspection). Container exits are detected separately — and instantly, with the exit code — via the exit wait `runtime.Runtime.Start` registers between create and start.
 - `LSTK_OTEL=1` - Enables OpenTelemetry trace export (disabled by default); when enabled, standard `OTEL_EXPORTER_OTLP_*` env vars are respected by the SDK. Requires an OTLP-compatible backend to receive and visualize telemetry — for local development, `make otel` starts one (UI at http://localhost:16686).
+- `LSTK_MERGE_STRATEGY` - Default merge strategy for `snapshot load` / `load` (`account-region-merge`, `overwrite`, or `service-merge`) when `--merge` is not passed; an explicit `--merge` always wins. Resolved in `resolveMergeStrategy` (`cmd/snapshot.go`).
 
 # Infrastructure as Code Commands
 

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -88,7 +88,9 @@ Merge strategies control how snapshot state is combined with running state:
 
   --merge=account-region-merge  (default) snapshot wins on (service, account, region) overlap
   --merge=overwrite             wipe running state, then load
-  --merge=service-merge         snapshot wins per-resource; non-overlapping resources combined`, cmdName)
+  --merge=service-merge         snapshot wins per-resource; non-overlapping resources combined
+
+Alternatively, set LSTK_MERGE_STRATEGY to specify the merge strategy.`, cmdName)
 }
 
 func newSnapshotCmd(cfg *env.Env, tel *telemetry.Client, logger log.Logger) *cobra.Command {
@@ -226,17 +228,39 @@ func addMergeFlag(cmd *cobra.Command) {
 	cmd.Flags().String("merge", snapshot.MergeStrategyAccountRegion, "Merge strategy: overwrite, account-region-merge, service-merge")
 }
 
+// resolveMergeStrategy applies the LSTK_MERGE_STRATEGY env var as the default
+// when --merge was not explicitly passed; an explicit --merge always wins.
+func resolveMergeStrategy(flagValue string, flagChanged bool, envValue string) string {
+	if flagChanged || envValue == "" {
+		return flagValue
+	}
+	return envValue
+}
+
+// resolveLoadStrategy reads --merge off cmd, applies the LSTK_MERGE_STRATEGY
+// env var fallback via resolveMergeStrategy, and validates the result. It's
+// split out from runSnapshotLoad so the CLI-facing wiring (real cobra flag
+// parsing plus the env var) can be tested without a running emulator.
+func resolveLoadStrategy(cmd *cobra.Command, cfg *env.Env) (string, error) {
+	flagValue, err := cmd.Flags().GetString("merge")
+	if err != nil {
+		return "", err
+	}
+	strategy := resolveMergeStrategy(flagValue, cmd.Flags().Changed("merge"), cfg.MergeStrategy)
+	if err := snapshot.ValidateMergeStrategy(strategy); err != nil {
+		return "", err
+	}
+	return strategy, nil
+}
+
 func runSnapshotLoad(cfg *env.Env, tel *telemetry.Client, logger log.Logger) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		strategy, err := cmd.Flags().GetString("merge")
+		strategy, err := resolveLoadStrategy(cmd, cfg)
 		if err != nil {
 			return err
 		}
 		profile, err := cmd.Flags().GetString("profile")
 		if err != nil {
-			return err
-		}
-		if err := snapshot.ValidateMergeStrategy(strategy); err != nil {
 			return err
 		}
 

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -230,6 +230,9 @@ func addMergeFlag(cmd *cobra.Command) {
 
 // resolveMergeStrategy applies the LSTK_MERGE_STRATEGY env var as the default
 // when --merge was not explicitly passed; an explicit --merge always wins.
+// flagChanged (cmd.Flags().Changed("merge")) is required because the flag's
+// own default value is itself a valid strategy, so flagValue alone can't
+// distinguish "user explicitly chose this" from "this is just the default."
 func resolveMergeStrategy(flagValue string, flagChanged bool, envValue string) string {
 	if flagChanged || envValue == "" {
 		return flagValue

--- a/cmd/snapshot_merge_test.go
+++ b/cmd/snapshot_merge_test.go
@@ -9,35 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// resolveMergeStrategy(flagValue, flagChanged, envValue) picks the strategy to use.
-// flagChanged is cmd.Flags().Changed("merge") — true only if the user actually
-// typed --merge on the command line. It's needed because the flag's default value
-// ("account-region-merge") is itself a valid strategy, so flagValue alone can't
-// tell "user explicitly chose account-region-merge" apart from "user passed
-// nothing and this is just the zero-value default".
-func TestResolveMergeStrategy(t *testing.T) {
-	t.Run("flag changed wins over env", func(t *testing.T) {
-		// flagChanged=true means --merge was passed explicitly, so it must win
-		// even though LSTK_MERGE_STRATEGY also has a value.
-		got := resolveMergeStrategy("account-region-merge", true, "overwrite")
-		assert.Equal(t, "account-region-merge", got)
-	})
-
-	t.Run("env used when flag not changed", func(t *testing.T) {
-		// flagChanged=false means the caller never passed --merge; flagValue here
-		// is just cobra's default, which the env var should override.
-		got := resolveMergeStrategy("account-region-merge", false, "overwrite")
-		assert.Equal(t, "overwrite", got)
-	})
-
-	t.Run("flag default kept when env unset", func(t *testing.T) {
-		// Neither --merge nor LSTK_MERGE_STRATEGY was set, so the flag's own
-		// default ("account-region-merge") passes through unchanged.
-		got := resolveMergeStrategy("account-region-merge", false, "")
-		assert.Equal(t, "account-region-merge", got)
-	})
-}
-
 // mergeTestCmd builds a bare *cobra.Command with just the --merge flag
 // registered (via the same addMergeFlag used by the real load commands), so
 // resolveLoadStrategy sees real cobra flag/Changed() behavior rather than

--- a/cmd/snapshot_merge_test.go
+++ b/cmd/snapshot_merge_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/localstack/lstk/internal/env"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resolveMergeStrategy(flagValue, flagChanged, envValue) picks the strategy to use.
+// flagChanged is cmd.Flags().Changed("merge") — true only if the user actually
+// typed --merge on the command line. It's needed because the flag's default value
+// ("account-region-merge") is itself a valid strategy, so flagValue alone can't
+// tell "user explicitly chose account-region-merge" apart from "user passed
+// nothing and this is just the zero-value default".
+func TestResolveMergeStrategy(t *testing.T) {
+	t.Run("flag changed wins over env", func(t *testing.T) {
+		// flagChanged=true means --merge was passed explicitly, so it must win
+		// even though LSTK_MERGE_STRATEGY also has a value.
+		got := resolveMergeStrategy("account-region-merge", true, "overwrite")
+		assert.Equal(t, "account-region-merge", got)
+	})
+
+	t.Run("env used when flag not changed", func(t *testing.T) {
+		// flagChanged=false means the caller never passed --merge; flagValue here
+		// is just cobra's default, which the env var should override.
+		got := resolveMergeStrategy("account-region-merge", false, "overwrite")
+		assert.Equal(t, "overwrite", got)
+	})
+
+	t.Run("flag default kept when env unset", func(t *testing.T) {
+		// Neither --merge nor LSTK_MERGE_STRATEGY was set, so the flag's own
+		// default ("account-region-merge") passes through unchanged.
+		got := resolveMergeStrategy("account-region-merge", false, "")
+		assert.Equal(t, "account-region-merge", got)
+	})
+}
+
+// mergeTestCmd builds a bare *cobra.Command with just the --merge flag
+// registered (via the same addMergeFlag used by the real load commands), so
+// resolveLoadStrategy sees real cobra flag/Changed() behavior rather than
+// hand-constructed booleans.
+func mergeTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "load"}
+	addMergeFlag(cmd)
+	return cmd
+}
+
+// TestResolveLoadStrategy exercises the exact glue runSnapshotLoad uses to go
+// from "what the user/environment configured" to "the strategy string handed
+// to snapshot.LoadLocal/LoadPod" — real cobra flag parsing, cfg.MergeStrategy
+// (the field env.Init() populates from LSTK_MERGE_STRATEGY), and
+// snapshot.ValidateMergeStrategy — with no emulator or network involved.
+// internal/snapshot's own tests separately cover that a given strategy string
+// then produces the right client calls; this test covers the seam in between.
+func TestResolveLoadStrategy(t *testing.T) {
+	t.Run("no flag, no env: default strategy", func(t *testing.T) {
+		cmd := mergeTestCmd()
+		strategy, err := resolveLoadStrategy(cmd, &env.Env{})
+		require.NoError(t, err)
+		assert.Equal(t, "account-region-merge", strategy)
+	})
+
+	t.Run("env var alone sets the strategy", func(t *testing.T) {
+		cmd := mergeTestCmd()
+		strategy, err := resolveLoadStrategy(cmd, &env.Env{MergeStrategy: "overwrite"})
+		require.NoError(t, err)
+		assert.Equal(t, "overwrite", strategy)
+	})
+
+	t.Run("explicit flag overrides env var", func(t *testing.T) {
+		cmd := mergeTestCmd()
+		require.NoError(t, cmd.Flags().Parse([]string{"--merge=account-region-merge"}))
+		strategy, err := resolveLoadStrategy(cmd, &env.Env{MergeStrategy: "overwrite"})
+		require.NoError(t, err)
+		assert.Equal(t, "account-region-merge", strategy)
+	})
+
+	t.Run("invalid env var value is rejected", func(t *testing.T) {
+		cmd := mergeTestCmd()
+		_, err := resolveLoadStrategy(cmd, &env.Env{MergeStrategy: "bogus"})
+		assert.ErrorContains(t, err, "unknown merge strategy")
+	})
+}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -24,6 +24,7 @@ type Env struct {
 	NonInteractive bool
 	JSON           bool
 	GitHubToken    string
+	MergeStrategy  string
 }
 
 // Init initializes environment variable configuration and returns the result.
@@ -49,6 +50,7 @@ func Init() *Env {
 		ForceFileKeyring:  viper.GetString("keyring") == "file",
 		AnalyticsEndpoint: viper.GetString("analytics_endpoint"),
 		GitHubToken:       viper.GetString("github_token"),
+		MergeStrategy:     viper.GetString("merge_strategy"),
 	}
 
 }


### PR DESCRIPTION
## Summary

While reviewing the existing "Snapshot" docs, with the goal of migrating them to use `lstk`, I noticed that the `MERGE_STRATEGY` flag was not recognized by `lstk`. This simple PR adds the variable, making it possible for customers to set a new default value, rather than specifying `--merge` each time on the command line.

- `lstk snapshot load` / `lstk load` now read `LSTK_MERGE_STRATEGY` as the default `--merge` strategy when `--merge` isn't passed; an explicit `--merge` still wins.
- Wiring is split into `resolveMergeStrategy` (flag/env precedence) and `resolveLoadStrategy` (flag parsing + validation), each unit tested without a running emulator.

Note: the only thing I was hesitant about is the variable naming `MERGE_STRATEGY` vs `LSTK_MERGE_STRATEGY`. Using `LSTK_` seems to be a new standard.

Closes DEVX-1010