### PR TITLE
Fix Automated Weekly Release startup_failure: grant security-events:write

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   pull-requests: write
   checks: write
+  security-events: write
 
 concurrency:
   group: create-release-tag


### PR DESCRIPTION
## Summary
-`Automated Weekly Release` runs (e.g. [run 30356430010](https://github.com/localstack/lstk/actions/runs/30356430010)) failed with `startup_failure` and 0 jobs scheduled, on the same commit that a direct `ci.yml` run had just passed on.
- Root cause: a `govulncheck` job was added `ci.yml` that requests `security-events: write` (needed by `upload-sarif` to publish scan results to the Security tab). `automated-release.yml` calls `ci.yml` as a reusable workflow via `uses: ./.github/workflows/ci.yml`. `security-events` wasn't in the list of `permissions:`, so GitHub refused to even schedule the run.
- Fix: add `security-events: write` to `automated-release.yml`'s top-level `permissions:` block so the ceiling covers what `govulncheck` needs.

## Test plan
- [x] Merge and manually trigger `Automated Weekly Release` via `workflow_dispatch` to confirm it no longer hits `startup_failure` and jobs actually run.