### PR TITLE
docs: update README and docs for v0.18.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This installs a [gitleaks](https://github.com/gitleaks/gitleaks) hook that scans
 # Build and Test Commands
 
 ```bash
-make build              # Compiles to bin/lstk (cleans first)
+make build              # Compiles to bin/lstk
 make test               # Run unit tests (cmd/ and internal/) via gotestsum
 make test-integration   # Run integration tests (rebuilds bin/lstk via `build`, requires Docker)
 make lint               # Run golangci-lint (version pinned via .tool-versions)
@@ -60,6 +60,7 @@ Notes:
   - `log/` - Internal diagnostic logging (not for user-facing output — use `output/` for that)
   - `output/` - Generic event and sink abstractions for CLI/TUI/non-interactive rendering
   - `ports/` - Port availability checks
+  - `proc/` - Runs wrapped external tools (`aws`, `terraform`, `cdk`, `sam`, `az`, extensions) with signal forwarding instead of `cmd.Run()` — see Signal Forwarding to Wrapped Tools below
   - `reset/` - `lstk reset` domain logic
   - `runtime/` - Abstraction for container runtimes (Docker, Kubernetes, etc.) - currently only Docker implemented
   - `snapshot/` - Snapshot save/load/list/remove/show domain logic — see `internal/snapshot/CLAUDE.md`

--- a/internal/container/CLAUDE.md
+++ b/internal/container/CLAUDE.md
@@ -29,3 +29,13 @@ A stale cached license (`license.json`) or a stale token (e.g. one that predates
 - **Definitive rejection (HTTP 400/401/403) in the pre-flight**: `validateLicense` deletes the cached `license.json` (the verdict invalidates it — a later start whose pre-flight is skipped must not keep mounting the stale copy). In interactive mode, `container.Start` then prompts to log in again (`auth.Relogin`: drops the stored token + cached license, reruns the browser login) and retries the start once with the fresh token. In non-interactive mode it emits an `ErrorEvent` pointing at `lstk logout && lstk login` / `LOCALSTACK_AUTH_TOKEN` and returns a silent error.
 - **Startup license failure with a stale mounted cache**: when the container exits with license-related logs while a cached `license.json` that this run did *not* refresh was mounted (pre-flight skipped, e.g. image already local), `startContainers` returns a `licenseStartupError` instead of rendering the failure through `startupMonitor.handleFailure`, and `startWithLicenseRetry` drops the cache, re-validates against the license server (forced, bypassing the image-local skip), and retries the start once. No retry when the license was freshly fetched this run or no cache was mounted; a repeat failure is rendered by `handleFailure` as usual. The self-validating "not covered by your license" case keeps its dedicated messaging and is never retried.
 - `StartOptions.AuthOptions` threads `auth.Option`s (e.g. `WithBrowserOpener`) into the internally constructed `auth.Auth` so tests of the re-login path never open a real browser tab.
+
+## Host environment forwarding (`filterHostEnv`)
+
+`Start` forwards `CI` and `LOCALSTACK_*` host env vars to the emulator, but `filterHostEnv` (`internal/container/start.go`) silently or warningly drops entries that would corrupt the container rather than passing them through:
+
+- `LOCALSTACK_AUTH_TOKEN` is dropped silently — lstk forwards its own resolved token (keyring or env) instead, so the host value must never win.
+- A value containing `\n`/`\r` is dropped with a warning: the image's entrypoint re-exports `LOCALSTACK_*` vars through a line-oriented `env | sed` pipeline, and an embedded newline would inject a rogue export.
+- A `LOCALSTACK_*` var whose prefix-stripped name is a `criticalContainerVar` (`PATH`, `HOME`, `IFS`, `BASH_ENV`, `LD_PRELOAD`, `LD_LIBRARY_PATH`, `PYTHONPATH`, `PYTHONHOME`) is dropped with a warning — the entrypoint strips the `LOCALSTACK_` prefix and re-exports the remainder, so e.g. a host `LOCALSTACK_PATH` becomes `PATH` inside the emulator and startup breaks (DEVX-984, localstack/lstk#378).
+
+Warnings are emitted via `output.MessageEvent{Severity: output.SeverityWarning}`, one per dropped variable.


### PR DESCRIPTION
## Summary

Docs-only. Audited README.md, CLAUDE.md, every `internal/*/CLAUDE.md`, and every file under `docs/` against current source for the v0.18.0 release, covering the full range since the last docs update (`docs: update README and docs for v0.17.1`, #389).

Most of the delta since then was already documented in-PR (`--type` flag, `LSTK_MERGE_STRATEGY`, SIGINT/SIGTERM forwarding, the bash-completion fix, the emulator-selection fix). What landed here are the gaps that cross-checking `lstk --help`, the `Makefile`, and source turned up.

## What merged (2 files, +12/-1)

- **`CLAUDE.md`** — corrected the "Build and Test Commands" comment: `make build` no longer cleans first (#395 switched the target to a plain `go build` relying on Go's build cache). Also added `internal/proc` (#391) to the Architecture package list; it was referenced elsewhere in the file but missing from the list itself.
- **`internal/container/CLAUDE.md`** — new "Host environment forwarding (`filterHostEnv`)" section documenting the drop rules: silent for `LOCALSTACK_AUTH_TOKEN`, warned for newline-containing values and for any `LOCALSTACK_*` var whose prefix-stripped name would clobber a critical container var like `PATH`/`HOME` (#378, DEVX-984). This logic had no reference doc anywhere.

## What was dropped before merge

The README.md changes originally proposed here — the `-n`/`--tail` flag for `lstk logs` (#359), the `LSTK_MERGE_STRATEGY` row in the environment variables table (#400), the note that `lstk start --timeout` overrides `LSTK_STARTUP_TIMEOUT`, and the expanded "Passing environment variables to the container" section (#378).

#406 landed first and removed those sections outright in favor of linking to the [lstk documentation](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/), so there was nothing left to update. The title still says "README and docs" for that reason; no README change is part of this PR.

## Needing a human decision

None — no public-messaging wording changed; all additions describe existing, already-shipped behavior.

## Test plan

- [x] `make build` succeeds
- [x] Verified the `filterHostEnv` drop rules against `internal/container/start.go`
- [x] Verified the `Makefile`'s `build`/`test-integration` targets against the corrected CLAUDE.md wording
- Docs-only change; no other build/test impact

Co-Authored-By: Claude <noreply@anthropic.com>
