### PR TITLE
Use already-running instances for discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,10 @@ There is no `--offline` flag. Instead `container.Start` degrades gracefully when
 
 Emulator type (aws/azure/snowflake) is always auto-detected by probing `/_localstack/health` (falling back to `/_localstack/info` for Azure, whose health response omits `version`) — there is no manual override flag or config setting; an inconclusive result is a hard failure. `terraform`/`cdk`/`sam` (AWS-only) reject a detected non-AWS type with the same error shape used for a wrong locally-running emulator.
 
+# Already-Running / From-Source Instances
+
+The proxies (`aws`, `az`, `terraform`/`cdk`/`sam`) plus `reset` and `snapshot save/load` work against a LocalStack instance lstk did not start — a from-source run, a hand-started container with an unknown image, or a remote host via `LOCALSTACK_HOST`. When Docker discovery finds nothing (or Docker is down), they probe `GET /_localstack/info` on the resolved host and attach silently on a LocalStack-shaped answer. `stop`/`logs`/`restart`/`status` remain Docker-only. Discovery semantics and the wrong-type guard are documented on `container.ResolveEmulator`/`container.FirstReachableEmulator` (`internal/container/running.go`) and `resolveReachableEmulator` (`cmd/emulator.go`); the test-pinning rule is on `deadLocalStackHost` (`test/integration/external_instance_test.go`).
+
 # Emulator Setup Commands
 
 Use `lstk setup <emulator>` to set up CLI integration for an emulator type:

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -14,7 +14,6 @@ import (
 	"github.com/localstack/lstk/internal/endpoint"
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
-	"github.com/localstack/lstk/internal/runtime"
 	"github.com/localstack/lstk/internal/terminal"
 	"github.com/spf13/cobra"
 )
@@ -163,11 +162,6 @@ Examples:
 				}
 				endpointURL = target.URL
 			} else {
-				rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
-				if err != nil {
-					return err
-				}
-
 				appCfg, err := config.Get()
 				if err != nil {
 					return fmt.Errorf("failed to get config: %w", err)
@@ -181,22 +175,19 @@ Examples:
 					}
 				}
 
-				if err := rt.IsHealthy(cmd.Context()); err != nil {
-					rt.EmitUnhealthyError(sink, err)
-					return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
-				}
+				host, _ := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
 
-				runningName, err := container.ResolveRunningContainerName(cmd.Context(), rt, awsContainer)
+				resolved, _, err := resolveReachableEmulator(cmd.Context(), cfg.DockerHost, sink, awsContainer, host)
 				if err != nil {
-					return fmt.Errorf("checking emulator status: %w", err)
+					return err
 				}
-				if runningName == "" {
+				if !resolved.Found() {
 					return container.HandleNoRunningContainer(sink, awsContainer)
 				}
 
-				host, _ := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
 				endpointURL = "http://" + host
 			}
