### PR TITLE
docs: update README for v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [Installation](#installation) for other install methods.
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) — required as a container engine.
+- A Docker-API-compatible container engine — [Docker](https://docs.docker.com/get-docker/), Rancher Desktop, Colima, OrbStack, Lima, and Podman are all auto-detected; see [container runtimes](docs/container-runtimes.md) for details.
 - [LocalStack account](https://app.localstack.cloud) — required for credentials, the CLI will guide you through authentication.
 
 ## Installation


### PR DESCRIPTION
## Summary

Since the README was last touched (#406), `lstk` gained auto-detection of Docker-API-compatible container runtimes beyond Docker itself — Rancher Desktop, Colima, OrbStack, Lima, and Podman (#399, see `docs/container-runtimes.md`). This made the Prerequisites section narrower than reality, so it's updated to reflect the broader runtime support and link to the new doc.

Everything else that shipped in this window (`-s`/`--services` on `snapshot save`, `--dry-run` on `snapshot load`, license-recovery fix, log-scrollback streaming, govulncheck CI) is a flag, fix, or internal change rather than a whole new capability, so it's left out per the README's "peer of existing bullets" bar.

## Review

Small, self-contained doc correction — self-merge candidate.