### PR TITLE
Honor lstk's own flags for lstk az instead of forwarding them to az

### DIFF
--- a/cmd/az.go
+++ b/cmd/az.go
@@ -21,11 +21,12 @@ import (
 )
 
 func newAzCmd(cfg *env.Env) *cobra.Command {
-	// DisableFlagParsing means Cobra won't strip a pre-command --endpoint-url;
-	// PreRunE does that and stashes the corrected args here for RunE to
-	// forward, mirroring aws.go/terraform.go/cdk.go/sam.go's passthrough
-	// pattern (RunE's own args parameter is NOT updated by PreRunE's local
-	// changes — Cobra calls each independently with its own resolved args).
+	// DisableFlagParsing means Cobra won't strip lstk's own flags (a pre-command
+	// --endpoint-url, --non-interactive, --config); PreRunE does that and
+	// stashes the remaining args here for RunE to forward, mirroring
+	// aws.go/terraform.go/cdk.go/sam.go's passthrough pattern (RunE's own args
+	// parameter is NOT updated by PreRunE's local changes — Cobra calls each
+	// independently with its own resolved args).
 	var passthrough []string
 	cmd := &cobra.Command{
 		Use:   "az [args...]",
@@ -54,7 +55,18 @@ Examples:
 				}
 				args = strippedArgs
 			}