+
 
 			profileExists, _ := awsconfig.ProfileExists(cmd.Context())
 			if !profileExists {

--- a/cmd/az.go
+++ b/cmd/az.go
@@ -14,7 +14,6 @@ import (
 	"github.com/localstack/lstk/internal/endpoint"
 	"github.com/localstack/lstk/internal/env"
 	"github.com/localstack/lstk/internal/output"
-	"github.com/localstack/lstk/internal/runtime"
 	"github.com/localstack/lstk/internal/terminal"
 	"github.com/localstack/lstk/internal/ui"
 	"github.com/spf13/cobra"
@@ -173,8 +172,9 @@ func newAzStopInterceptionCmd(cfg *env.Env) *cobra.Command {
 }
 
 // azPreflight runs the checks shared by 'lstk az' passthrough and 'start-interception':
-// the Azure CLI is installed, the Docker runtime is healthy, the Azure emulator is
-// running, and *.localhost.localstack.cloud resolves. On failure it emits the matching
+// the Azure CLI is installed, the Azure emulator is reachable (a managed container, or
+// an already-running instance found via the HTTP probe when Docker discovery comes up
+// empty), and *.localhost.localstack.cloud resolves. On failure it emits the matching
 // ErrorEvent and returns a silent error. On success it returns the resolved LocalStack
 // Azure endpoint URL.
 //
@@ -213,24 +213,16 @@ func azPreflight(ctx context.Context, cfg *env.Env, sink output.Sink, target *en
 		}
 	}
 
-	rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
+	resolvedHost, dnsOK := endpoint.ResolveHost(ctx, azureContainer.Port, cfg.LocalStackHost)
+
+	resolved, _, err := resolveReachableEmulator(ctx, cfg.DockerHost, sink, azureContainer, resolvedHost)
 	if err != nil {
 		return "", err
 	}
-	if err := rt.IsHealthy(ctx); err != nil {
-		rt.EmitUnhealthyError(sink, err)
-		return "", output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
-	}
-
-	runningName, err := container.ResolveRunningContainerName(ctx, rt, azureContainer)
-	if err != nil {
-		return "", fmt.Errorf("checking emulator status: %w", err)
-	}
-	if runningName == "" {
+	if !resolved.Found() {
 		return "", container.HandleNoRunningContainer(sink, azureContainer)
 	}
 
-	resolvedHost, dnsOK := endpoint.ResolveHost(ctx, azureContainer.Port, cfg.LocalStackHost)
 	if !dnsOK {
 		sink.Emit(output.ErrorEvent{
 			Title: "DNS resolution required for 'lstk az'",

--- a/cmd/cdk.go
+++ b/cmd/cdk.go
@@ -10,7 +10,6 @@ import (
 	cdkcli "github.com/localstack/lstk/internal/iac/cdk/cli"
 	"github.com/localstack/lstk/internal/log"
 	"github.com/localstack/lstk/internal/output"
-	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
 
@@ -119,21 +118,12 @@ Examples:
 				return cdkcli.Run(cmd.Context(), target.URL, region, sink, logger, cdkArgs)
 			}
 
-			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
-			if err != nil {
-				return err
-			}
-
-			if err := rt.IsHealthy(cmd.Context()); err != nil {
-				rt.EmitUnhealthyError(sink, err)
-				return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
-			}
-
-			if err := requireRunningAWSEmulator(cmd.Context(), rt, sink, awsContainer, "cdk"); err != nil {
-				return err
-			}
-
 			host, dnsOK := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
+
+			if err := requireRunningAWSEmulator(cmd.Context(), cfg.DockerHost, sink, awsContainer, host, "cdk"); err != nil {
+				return err
+			}
+
 			if !dnsOK {
 				// CDK has no env-only lever to force S3 path style, so on the
 				// loopback fallback its S3 asset operations (bootstrap, asset

--- a/cmd/emulator.go
+++ b/cmd/emulator.go
@@ -1,0 +1,51 @@
+package cmd
+
+// Command-boundary emulator reachability shared by the proxy commands (aws,
+// az, terraform, cdk, sam). Lives in cmd/ (not a domain package) because it
+// constructs the runtime from env config and renders errors through the sink.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/container"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+)
+
+// resolveReachableEmulator constructs the Docker runtime, checks its health,
+// and resolves the emulator via container.ResolveEmulator: Docker discovery
+// first, then an HTTP probe of host, which also finds instances lstk did not
+// start (e.g. LocalStack running from source). Docker being unavailable is
+// fatal only when the probe finds nothing either, preserving today's errors
+// (raw construction error, or the standard unhealthy ErrorEvent as a silent
+// error). err == nil with !resolved.Found() means Docker is healthy but
+// nothing answered — the caller picks its own not-running message. The
+// returned runtime is non-nil only when Docker is healthy.
+func resolveReachableEmulator(ctx context.Context, dockerHost string, sink output.Sink, c config.ContainerConfig, host string) (container.ResolvedEmulator, runtime.Runtime, error) {
+	var healthyRT runtime.Runtime
+	var healthErr error
+	rt, rtErr := runtime.NewDockerRuntime(dockerHost)
+	if rtErr == nil {
+		if healthErr = rt.IsHealthy(ctx); healthErr == nil {
+			healthyRT = rt
+		}
+	}
+
+	resolved, err := container.ResolveEmulator(ctx, healthyRT, c, host)
+	if err != nil {
+		return container.ResolvedEmulator{}, healthyRT, fmt.Errorf("checking emulator status: %w", err)
+	}
+	if resolved.Found() {
+		return resolved, healthyRT, nil
+	}
+	if rtErr != nil {
+		return container.ResolvedEmulator{}, nil, rtErr
+	}
+	if healthErr != nil {
+		rt.EmitUnhealthyError(sink, healthErr)
+		return container.ResolvedEmulator{}, nil, output.NewSilentError(fmt.Errorf("runtime not healthy: %w", healthErr))
+	}
+	return container.ResolvedEmulator{}, healthyRT, nil
+}

--- a/cmd/iac.go
+++ b/cmd/iac.go
@@ -20,32 +20,36 @@ import (
 // The leading-flag parsing and account resolution that used to live here now
 // sit in proxy.go: `lstk aws` shares them, so they are no longer IaC-specific.
 
-// requireRunningAWSEmulator verifies the AWS emulator is running before an IaC
-// proxy command (terraform/cdk) that contacts AWS proceeds. When it is not
-// running it emits an actionable error through the sink — an AWS-specific
+// requireRunningAWSEmulator verifies the AWS emulator is reachable before an
+// IaC proxy command (terraform/cdk/sam) that contacts AWS proceeds — a managed
+// container found via Docker, or an already-running instance answering the
+// HTTP probe on host (e.g. LocalStack running from source). When nothing is
+// reachable it emits an actionable error through the sink — an AWS-specific
 // message naming the other emulator when a non-AWS one is up, otherwise the
 // generic "not running" error — and returns a silent error. cmdLabel is the
 // lstk command name used in the message (e.g. "terraform"/"cdk"). It returns nil
-// when the AWS emulator is running.
-func requireRunningAWSEmulator(ctx context.Context, rt runtime.Runtime, sink output.Sink, awsContainer config.ContainerConfig, cmdLabel string) error {
-	runningName, err := container.ResolveRunningContainerName(ctx, rt, awsContainer)
+// when the AWS emulator is reachable.
+func requireRunningAWSEmulator(ctx context.Context, dockerHost string, sink output.Sink, awsContainer config.ContainerConfig, host, cmdLabel string) error {
+	resolved, rt, err := resolveReachableEmulator(ctx, dockerHost, sink, awsContainer, host)
 	if err != nil {
-		return fmt.Errorf("checking emulator status: %w", err)
+		return err
 	}
-	if runningName != "" {
+	if resolved.Found() {
 		return nil
 	}
 	// These commands only work with the AWS emulator. If a different emulator
 	// is running, say so specifically rather than reporting a misleading
-	// "AWS not running".
-	if other := runningNonAWSEmulator(ctx, rt); other != "" {
-		sink.Emit(output.ErrorEvent{
-			Title: fmt.Sprintf("lstk %s requires the %s, but the %s is running", cmdLabel, awsContainer.DisplayName(), other),
-			Actions: []output.ErrorAction{
-				{Label: "Start the AWS emulator:", Value: "lstk"},
-			},
-		})
-		return output.NewSilentError(fmt.Errorf("lstk %s requires the AWS emulator, but the %s is running", cmdLabel, other))
+	// "AWS not running". Skipped when Docker is unavailable (rt == nil).
+	if rt != nil {
+		if other := runningNonAWSEmulator(ctx, rt); other != "" {
+			sink.Emit(output.ErrorEvent{
+				Title: fmt.Sprintf("lstk %s requires the %s, but the %s is running", cmdLabel, awsContainer.DisplayName(), other),
+				Actions: []output.ErrorAction{
+					{Label: "Start the AWS emulator:", Value: "lstk"},
+				},
+			})
+			return output.NewSilentError(fmt.Errorf("lstk %s requires the AWS emulator, but the %s is running", cmdLabel, other))
+		}
 	}
 	return container.HandleNoRunningContainer(sink, awsContainer)
 }

--- a/cmd/sam.go
+++ b/cmd/sam.go
@@ -10,7 +10,6 @@ import (
 	samcli "github.com/localstack/lstk/internal/iac/sam/cli"
 	"github.com/localstack/lstk/internal/log"
 	"github.com/localstack/lstk/internal/output"
-	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
 
@@ -116,21 +115,11 @@ Examples:
 				return samcli.Run(cmd.Context(), target.URL, account, region, regionSelected, sink, logger, samArgs)
 			}
 
-			rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
-			if err != nil {
-				return err
-			}
-
-			if err := rt.IsHealthy(cmd.Context()); err != nil {
-				rt.EmitUnhealthyError(sink, err)
-				return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
-			}
-
-			if err := requireRunningAWSEmulator(cmd.Context(), rt, sink, awsContainer, "sam"); err != nil {
-				return err
-			}
-
 			host, _ := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
+
+			if err := requireRunningAWSEmulator(cmd.Context(), cfg.DockerHost, sink, awsContainer, host, "sam"); err != nil {
+				return err
+			}
 
 			return samcli.Run(cmd.Context(), "http://"+host, account, region, regionSelected, sink, logger, samArgs)
 		},

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -10,7 +10,6 @@ import (
 	tfcli "github.com/localstack/lstk/internal/iac/terraform/cli"
 	"github.com/localstack/lstk/internal/log"
 	"github.com/localstack/lstk/internal/output"
-	"github.com/localstack/lstk/internal/runtime"
 	"github.com/spf13/cobra"
 )
 
@@ -120,23 +119,14 @@ Examples:
 				}
 				endpointURL = target.URL
 			} else {
-				rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
-				if err != nil {
-					return err
-				}
-
 				awsContainer := resolveAWSContainer()
 
-				if err := rt.IsHealthy(cmd.Context()); err != nil {
-					rt.EmitUnhealthyError(sink, err)
-					return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
-				}
+				host, _ := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
 
-				if err := requireRunningAWSEmulator(cmd.Context(), rt, sink, awsContainer, "terraform"); err != nil {
+				if err := requireRunningAWSEmulator(cmd.Context(), cfg.DockerHost, sink, awsContainer, host, "terraform"); err != nil {
 					return err
 				}
 
-				host, _ := endpoint.ResolveHost(cmd.Context(), awsContainer.Port, cfg.LocalStackHost)
 				endpointURL = "http://" + host
 			}
 

--- a/internal/container/info.go
+++ b/internal/container/info.go
@@ -10,8 +10,13 @@ import (
 	"github.com/localstack/lstk/internal/telemetry"
 )
 
-func fetchLocalStackInfo(ctx context.Context, port string) (*telemetry.LocalStackInfo, error) {
-	url := fmt.Sprintf("http://localhost:%s/_localstack/info", port)
+// ProbeEmulatorInfo fetches /_localstack/info from host ("host:port", plain
+// HTTP, 2s timeout). It errors when nothing LocalStack-like answers there:
+// transport error, non-200, non-JSON, or a response without a version (any
+// JSON object decodes into LocalStackInfo, so an unrelated service returning
+// 200 JSON must not count as a LocalStack instance).
+func ProbeEmulatorInfo(ctx context.Context, host string) (*telemetry.LocalStackInfo, error) {
+	url := fmt.Sprintf("http://%s/_localstack/info", host)
 	client := &http.Client{Timeout: 2 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -29,5 +34,12 @@ func fetchLocalStackInfo(ctx context.Context, port string) (*telemetry.LocalStac
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
 		return nil, err
 	}
+	if info.Version == "" {
+		return nil, fmt.Errorf("no LocalStack version in /_localstack/info response")
+	}
 	return &info, nil
+}
+
+func fetchLocalStackInfo(ctx context.Context, port string) (*telemetry.LocalStackInfo, error) {
+	return ProbeEmulatorInfo(ctx, "localhost:"+port)
 }

--- a/internal/container/info_test.go
+++ b/internal/container/info_test.go
@@ -1,0 +1,64 @@
+package container
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func infoServer(t *testing.T, status int, body string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_localstack/info" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+func TestProbeEmulatorInfoReturnsInfo(t *testing.T) {
+	host := infoServer(t, http.StatusOK, `{"version":"4.16.0","edition":"pro","is_docker":false,"uptime":42}`)
+
+	info, err := ProbeEmulatorInfo(context.Background(), host)
+	require.NoError(t, err)
+	assert.Equal(t, "4.16.0", info.Version)
+	assert.Equal(t, "pro", info.Edition)
+	assert.Equal(t, 42, info.Uptime)
+}
+
+func TestProbeEmulatorInfoRejectsNon200(t *testing.T) {
+	host := infoServer(t, http.StatusServiceUnavailable, `{}`)
+
+	_, err := ProbeEmulatorInfo(context.Background(), host)
+	assert.Error(t, err)
+}
+
+func TestProbeEmulatorInfoRejectsNonJSON(t *testing.T) {
+	host := infoServer(t, http.StatusOK, `<html>not localstack</html>`)
+
+	_, err := ProbeEmulatorInfo(context.Background(), host)
+	assert.Error(t, err)
+}
+
+func TestProbeEmulatorInfoRejectsEmptyVersion(t *testing.T) {
+	// Any JSON object decodes into LocalStackInfo, so a 200 from an unrelated
+	// service must not count as a LocalStack instance.
+	host := infoServer(t, http.StatusOK, `{"status":"ok"}`)
+
+	_, err := ProbeEmulatorInfo(context.Background(), host)
+	assert.Error(t, err)
+}
+
+func TestProbeEmulatorInfoUnreachableHost(t *testing.T) {
+	_, err := ProbeEmulatorInfo(context.Background(), "127.0.0.1:1")
+	assert.Error(t, err)
+}

--- a/internal/container/running.go
+++ b/internal/container/running.go
@@ -8,6 +8,7 @@ import (
 	"github.com/localstack/lstk/internal/config"
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/runtime"
+	"github.com/localstack/lstk/internal/telemetry"
 )
 
 func StillRunningMessage(running []config.ContainerConfig) string {
@@ -58,6 +59,93 @@ func ResolveRunningContainerName(ctx context.Context, rt runtime.Runtime, c conf
 	}
 
 	return "", nil
+}
+
+// ResolvedEmulator reports how the emulator can be reached.
+type ResolvedEmulator struct {
+	ContainerName string                    // non-empty: managed container found via the runtime
+	External      bool                      // reachable over HTTP only (e.g. running from source)
+	Info          *telemetry.LocalStackInfo // /_localstack/info payload when External
+}
+
+func (r ResolvedEmulator) Found() bool {
+	return r.ContainerName != "" || r.External
+}
+
+// ResolveEmulator locates the emulator described by c: first via the container
+// runtime (skipped when rt is nil, i.e. Docker is unavailable), then by probing
+// host's /_localstack/info endpoint, which also finds instances lstk did not
+// start (e.g. LocalStack running from source). It emits nothing; the returned
+// error covers only runtime-API failures — an unreachable endpoint is a
+// not-found result, not an error.
+func ResolveEmulator(ctx context.Context, rt runtime.Runtime, c config.ContainerConfig, host string) (ResolvedEmulator, error) {
+	if rt != nil {
+		name, err := ResolveRunningContainerName(ctx, rt, c)
+		if err != nil {
+			return ResolvedEmulator{}, err
+		}
+		if name != "" {
+			return ResolvedEmulator{ContainerName: name}, nil
+		}
+	}
+
+	info, err := ProbeEmulatorInfo(ctx, host)
+	if err != nil {
+		return ResolvedEmulator{}, nil
+	}
+
+	// The probe cannot tell which emulator product answered. When a known
+	// LocalStack container of any type is running, the answer is that
+	// container, not an external instance — report not-found so callers keep
+	// today's type-mismatch errors. Without Docker the guard cannot run; the
+	// looseness is accepted (from-source runs are overwhelmingly single-type).
+	if rt != nil {
+		containerPort, err := c.ContainerPort()
+		if err != nil {
+			return ResolvedEmulator{}, err
+		}
+		found, err := rt.FindRunningByImage(ctx, config.KnownImageRepos(), containerPort)
+		if err != nil {
+			return ResolvedEmulator{}, fmt.Errorf("failed to scan for running containers: %w", err)
+		}
+		if found != nil {
+			return ResolvedEmulator{}, nil
+		}
+	}
+
+	return ResolvedEmulator{External: true, Info: info}, nil
+}
+
+// FirstReachableEmulator returns the first container from containers that is
+// reachable: via Docker discovery when the runtime is healthy, else via the
+// HTTP probe of host (which also finds instances lstk did not start, e.g.
+// LocalStack running from source). Docker being unhealthy is fatal only when
+// the probe finds nothing either — then the standard unhealthy error is
+// emitted through sink and a silent error returned, preserving today's
+// behavior. A zero result with a nil error means Docker is healthy but
+// nothing answered; callers emit their own not-running message.
+func FirstReachableEmulator(ctx context.Context, rt runtime.Runtime, sink output.Sink, containers []config.ContainerConfig, host string) (config.ContainerConfig, ResolvedEmulator, error) {
+	discoveryRT := rt
+	healthErr := rt.IsHealthy(ctx)
+	if healthErr != nil {
+		discoveryRT = nil
+	}
+
+	for _, c := range containers {
+		resolved, err := ResolveEmulator(ctx, discoveryRT, c, host)
+		if err != nil {
+			return config.ContainerConfig{}, ResolvedEmulator{}, fmt.Errorf("checking emulator status: %w", err)
+		}
+		if resolved.Found() {
+			return c, resolved, nil
+		}
+	}
+
+	if healthErr != nil {
+		rt.EmitUnhealthyError(sink, healthErr)
+		return config.ContainerConfig{}, ResolvedEmulator{}, output.NewSilentError(fmt.Errorf("runtime not healthy: %w", healthErr))
+	}
+	return config.ContainerConfig{}, ResolvedEmulator{}, nil
 }
 
 // HandleNoRunningContainer emits the standard "not running" error for c

--- a/internal/container/running_test.go
+++ b/internal/container/running_test.go
@@ -1,0 +1,181 @@
+package container
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/localstack/lstk/internal/config"
+	"github.com/localstack/lstk/internal/output"
+	"github.com/localstack/lstk/internal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func nopSink() output.Sink {
+	return output.SinkFunc(func(output.Event) {})
+}
+
+// countingInfoServer serves /_localstack/info and counts requests, so tests can
+// assert the HTTP probe did or did not run.
+func countingInfoServer(t *testing.T) (host string, calls *atomic.Int32) {
+	t.Helper()
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_localstack/info" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		n.Add(1)
+		_, _ = w.Write([]byte(`{"version":"4.16.0","edition":"community"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://"), &n
+}
+
+func awsTestContainer() config.ContainerConfig {
+	return config.ContainerConfig{Type: config.EmulatorAWS, Port: config.DefaultPort}
+}
+
+func TestResolveEmulatorManagedContainerSkipsProbe(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	c := awsTestContainer()
+	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name()).Return(true, nil)
+
+	host, calls := countingInfoServer(t)
+
+	resolved, err := ResolveEmulator(context.Background(), mockRT, c, host)
+	require.NoError(t, err)
+	assert.Equal(t, c.Name(), resolved.ContainerName)
+	assert.False(t, resolved.External)
+	assert.True(t, resolved.Found())
+	assert.Equal(t, int32(0), calls.Load(), "probe must not run when a managed container is found")
+}
+
+func TestResolveEmulatorFallsBackToProbe(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	c := awsTestContainer()
+	containerPort, err := c.ContainerPort()
+	require.NoError(t, err)
+
+	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name()).Return(false, nil)
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), config.KnownImageReposForType(c.Type), containerPort).Return(nil, nil)
+	// Wrong-type guard: no known LocalStack container of any type is running.
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), config.KnownImageRepos(), containerPort).Return(nil, nil)
+
+	host, calls := countingInfoServer(t)
+
+	resolved, err := ResolveEmulator(context.Background(), mockRT, c, host)
+	require.NoError(t, err)
+	assert.Empty(t, resolved.ContainerName)
+	assert.True(t, resolved.External)
+	assert.True(t, resolved.Found())
+	require.NotNil(t, resolved.Info)
+	assert.Equal(t, "4.16.0", resolved.Info.Version)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestResolveEmulatorNilRuntimeProbesDirectly(t *testing.T) {
+	host, _ := countingInfoServer(t)
+
+	resolved, err := ResolveEmulator(context.Background(), nil, awsTestContainer(), host)
+	require.NoError(t, err)
+	assert.True(t, resolved.External)
+	assert.True(t, resolved.Found())
+}
+
+func TestResolveEmulatorNilRuntimeNothingListening(t *testing.T) {
+	resolved, err := ResolveEmulator(context.Background(), nil, awsTestContainer(), "127.0.0.1:1")
+	require.NoError(t, err)
+	assert.False(t, resolved.Found())
+}
+
+func TestResolveEmulatorProbeAnswerFromOtherEmulatorContainer(t *testing.T) {
+	// A known LocalStack container of a different type is running: the probe
+	// answer is that container, not an external instance, so resolution must
+	// report not-found and let callers keep today's type-mismatch errors.
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	c := awsTestContainer()
+	containerPort, err := c.ContainerPort()
+	require.NoError(t, err)
+
+	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name()).Return(false, nil)
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), config.KnownImageReposForType(c.Type), containerPort).Return(nil, nil)
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), config.KnownImageRepos(), containerPort).
+		Return(&runtime.RunningContainer{Name: "localstack-snowflake", Image: "localstack/snowflake:latest"}, nil)
+
+	host, _ := countingInfoServer(t)
+
+	resolved, err := ResolveEmulator(context.Background(), mockRT, c, host)
+	require.NoError(t, err)
+	assert.False(t, resolved.Found())
+}
+
+func TestFirstReachableEmulatorManagedContainer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	c := awsTestContainer()
+	mockRT.EXPECT().IsHealthy(gomock.Any()).Return(nil)
+	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name()).Return(true, nil)
+
+	target, resolved, err := FirstReachableEmulator(context.Background(), mockRT, nopSink(), []config.ContainerConfig{c}, "127.0.0.1:1")
+	require.NoError(t, err)
+	assert.Equal(t, c.Type, target.Type)
+	assert.True(t, resolved.Found())
+}
+
+func TestFirstReachableEmulatorDockerDownProbeOK(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsHealthy(gomock.Any()).Return(assert.AnError)
+
+	host, _ := countingInfoServer(t)
+
+	target, resolved, err := FirstReachableEmulator(context.Background(), mockRT, nopSink(), []config.ContainerConfig{awsTestContainer()}, host)
+	require.NoError(t, err)
+	assert.Equal(t, config.EmulatorAWS, target.Type)
+	assert.True(t, resolved.External)
+}
+
+func TestFirstReachableEmulatorDockerDownNothingListening(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsHealthy(gomock.Any()).Return(assert.AnError)
+	mockRT.EXPECT().EmitUnhealthyError(gomock.Any(), assert.AnError)
+
+	_, _, err := FirstReachableEmulator(context.Background(), mockRT, nopSink(), []config.ContainerConfig{awsTestContainer()}, "127.0.0.1:1")
+	require.Error(t, err)
+	assert.True(t, output.IsSilent(err))
+}
+
+func TestFirstReachableEmulatorDockerHealthyNothingFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	c := awsTestContainer()
+	containerPort, err := c.ContainerPort()
+	require.NoError(t, err)
+	mockRT.EXPECT().IsHealthy(gomock.Any()).Return(nil)
+	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name()).Return(false, nil)
+	mockRT.EXPECT().FindRunningByImage(gomock.Any(), config.KnownImageReposForType(c.Type), containerPort).Return(nil, nil)
+
+	_, resolved, err := FirstReachableEmulator(context.Background(), mockRT, nopSink(), []config.ContainerConfig{c}, "127.0.0.1:1")
+	require.NoError(t, err)
+	assert.False(t, resolved.Found())
+}
+
+func TestResolveEmulatorRuntimeErrorPropagates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	c := awsTestContainer()
+	mockRT.EXPECT().IsRunning(gomock.Any(), c.Name()).Return(false, assert.AnError)
+
+	_, err := ResolveEmulator(context.Background(), mockRT, c, "127.0.0.1:1")
+	assert.Error(t, err)
+}

--- a/internal/reset/reset.go
+++ b/internal/reset/reset.go
@@ -18,16 +18,11 @@ type StateResetter interface {
 }
 
 func Reset(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, resetter StateResetter, host string, force bool, sink output.Sink) (retErr error) {
-	if err := rt.IsHealthy(ctx); err != nil {
-		rt.EmitUnhealthyError(sink, err)
-		return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
-	}
-
-	runningContainers, err := container.RunningEmulators(ctx, rt, containers)
+	target, resolved, err := container.FirstReachableEmulator(ctx, rt, sink, containers, host)
 	if err != nil {
-		return fmt.Errorf("checking emulator status: %w", err)
+		return err
 	}
-	if len(runningContainers) == 0 {
+	if !resolved.Found() {
 		sink.Emit(output.ErrorEvent{
 			Title: "LocalStack is not running",
 			Actions: []output.ErrorAction{
@@ -65,7 +60,7 @@ func Reset(ctx context.Context, rt runtime.Runtime, containers []config.Containe
 	defer func() {
 		sink.Emit(output.SpinnerStop())
 		if retErr == nil {
-			sink.Emit(output.EmulatorResetEvent{Type: string(runningContainers[0].Type), Name: runningContainers[0].Name()})
+			sink.Emit(output.EmulatorResetEvent{Type: string(target.Type), Name: target.Name()})
 		}
 	}()
 

--- a/internal/snapshot/load.go
+++ b/internal/snapshot/load.go
@@ -89,21 +89,20 @@ type PodLoader interface {
 }
 
 // load is the shared entry point for both LoadLocal and LoadPod.
-// It checks runtime health, auto-starts the emulator if needed, then runs do().
-func load(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, sink output.Sink, starter Starter, spinnerText string, onSuccess func(), do func() error) (retErr error) {
-	if err := rt.IsHealthy(ctx); err != nil {
-		rt.EmitUnhealthyError(sink, err)
-		return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
+// It checks the emulator is reachable (a managed container, or an
+// already-running instance answering the HTTP probe on host, e.g. LocalStack
+// running from source), auto-starts the emulator if needed, then runs do().
+// The auto-starter requires Docker, so it only runs when Docker is healthy;
+// an external instance found via the probe is used as-is.
+func load(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, sink output.Sink, host string, starter Starter, spinnerText string, onSuccess func(), do func() error) (retErr error) {
+	_, resolved, err := container.FirstReachableEmulator(ctx, rt, sink, containers, host)
+	if err != nil {
+		return err
 	}
 
 	emitExperimentalWarning(containers, sink)
 
-	runningContainers, err := container.RunningEmulators(ctx, rt, containers)
-	if err != nil {
-		return fmt.Errorf("checking emulator status: %w", err)
-	}
-
-	if len(runningContainers) == 0 {
+	if !resolved.Found() {
 		if starter == nil {
 			sink.Emit(output.ErrorEvent{
 				Title: "LocalStack is not running",
@@ -162,7 +161,7 @@ func LoadLocal(ctx context.Context, rt runtime.Runtime, containers []config.Cont
 	cwd, _ := os.Getwd()
 	home, _ := os.UserHomeDir()
 
-	return load(ctx, rt, containers, sink, starter,
+	return load(ctx, rt, containers, sink, host, starter,
 		"Loading snapshot...",
 		func() {
 			sink.Emit(output.SnapshotLoadedEvent{Source: displayPath(src, cwd, home)})
@@ -207,7 +206,7 @@ func LoadPod(ctx context.Context, rt runtime.Runtime, containers []config.Contai
 	}
 
 	var services []string
-	err := load(ctx, rt, containers, sink, starter,
+	err := load(ctx, rt, containers, sink, host, starter,
 		spinnerText,
 		func() {
 			sink.Emit(output.SnapshotLoadedEvent{

--- a/internal/snapshot/remote.go
+++ b/internal/snapshot/remote.go
@@ -144,7 +144,7 @@ func SaveRemoteS3(ctx context.Context, rt runtime.Runtime, containers []config.C
 	name := remoteName(s3URL)
 	remoteURL := templatedRemoteURL(s3URL, creds.SessionToken != "")
 	var result PodSaveResult
-	return save(ctx, rt, containers, sink,
+	return save(ctx, rt, containers, sink, host,
 		fmt.Sprintf("Saving snapshot to %s...", s3URL),
 		func() {
 			sink.Emit(output.RemoteSnapshotSavedEvent{
@@ -175,7 +175,7 @@ func LoadRemoteS3(ctx context.Context, rt runtime.Runtime, containers []config.C
 	name := remoteName(s3URL)
 	remoteURL := templatedRemoteURL(s3URL, creds.SessionToken != "")
 	var services []string
-	return load(ctx, rt, containers, sink, starter,
+	return load(ctx, rt, containers, sink, host, starter,
 		fmt.Sprintf("Loading snapshot %q from %s...", podName, s3URL),
 		func() {
 			sink.Emit(output.SnapshotLoadedEvent{

--- a/internal/snapshot/save.go
+++ b/internal/snapshot/save.go
@@ -35,17 +35,12 @@ type PodSaver interface {
 	SavePodSnapshot(ctx context.Context, host, podName, authToken string, services []string) (PodSaveResult, error)
 }
 
-func save(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, sink output.Sink, spinnerText string, onSuccess func(), do func() error) (retErr error) {
-	if err := rt.IsHealthy(ctx); err != nil {
-		rt.EmitUnhealthyError(sink, err)
-		return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
-	}
-
-	runningContainers, err := container.RunningEmulators(ctx, rt, containers)
+func save(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, sink output.Sink, host, spinnerText string, onSuccess func(), do func() error) (retErr error) {
+	_, resolved, err := container.FirstReachableEmulator(ctx, rt, sink, containers, host)
 	if err != nil {
-		return fmt.Errorf("checking emulator status: %w", err)
+		return err
 	}
-	if len(runningContainers) == 0 {
+	if !resolved.Found() {
 		sink.Emit(output.ErrorEvent{
 			Title: "LocalStack is not running",
 			Actions: []output.ErrorAction{
@@ -81,7 +76,7 @@ func SaveLocal(ctx context.Context, rt runtime.Runtime, containers []config.Cont
 	cwd, _ := os.Getwd()
 	home, _ := os.UserHomeDir()
 	var extracted []string
-	return save(ctx, rt, containers, sink,
+	return save(ctx, rt, containers, sink, host,
 		"Saving snapshot...",
 		func() {
 			sink.Emit(output.LocalSnapshotSavedEvent{
@@ -124,7 +119,7 @@ func SavePod(ctx context.Context, rt runtime.Runtime, containers []config.Contai
 		return fmt.Errorf("pod snapshots require authentication — set LOCALSTACK_AUTH_TOKEN or run %q", "lstk login")
 	}
 	var result PodSaveResult
-	return save(ctx, rt, containers, sink,
+	return save(ctx, rt, containers, sink, host,
 		fmt.Sprintf("Saving snapshot to pod %q...", podName),
 		func() {
 			sink.Emit(output.PodSnapshotSavedEvent{

--- a/test/integration/aws_cmd_test.go
+++ b/test/integration/aws_cmd_test.go
@@ -534,7 +534,8 @@ func TestAWSCommandFailsWhenDockerNotRunning(t *testing.T) {
 	fakeDir := writeFakeAWS(t)
 	e := env.With(env.DisableEvents, "1").
 		With("PATH", fakeDir).
-		With(env.Key("DOCKER_HOST"), "tcp://localhost:1")
+		With(env.Key("DOCKER_HOST"), "tcp://localhost:1").
+		With(env.LocalStackHost, deadLocalStackHost)
 
 	stdout, _, err := runLstk(t, testContext(t), t.TempDir(), e, "aws", "s3", "ls")
 	require.Error(t, err)
@@ -549,7 +550,8 @@ func TestAWSCommandFailsWhenEmulatorNotRunning(t *testing.T) {
 	fakeDir := writeFakeAWS(t)
 	analyticsSrv, events := mockAnalyticsServer(t)
 	e := env.With("PATH", fakeDir).
-		With(env.AnalyticsEndpoint, analyticsSrv.URL)
+		With(env.AnalyticsEndpoint, analyticsSrv.URL).
+		With(env.LocalStackHost, deadLocalStackHost)
 
 	stdout, _, err := runLstk(t, testContext(t), t.TempDir(), e, "aws", "s3", "ls")
 	require.Error(t, err)

--- a/test/integration/cdk_cmd_test.go
+++ b/test/integration/cdk_cmd_test.go
@@ -226,7 +226,8 @@ func TestCDKFailsWhenEmulatorNotRunning(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	fakeDir := writeFakeCDK(t, "2.177.0")
-	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).WithHome(t.TempDir())
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).WithHome(t.TempDir()).
+		With(env.LocalStackHost, deadLocalStackHost)
 
 	stdout, _, err := runLstk(t, testContext(t), t.TempDir(), e, "cdk", "deploy")
 	require.Error(t, err)

--- a/test/integration/external_instance_test.go
+++ b/test/integration/external_instance_test.go
@@ -1,0 +1,273 @@
+package integration_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/localstack/lstk/test/integration/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadLocalStackHost pins LOCALSTACK_HOST to a closed port so the emulator
+// reachability probe deterministically fails. Negative-path tests ("is not
+// running", "Docker is not available") must set this: without it they would
+// probe 127.0.0.1:4566 and attach to a real LocalStack instance on the
+// developer's machine (e.g. one running from source).
+const deadLocalStackHost = "127.0.0.1:1"
+
+// mockLocalStackInfoServer serves /_localstack/info the way a running
+// LocalStack instance (container or from-source) does, so tests can stand in
+// for an emulator lstk did not start. Extra handlers extend the mux for
+// endpoints a command calls after discovery (reset, snapshot, ...).
+func mockLocalStackInfoServer(t *testing.T, extra map[string]http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_localstack/info", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"version":"4.16.0","edition":"community","is_docker":false,"uptime":42}`))
+	})
+	for pattern, handler := range extra {
+		mux.HandleFunc(pattern, handler)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestAWSCommandUsesExternalInstance is the from-source regression test for
+// the head-of-engineering report: `lstk aws` against a LocalStack that is a
+// plain process (no container, Docker daemon down) must proxy to it instead of
+// failing with "Docker is not available".
+func TestAWSCommandUsesExternalInstance(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake aws script and unix-socket DOCKER_HOST not supported on Windows")
+	}
+
+	srv := mockLocalStackInfoServer(t, nil)
+	fakeDir := writeFakeAWS(t)
+	e := unhealthyDockerEnv().
+		With(env.DisableEvents, "1").
+		With("PATH", fakeDir).
+		With(env.Home, t.TempDir()).
+		With(env.LocalStackHost, lsHost(srv))
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "aws", "s3", "ls")
+	require.NoError(t, err, "lstk aws should use the external instance: %s", stderr)
+
+	assert.Contains(t, stdout, "ENDPOINT:http://"+lsHost(srv))
+	assert.Contains(t, stdout, "ARGS:s3 ls")
+}
+
+// Without LOCALSTACK_HOST, the probe targets the configured port — the
+// zero-config from-source case (instance on the config/default port).
+func TestAWSCommandUsesExternalInstanceFromConfigPort(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake aws script and unix-socket DOCKER_HOST not supported on Windows")
+	}
+
+	srv := mockLocalStackInfoServer(t, nil)
+	port := srv.URL[strings.LastIndex(srv.URL, ":")+1:]
+
+	workDir := t.TempDir()
+	lstkDir := filepath.Join(workDir, ".lstk")
+	require.NoError(t, os.MkdirAll(lstkDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(lstkDir, "config.toml"),
+		[]byte(fmt.Sprintf("[[containers]]\ntype = \"aws\"\ntag = \"latest\"\nport = %q\n", port)), 0644))
+
+	fakeDir := writeFakeAWS(t)
+	e := unhealthyDockerEnv().
+		With(env.DisableEvents, "1").
+		With("PATH", fakeDir).
+		With(env.Home, t.TempDir())
+
+	stdout, stderr, err := runLstk(t, testContext(t), workDir, e, "aws", "s3", "ls")
+	require.NoError(t, err, "lstk aws should use the external instance on the configured port: %s", stderr)
+
+	assert.Contains(t, stdout, ":"+port)
+	assert.Contains(t, stdout, "ARGS:s3 ls")
+}
+
+// Docker healthy but no LocalStack container: discovery falls back to the
+// probe instead of erroring.
+func TestAWSCommandExternalInstanceWithDockerHealthy(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	srv := mockLocalStackInfoServer(t, nil)
+	fakeDir := writeFakeAWS(t)
+	e := env.With(env.DisableEvents, "1").
+		With("PATH", fakeDir).
+		With(env.Home, t.TempDir()).
+		With(env.LocalStackHost, lsHost(srv))
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "aws", "s3", "ls")
+	require.NoError(t, err, "lstk aws should use the external instance: %s", stderr)
+
+	assert.Contains(t, stdout, "ENDPOINT:http://"+lsHost(srv))
+}
+
+func TestTerraformUsesExternalInstance(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake terraform script and unix-socket DOCKER_HOST not supported on Windows")
+	}
+
+	srv := mockLocalStackInfoServer(t, nil)
+	fakeDir := writeFakeTerraform(t)
+	e := unhealthyDockerEnv().
+		With(env.DisableEvents, "1").
+		With("PATH", fakeDir).
+		With(env.Home, t.TempDir()).
+		With(env.LocalStackHost, lsHost(srv))
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "terraform", "plan")
+	require.NoError(t, err, "lstk terraform should use the external instance: %s", stderr)
+
+	assert.Contains(t, stdout, "ARGS:plan")
+	assert.Contains(t, stdout, lsHost(srv), "override should point endpoints at the external instance")
+}
+
+func TestResetExternalInstance(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-socket DOCKER_HOST not supported on Windows")
+	}
+
+	var resetCalls atomic.Int32
+	srv := mockLocalStackInfoServer(t, map[string]http.HandlerFunc{
+		"/_localstack/state/reset": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				resetCalls.Add(1)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		},
+	})
+
+	e := unhealthyDockerEnv().
+		With(env.DisableEvents, "1").
+		With(env.Home, t.TempDir()).
+		With(env.LocalStackHost, lsHost(srv))
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "--non-interactive", "reset", "--force")
+	require.NoError(t, err, "lstk reset should work against the external instance: %s", stderr)
+
+	assert.Contains(t, stdout, "Emulator state reset")
+	assert.Equal(t, int32(1), resetCalls.Load())
+}
+
+func TestSnapshotSaveExternalInstance(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-socket DOCKER_HOST not supported on Windows")
+	}
+
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	f, err := zw.Create("state.json")
+	require.NoError(t, err)
+	_, err = f.Write([]byte(`{"services":{}}`))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	srv := mockLocalStackInfoServer(t, map[string]http.HandlerFunc{
+		"/_localstack/pods/state": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(zipBuf.Bytes())
+		},
+	})
+
+	dir := t.TempDir()
+	e := unhealthyDockerEnv().
+		With(env.DisableEvents, "1").
+		With(env.Home, t.TempDir()).
+		With(env.LocalStackHost, lsHost(srv))
+
+	stdout, stderr, err := runLstk(t, testContext(t), dir, e, "--non-interactive", "snapshot", "save", filepath.Join(dir, "ext.snapshot"))
+	require.NoError(t, err, "lstk snapshot save should work against the external instance: %s", stderr)
+
+	assert.Contains(t, stdout, "Snapshot saved")
+	_, statErr := os.Stat(filepath.Join(dir, "ext.snapshot"))
+	assert.NoError(t, statErr)
+}
+
+func TestSnapshotLoadExternalInstance(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-socket DOCKER_HOST not supported on Windows")
+	}
+
+	var imported atomic.Bool
+	srv := mockLocalStackInfoServer(t, map[string]http.HandlerFunc{
+		"/_localstack/pods": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				imported.Store(true)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		},
+	})
+
+	// A minimal zip is a valid snapshot payload for the mock import endpoint.
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "ext.snapshot")
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	f, err := zw.Create("state.json")
+	require.NoError(t, err)
+	_, err = f.Write([]byte(`{"services":{}}`))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, os.WriteFile(snapPath, zipBuf.Bytes(), 0644))
+
+	e := unhealthyDockerEnv().
+		With(env.DisableEvents, "1").
+		With(env.Home, t.TempDir()).
+		With(env.LocalStackHost, lsHost(srv))
+
+	stdout, stderr, err := runLstk(t, testContext(t), dir, e, "--non-interactive", "snapshot", "load", snapPath)
+	require.NoError(t, err, "lstk snapshot load should work against the external instance: %s", stderr)
+
+	assert.Contains(t, stdout, "Snapshot loaded")
+	assert.True(t, imported.Load(), "import endpoint should be called")
+}
+
+func TestAzCommandUsesExternalInstance(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake az script and unix-socket DOCKER_HOST not supported on Windows")
+	}
+
+	srv := mockLocalStackInfoServer(t, nil)
+	workDir := azureWorkDir(t)
+	writeAzureSetupMarker(t, workDir)
+
+	fakeDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(fakeDir, "az"),
+		[]byte("#!/bin/sh\necho \"AZ-ARGS:$*\"\n"), 0755))
+
+	e := unhealthyDockerEnv().
+		With(env.DisableEvents, "1").
+		With("PATH", fakeDir).
+		With(env.Home, t.TempDir()).
+		With(env.LocalStackHost, lsHost(srv))
+
+	stdout, stderr, err := runLstk(t, testContext(t), workDir, e, "az", "group", "list")
+	require.NoError(t, err, "lstk az should use the external instance: %s", stderr)
+
+	assert.Contains(t, stdout, "AZ-ARGS:group list")
+}

