### PR TITLE
Fix npm README links and package keywords

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
           --license Apache-2.0
           --description "LocalStack CLI v2 - Start and manage LocalStack emulators"
           --files README.md LICENSE
-          --keywords localstack cli aws emulator docker
+          --keywords cli developer-tools local-development localstack
 
       # Replace the auto-generated wrapper with our launcher, which forwards
       # SIGINT/SIGTERM/SIGHUP to the Go binary (DEVX-942). The generated wrapper

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [Installation](#installation) for other install methods.
 
 ## Prerequisites
 
-- A Docker-API-compatible container engine — [Docker](https://docs.docker.com/get-docker/), Rancher Desktop, Colima, OrbStack, Lima, and Podman are all auto-detected; see [container runtimes](docs/container-runtimes.md) for details.
+- A Docker-API-compatible container engine — [Docker](https://docs.docker.com/get-docker/), Rancher Desktop, Colima, OrbStack, Lima, and Podman are all auto-detected; see [container runtimes](https://github.com/localstack/lstk/blob/main/docs/container-runtimes.md) for details.
 - [LocalStack account](https://app.localstack.cloud) — required for credentials, the CLI will guide you through authentication.
 
 ## Installation
@@ -47,15 +47,15 @@ Running `lstk` will automatically handle authentication, configuration, and cont
 - **Snapshots** — save, load, and manage emulator state as local files, cloud snapshots, or in your own S3 bucket
 - **Cloud CLI proxies** — run `aws`, `az`, `terraform`, `cdk`, and `sam` commands against LocalStack with the endpoint, credentials, and region pre-configured
 - **Target an external emulator** — pass `--endpoint-url <url>` (or set `LSTK_ENDPOINT_URL`) to point most commands at an already-running LocalStack instance — docker compose, host-network mode, CI, a different machine, or a cloud-hosted ephemeral instance (`https://` is supported) — instead of one lstk manages locally
-- **Extensions** — Git-style `lstk-<name>` executables extend the CLI with new commands; see [docs/extensions-authoring.md](docs/extensions-authoring.md)
+- **Extensions** — Git-style `lstk-<name>` executables extend the CLI with new commands; see [extension authoring](https://github.com/localstack/lstk/blob/main/docs/extensions-authoring.md)
 - **Self-update** — `lstk update` checks for and installs the latest release
-- **Structured JSON output** — pass `--json` to a supported command for a machine-readable envelope instead of formatted text; see [docs/structured-output.md](docs/structured-output.md)
+- **Structured JSON output** — pass `--json` to a supported command for a machine-readable envelope instead of formatted text; see [structured output](https://github.com/localstack/lstk/blob/main/docs/structured-output.md)
 
 For the full command reference, configuration options, environment variables, and troubleshooting, see the **[lstk documentation](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/)**.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, architecture, and pull request guidelines.
+See [CONTRIBUTING.md](https://github.com/localstack/lstk/blob/main/CONTRIBUTING.md) for development setup, architecture, and pull request guidelines.
 
 ## Reporting bugs
 


### PR DESCRIPTION
## Summary

- use absolute GitHub URLs for repository files linked from the README published to npm
- align the generated npm package keywords with the repository topics

## Why

The generated npm package does not include repository metadata, so npm resolved relative README links as paths under the `@localstack` npm scope instead of the GitHub repository.

## Impact

Users browsing `@localstack/lstk` on npm can follow all README links, and package discovery uses the same keywords as the GitHub repository.

## Validation

- verified all four replacement links return HTTP 200
- `git diff --cached --check`

Review: Self-merge candidate — this is a small, already-discussed documentation and release-metadata change.

Closes PRO-372

Co-Authored-By: Claude <noreply@anthropic.com>