-			passthrough = args
+
+			var gf globalFlags
+			passthrough, gf = stripGlobalFlags(args)
+			if gf.nonInteractive {
+				cfg.NonInteractive = true
+			}
+			if gf.configPath != "" {
+				// initConfigDeferCreate reads the "config" flag, so feed the value back to it.
+				if err := cmd.Flags().Set("config", gf.configPath); err != nil {
+					return err
+				}
+			}
 			return initConfigDeferCreate(nil)(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -88,7 +100,7 @@ Examples:
 			azEnv := azureconfig.Env(azureConfigDir)
 
 			stdout, stderr := io.Writer(os.Stdout), io.Writer(os.Stderr)
-			if terminal.IsTerminal(os.Stderr) {
+			if !cfg.NonInteractive && terminal.IsTerminal(os.Stderr) {
 				s := terminal.NewSpinner(os.Stderr, "Loading service...", 4*time.Second)
 				s.Start()
 				defer s.Stop()

--- a/test/integration/az_cmd_test.go
+++ b/test/integration/az_cmd_test.go
@@ -1,6 +1,13 @@
 package integration_test
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/localstack/lstk/test/integration/env"
@@ -20,4 +27,158 @@ func TestAzCommandFailsWhenAzureCLINotInstalled(t *testing.T) {
 	assert.Contains(t, stdout, "az CLI not found in PATH")
 	assert.Contains(t, stdout, "Install Azure CLI:")
 	assert.Contains(t, stdout, "https://learn.microsoft.com/en-us/cli/azure/")
+}
+
+// azureHealthServer answers like an Azure-flavored emulator: /_localstack/health
+// omits "version" (which is what makes type detection fall back to
+// /_localstack/info), so a --endpoint-url pointed here is detected as azure and
+// `lstk az` never touches Docker.
+func azureHealthServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_localstack/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"services": map[string]string{}})
+		case "/_localstack/info":
+			_ = json.NewEncoder(w).Encode(map[string]any{"version": "3.0.2"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// writeFakeAz creates a shell script that mimics `az` by printing its args,
+// sleeping first when sleepSeconds > 0 so PTY-based tests have time to observe
+// the spinner. Returns the directory containing the script (to prepend to PATH).
+func writeFakeAz(t *testing.T, sleepSeconds int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake az script not supported on Windows")
+	}
+	dir := t.TempDir()
+	script := "#!/bin/sh\n"
+	if sleepSeconds > 0 {
+		script += fmt.Sprintf("sleep %d\n", sleepSeconds)
+	}
+	script += `echo "AZ_ARGS:$@"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "az"), []byte(script), 0755))
+	return dir
+}
+
+// azureConfigWithSetupMarker writes a config.toml holding an Azure container at
+// a path *outside* any config search dir, plus the azure setup marker next to
+// it (azureconfig.ConfigDir is derived from the resolved config file's
+// directory). `lstk az` can only find both if --config actually reached config
+// resolution, which makes the returned path a probe for that.
+func azureConfigWithSetupMarker(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+[[containers]]
+type = "azure"
+tag  = "latest"
+port = "4566"
+`), 0644))
+	markerDir := filepath.Join(dir, "azure")
+	require.NoError(t, os.MkdirAll(markerDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(markerDir, ".lstk-setup-complete"), []byte("ok\n"), 0600))
+	return configPath
+}
+
+// azFakeEnv is the environment for the fake-`az` tests below: DOCKER_HOST points
+// at a nonexistent socket so any code path that fell back to Docker discovery
+// would fail loudly instead of silently passing on a developer machine.
+func azFakeEnv(t *testing.T, fakeDir, homeDir string) []string {
+	t.Helper()
+	e := env.With(env.DisableEvents, "1").With("PATH", fakeDir+":/bin:/usr/bin").With(env.Home, homeDir)
+	return append(e, unreachableDockerHost)
+}
+
+// azureHomeWithSetupMarker prepares a HOME whose $HOME/.config/lstk holds both
+// an Azure config.toml and the azure setup marker, so `lstk az` is fully set up
+// without a --config flag. runLstkInPTY runs with no working directory of its
+// own, so the PTY tests below can't use a project-local config.
+func azureHomeWithSetupMarker(t *testing.T) string {
+	t.Helper()
+	homeDir := t.TempDir()
+	lstkDir := filepath.Join(homeDir, ".config", "lstk")
+	require.NoError(t, os.MkdirAll(filepath.Join(lstkDir, "azure"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(lstkDir, "config.toml"), []byte(`
+[[containers]]
+type = "azure"
+tag  = "latest"
+port = "4566"
+`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(lstkDir, "azure", ".lstk-setup-complete"), []byte("ok\n"), 0600))
+	return homeDir
+}
+
+// `lstk az` sets DisableFlagParsing, so lstk's own persistent flags must be
+// stripped from the forwarded args in PreRunE — otherwise they reach the `az`
+// child, which rejects them as unknown, and their effect on lstk is lost.
+func TestAzCommandStripsGlobalFlagsFromPassthrough(t *testing.T) {
+	t.Parallel()
+	srv := azureHealthServer(t)
+	configPath := azureConfigWithSetupMarker(t)
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), azFakeEnv(t, writeFakeAz(t, 0), t.TempDir()),
+		"--endpoint-url", srv.URL, "--config", configPath, "--non-interactive", "az", "group", "list")
+	require.NoError(t, err, "stderr: %s", stderr)
+
+	assert.Contains(t, stdout, "AZ_ARGS:group list")
+	assert.NotContains(t, stdout, "--non-interactive")
+	assert.NotContains(t, stdout, "--config")
+}
+
+// --config must select the given config file for `lstk az` too: the Azure setup
+// marker lives next to that file, so the passthrough only runs if the flag was
+// honored. The no-flag run is the control — same environment, no config file
+// found, so the setup check fails instead.
+func TestAzCommandConfigFlagSelectsConfigFile(t *testing.T) {
+	t.Parallel()
+	srv := azureHealthServer(t)
+	configPath := azureConfigWithSetupMarker(t)
+	e := azFakeEnv(t, writeFakeAz(t, 0), t.TempDir())
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e,
+		"--endpoint-url", srv.URL, "--config", configPath, "az", "group", "list")
+	require.NoError(t, err, "stderr: %s", stderr)
+	assert.Contains(t, stdout, "AZ_ARGS:group list")
+
+	stdout, _, err = runLstk(t, testContext(t), t.TempDir(), e,
+		"--endpoint-url", srv.URL, "az", "group", "list")
+	require.Error(t, err, "without --config the azure setup marker must not be found")
+	assert.Contains(t, stdout, "Azure CLI integration is not set up")
+}
+
+func TestAzCommandShowsSpinnerForSlowOperation(t *testing.T) {
+	t.Parallel()
+	srv := azureHealthServer(t)
+
+	// The spinner only renders after 4s, so the fake `az` must outlast that.
+	out, err := runLstkInPTY(t, testContext(t), azFakeEnv(t, writeFakeAz(t, 5), azureHomeWithSetupMarker(t)),
+		"--endpoint-url", srv.URL, "az", "group", "list")
+	require.NoError(t, err, "lstk az failed: %s", out)
+
+	assert.Contains(t, out, "Loading service")
+	assert.Contains(t, out, "AZ_ARGS:group list")
+}
+
+// --non-interactive must suppress the spinner: before the flag was stripped in
+// PreRunE it never reached cfg.NonInteractive, leaving the guard inert and ANSI
+// control codes in the captured streams.
+func TestAzCommandSuppressesSpinnerInNonInteractiveMode(t *testing.T) {
+	t.Parallel()
+	srv := azureHealthServer(t)
+
+	out, err := runLstkInPTY(t, testContext(t), azFakeEnv(t, writeFakeAz(t, 5), azureHomeWithSetupMarker(t)),
+		"--endpoint-url", srv.URL, "--non-interactive", "az", "group", "list")
+	require.NoError(t, err, "lstk az failed: %s", out)
+
+	assert.NotContains(t, out, "Loading service")
+	assert.Contains(t, out, "AZ_ARGS:group list")
 }