--- a/test/integration/external_instance_test.go
+++ b/test/integration/external_instance_test.go
@@ -271,3 +271,51 @@ func TestAzCommandUsesExternalInstance(t *testing.T) {
 
 	assert.Contains(t, stdout, "AZ-ARGS:group list")
 }
+
+// TestAzStartInterceptionUsesExternalInstance pins the regression Paolo reported
+// in the head-of-engineering thread: with the Azure emulator running as a host
+// process (debug mode — no container, and often the Docker daemon down), `lstk
+// az start-interception` failed its preflight with "LocalStack Azure Emulator is
+// not running", because emulator discovery was Docker-only.
+//
+// start-interception routes through the same azPreflight as `lstk az <args>`, so
+// the HTTP-probe fallback now lets it find the external instance too. The
+// interception step that follows registers the 'LocalStack' cloud against the
+// emulator's TLS gateway at azure.<host> and needs wildcard DNS, which a plain
+// httptest mock can't provide — so this test asserts the fix at the point that
+// regressed: the command gets past Docker-only discovery (no "is not running",
+// no "Docker is not available") and reaches the reachability check against the
+// resolved external endpoint. The full interception path is covered by
+// TestSetupAzureAndAzCommandSucceed (Docker + real az + auth token).
+func TestAzStartInterceptionUsesExternalInstance(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake az script and unix-socket DOCKER_HOST not supported on Windows")
+	}
+
+	srv := mockLocalStackInfoServer(t, nil)
+	workDir := azureWorkDir(t)
+
+	// azPreflight checks the az CLI is installed before discovery; a stub on PATH
+	// satisfies that. It is never executed here — IsHealthy fails first.
+	fakeDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(fakeDir, "az"),
+		[]byte("#!/bin/sh\nexit 0\n"), 0755))
+
+	e := unhealthyDockerEnv().
+		With(env.DisableEvents, "1").
+		With("PATH", fakeDir).
+		With(env.Home, t.TempDir()).
+		With(env.LocalStackHost, lsHost(srv))
+
+	stdout, stderr, err := runLstk(t, testContext(t), workDir, e, "az", "start-interception")
+	requireExitCode(t, 1, err)
+
+	combined := stdout + stderr
+	assert.NotContains(t, combined, "is not running",
+		"preflight must discover the external instance instead of reporting it missing")
+	assert.NotContains(t, combined, "Docker is not available",
+		"Docker being down must not block discovery of an already-running instance")
+	assert.Contains(t, combined, "not reachable at https://azure.",
+		"discovery succeeds, so interception proceeds to the reachability check against the resolved external endpoint")
+}

--- a/test/integration/reset_test.go
+++ b/test/integration/reset_test.go
@@ -74,7 +74,8 @@ func TestResetLocalStackNotRunning(t *testing.T) {
 	ctx := testContext(t)
 	// Intentionally no startTestContainer: the emulator is not running.
 
-	stdout, _, err := runLstk(t, ctx, t.TempDir(), testEnvWithHome(t.TempDir(), ""),
+	stdout, _, err := runLstk(t, ctx, t.TempDir(),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.LocalStackHost, deadLocalStackHost),
 		"--non-interactive", "reset", "--force",
 	)
 	requireExitCode(t, 1, err)
@@ -128,7 +129,9 @@ func TestResetTelemetryOnFailure(t *testing.T) {
 
 	analyticsSrv, events := mockAnalyticsServer(t)
 	_, _, err := runLstk(t, ctx, t.TempDir(),
-		env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.AnalyticsEndpoint, analyticsSrv.URL),
+		env.Environ(testEnvWithHome(t.TempDir(), "")).
+			With(env.AnalyticsEndpoint, analyticsSrv.URL).
+			With(env.LocalStackHost, deadLocalStackHost),
 		"--non-interactive", "reset", "--force",
 	)
 	requireExitCode(t, 1, err)

--- a/test/integration/sam_cmd_test.go
+++ b/test/integration/sam_cmd_test.go
@@ -229,7 +229,8 @@ func TestSAMFailsWhenEmulatorNotRunning(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	fakeDir := writeFakeSAM(t, "1.95.0")
-	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).WithHome(t.TempDir())
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).WithHome(t.TempDir()).
+		With(env.LocalStackHost, deadLocalStackHost)
 
 	stdout, _, err := runLstk(t, testContext(t), t.TempDir(), e, "sam", "deploy")
 	require.Error(t, err)