--- a/test/integration/setup_azure_test.go
+++ b/test/integration/setup_azure_test.go
@@ -37,9 +37,10 @@ func azTempHome(t *testing.T) string {
 
 // azureWorkDir prepares a fresh workDir with a project-local `.lstk/config.toml`
 // containing an Azure container, and returns its path. Tests run `lstk` with
-// `cmd.Dir = workDir` so the project-local config search finds this file —
-// `lstk az` has `DisableFlagParsing: true`, so a `--config` flag wouldn't reach
-// the parent flag set.
+// `cmd.Dir = workDir` so the project-local config search finds this file. (A
+// `--config` flag works for `lstk az` too — see
+// TestAzCommandConfigFlagSelectsConfigFile — but the project-local file keeps
+// the setup-marker path in `.lstk/azure` alongside it.)
 func azureWorkDir(t *testing.T) string {
 	t.Helper()
 	workDir := t.TempDir()


### PR DESCRIPTION
`lstk az` sets `DisableFlagParsing: true` but, unlike `lstk aws`, its `PreRunE` never called `stripGlobalFlags`. So lstk's own persistent flags were forwarded verbatim to the `az` child and their effect on lstk was lost:

- `lstk --non-interactive az group list` handed `--non-interactive group list` to `az` and never set `cfg.NonInteractive`, making lstk's non-interactive mode unreachable for `lstk az`.
- `--config <path>` had the same gap, which is why the azure integration tests had to use a project-local `.lstk/config.toml`.

Before — the forwarded flag makes `az` fail, and lstk exits 2:

```console
$ lstk --non-interactive az group list
ERROR: 'list' is misspelled or not recognized by the system.

https://aka.ms/cli_ref
Read more about the command in reference docs
Error: exit status 2
```

After — the flag is consumed by lstk and `az` gets `group list`:

```console
$ lstk --non-interactive az group list
[]
```

## What changed

- `cmd/az.go` `PreRunE` now mirrors `cmd/aws.go`: `stripGlobalFlags` on the args, `cfg.NonInteractive` set from the result, and `--config`'s value fed back into the `config` flag before `initConfigDeferCreate`.
- The spinner is now guarded by `!cfg.NonInteractive` (it previously only checked `terminal.IsTerminal`). `lstk az` has no PTY path yet, so there is nothing else to gate — that stays the pending follow-up.

## Tests

New integration tests in `test/integration/az_cmd_test.go`, all Docker-free (azure-flavored mock server behind `--endpoint-url`, `DOCKER_HOST` pointed at a dead socket, fake `az` script that echoes its args):

- `TestAzCommandStripsGlobalFlagsFromPassthrough` — the child sees `group list`, with no `--non-interactive` / `--config`.
- `TestAzCommandConfigFlagSelectsConfigFile` — the azure setup marker lives next to the `--config` file (`azureconfig.ConfigDir` derives from the resolved config file's dir), so the passthrough only runs if the flag was honored; the no-flag run is the control.
- `TestAzCommandSuppressesSpinnerInNonInteractiveMode` plus `TestAzCommandShowsSpinnerForSlowOperation` as the positive control.

All three fail before the fix and pass after — before, the PTY run literally showed `AZ_ARGS:--non-interactive group list` with the spinner rendering. `make lint` is clean for both modules and `make test` passes. Two pre-existing `TestSetupAzure*` failures locally are unrelated: they need the real `az` CLI on PATH.

## Review

Small, self-contained fix that brings `az` in line with the four other proxy commands, covered by tests that fail before and pass after — self-merge candidate.

Towards DEVX-1034

Co-Authored-By: Claude <noreply@anthropic.com>