--- a/test/integration/setup_azure_test.go
+++ b/test/integration/setup_azure_test.go
@@ -128,7 +128,7 @@ func TestAzCommandErrorsWhenEmulatorNotRunning(t *testing.T) {
 	writeAzureSetupMarker(t, workDir)
 
 	stdout, _, err := runLstk(t, testContext(t), workDir,
-		env.WithHome(t.TempDir()),
+		env.WithHome(t.TempDir()).With(env.LocalStackHost, deadLocalStackHost),
 		"az", "group", "list",
 	)
 	require.Error(t, err)

--- a/test/integration/snapshot_save_test.go
+++ b/test/integration/snapshot_save_test.go
@@ -644,7 +644,7 @@ func TestSnapshotSaveEmulatorNotRunning(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Intentionally no startTestContainer: the emulator is not running.
 			ctx := testContext(t)
-			e := env.Environ(testEnvWithHome(t.TempDir(), ""))
+			e := env.Environ(testEnvWithHome(t.TempDir(), "")).With(env.LocalStackHost, deadLocalStackHost)
 			if tc.authToken != "" {
 				e = e.With(env.AuthToken, tc.authToken)
 			}

--- a/test/integration/terraform_cmd_test.go
+++ b/test/integration/terraform_cmd_test.go
@@ -221,7 +221,8 @@ func TestTerraformFailsWhenEmulatorNotRunning(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	fakeDir := writeFakeTerraform(t)
-	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).WithHome(t.TempDir())
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir).WithHome(t.TempDir()).
+		With(env.LocalStackHost, deadLocalStackHost)
 
 	stdout, _, err := runLstk(t, testContext(t), t.TempDir(), e, "terraform", "plan")
 	require.Error(t, err)


### PR DESCRIPTION
## Motivation

`lstk aws` (and the other proxies) could not target a LocalStack running from source: discovery was Docker-only (container name, then image match), so a plain-process instance on 4566 was invisible and every command pushed the user to start a container — reported by Duncan for the internal dev loop, but equally affecting hand-started containers with unknown images and remote instances via `LOCALSTACK_HOST`. The same gate also broke `lstk az start-interception` against a debug/host-mode Azure emulator (reported by Paolo), since it shares the proxy discovery path.

## What changed

When Docker discovery finds nothing — or Docker is unavailable — lstk now probes `GET /_localstack/info` on the resolved host and silently attaches if a LocalStack instance answers (200 + JSON + non-empty version). The probe only runs on paths that errored before, so container flows are byte-for-byte unchanged and success paths gain no latency. This generalizes the attach precedent that `lstk start`'s port-conflict fallback already had; that path now shares the same probe.

- Adopted by: `aws`, `az` (incl. `start-interception`), `terraform`/`cdk`/`sam`, `reset`, `snapshot save/load` (incl. S3 save/load).
- Wrong-type guard: when Docker is healthy and a known LocalStack container of another type is running, the probe answer is attributed to that container, keeping the existing type-mismatch errors (`lstk terraform` with only Snowflake up).
- `snapshot load`'s Docker auto-start runs only when Docker is healthy and nothing is reachable; an external instance is used as-is.
- Unchanged: `stop`, `logs`, `restart`, `status`, `snapshot list s3://`/`remove` stay Docker-gated (follow-up: external-aware `status` + truthful "running, but not started by lstk" errors for stop/logs).
- New helpers: `container.ProbeEmulatorInfo`, `container.ResolveEmulator`, `container.FirstReachableEmulator`, `cmd/emulator.go:resolveReachableEmulator`.

## Testing

- Unit: probe fingerprinting (non-200 / non-JSON / empty version / unreachable) and resolution (managed-found skips probe, fallback, nil-runtime, wrong-type guard, Docker-down error parity).
- Integration (new `external_instance_test.go`, no Docker needed): aws/terraform/az/reset/snapshot-save/snapshot-load against a mock `/_localstack/info` server with a dead `DOCKER_HOST` — the aws case fails on main with "Docker is not available".
- `lstk az start-interception` against a host-run Azure emulator (Paolo's debug-mode report): the shared `azPreflight` now finds the external instance instead of reporting "not running". Pinned by `TestAzStartInterceptionUsesExternalInstance`, which asserts the command gets past Docker-only discovery and reaches the interception reachability check; verified red→green against the pre-fix binary (pre-fix: "Docker is not available"). The full interception (global `~/.azure` mutation) needs the emulator's TLS gateway + wildcard DNS and stays covered by `TestSetupAzureAndAzCommandSucceed`.
- Existing negative tests ("is not running"/"Docker is not available") are pinned to a dead `LOCALSTACK_HOST` so they stay deterministic on machines with a real LocalStack on 4566.
- Full integration suite run locally: only pre-existing failures remain (token-gated tests without `LOCALSTACK_AUTH_TOKEN`, and environment-specific ones — verified identical against a pre-change binary).
- Manual end-to-end: with the Docker daemon stopped and LocalStack running from source (`uv run -m localstack.runtime.main`), `lstk aws s3 mb/ls`, `lstk reset --force`, and `lstk snapshot save` all succeed; the pre-change binary fails the same setup with "Docker is not available". `lstk stop` still errors truthfully.

## Review

New user-facing behavior on five proxy commands plus reset/snapshot — human review advisable. The riskiest spots are the Docker-down error-precedence changes in `FirstReachableEmulator`/`resolveReachableEmulator` and the silent-attach semantics.

Closes DEVX-1016

Co-Authored-By: Claude <noreply@anthropic.com>
