### PR TITLE
Skip redundant image pulls in integration test helpers

### DIFF
--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -171,16 +171,30 @@ const (
 	testImage     = "alpine:latest"
 )
 
+// ensureImage makes sure image is present locally, pulling it only when missing.
+// The inspect-first check matters: the stand-in helpers below run ~100 times per
+// suite, and an unconditional ImagePull contacts the registry (manifest/digest
+// resolution, seconds each) even when the image is already local. Stand-in
+// images only need to exist — a stale local copy is fine.
+func ensureImage(t *testing.T, ctx context.Context, image string) {
+	t.Helper()
+
+	if _, err := dockerClient.ImageInspect(ctx, image); err == nil {
+		return
+	}
+	reader, err := dockerClient.ImagePull(ctx, image, client.ImagePullOptions{})
+	require.NoError(t, err, "failed to pull image %s", image)
+	_, _ = io.Copy(io.Discard, reader)
+	_ = reader.Close()
+}
+
 // startTestContainer starts the test container with no port bindings by default.
 // Pass hostPort to bind 4566/tcp to a specific host port (e.g. to test that lstk status
 // uses the actual bound port rather than the port from config).
 func startTestContainer(t *testing.T, ctx context.Context, hostPort ...string) {
 	t.Helper()
 
-	reader, err := dockerClient.ImagePull(ctx, testImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull test image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
+	ensureImage(t, ctx, testImage)
 
 	cfg := &container.Config{
 		Image: testImage,
@@ -234,40 +248,45 @@ func startExternalContainer(t *testing.T, ctx context.Context, imgName, name, ho
 	})
 }
 
-// commitNeverHealthyImage builds a local-only image whose default command stays
+// commitNeverHealthyImage ensures a local-only image whose default command stays
 // running (sleep infinity) but never serves /_localstack/health. Starting it via
 // lstk exercises the failure path where the emulator comes up but never reports
 // healthy. The tag must stay pinned (non-latest): a pinned locally-present image
 // skips both the pull and the license checks, while a "latest" tag is validated
 // post-pull via GetImageVersion, which fails on this image (no
 // LOCALSTACK_BUILD_VERSION) before the health wait is ever reached. Returns the
-// image reference; the image and its source container are removed on test cleanup.
+// image reference. The image is deliberately left in place across runs (it adds
+// no layer data on top of the alpine test image) so repeat runs skip the build;
+// the source container is removed as soon as the commit is done.
 func commitNeverHealthyImage(t *testing.T, ctx context.Context) string {
 	t.Helper()
 
-	reader, err := dockerClient.ImagePull(ctx, testImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull test image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
+	const imageRef = "lstk-never-healthy:test"
+	if _, err := dockerClient.ImageInspect(ctx, imageRef); err == nil {
+		return imageRef
+	}
+
+	ensureImage(t, ctx, testImage)
+
+	const srcName = "lstk-never-healthy-src"
+	// Remove any leftover source container from a previous interrupted run so
+	// the create below never hits a name conflict.
+	_, _ = dockerClient.ContainerRemove(ctx, srcName, client.ContainerRemoveOptions{Force: true})
 
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config: &container.Config{Image: testImage},
-		Name:   "lstk-never-healthy-src",
+		Name:   srcName,
 	})
 	require.NoError(t, err, "failed to create source container")
-	t.Cleanup(func() {
+	defer func() {
 		_, _ = dockerClient.ContainerRemove(context.Background(), resp.ID, client.ContainerRemoveOptions{Force: true})
-	})
+	}()
 
-	const imageRef = "lstk-never-healthy:test"
 	_, err = dockerClient.ContainerCommit(ctx, resp.ID, client.ContainerCommitOptions{
 		Reference: imageRef,
 		Changes:   []string{`CMD ["sleep", "infinity"]`},
 	})
 	require.NoError(t, err, "failed to commit never-healthy image")
-	t.Cleanup(func() {
-		_, _ = dockerClient.ImageRemove(context.Background(), imageRef, client.ImageRemoveOptions{Force: true})
-	})
 	return imageRef
 }
 
@@ -286,10 +305,7 @@ func startTestAzureContainer(t *testing.T, ctx context.Context) {
 func startNamedTestContainer(t *testing.T, ctx context.Context, name, label string) {
 	t.Helper()
 
-	reader, err := dockerClient.ImagePull(ctx, testImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull test image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
+	ensureImage(t, ctx, testImage)
 
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config: &container.Config{

--- a/test/integration/start_test.go
+++ b/test/integration/start_test.go
@@ -68,11 +68,8 @@ func TestStartCommandReusesLocalImageWhenPresent(t *testing.T) {
 
 	const pinnedTag = "reuse-local-test"
 	const pinnedImage = "localstack/localstack-pro:" + pinnedTag
-	reader, err := dockerClient.ImagePull(ctx, testImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull test image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
-	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: testImage, Target: pinnedImage})
+	ensureImage(t, ctx, testImage)
+	_, err := dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: testImage, Target: pinnedImage})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = dockerClient.ImageRemove(context.Background(), pinnedImage, client.ImageRemoveOptions{})
@@ -108,11 +105,8 @@ func TestStartFailsWhenContainerExitsDuringStartup(t *testing.T) {
 
 	const pinnedTag = "exit-during-startup-test"
 	const pinnedImage = "localstack/localstack-pro:" + pinnedTag
-	reader, err := dockerClient.ImagePull(ctx, testImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull test image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
-	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: testImage, Target: pinnedImage})
+	ensureImage(t, ctx, testImage)
+	_, err := dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: testImage, Target: pinnedImage})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = dockerClient.ImageRemove(context.Background(), pinnedImage, client.ImageRemoveOptions{})
@@ -159,11 +153,8 @@ func TestStartFailsWhenContainerNeverBecomesHealthy(t *testing.T) {
 	const standInImage = "nginx:alpine"
 	const pinnedTag = "never-healthy-test"
 	const pinnedImage = "localstack/localstack-pro:" + pinnedTag
-	reader, err := dockerClient.ImagePull(ctx, standInImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull nginx test image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
-	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: standInImage, Target: pinnedImage})
+	ensureImage(t, ctx, standInImage)
+	_, err := dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: standInImage, Target: pinnedImage})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = dockerClient.ImageRemove(context.Background(), pinnedImage, client.ImageRemoveOptions{})
@@ -218,11 +209,8 @@ func TestStartEmitsTelemetryWhenInterruptedDuringStartup(t *testing.T) {
 	const standInImage = "nginx:alpine"
 	const pinnedTag = "interrupted-startup-test"
 	const pinnedImage = "localstack/localstack-pro:" + pinnedTag
-	reader, err := dockerClient.ImagePull(ctx, standInImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull nginx test image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
-	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: standInImage, Target: pinnedImage})
+	ensureImage(t, ctx, standInImage)
+	_, err := dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: standInImage, Target: pinnedImage})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = dockerClient.ImageRemove(context.Background(), pinnedImage, client.ImageRemoveOptions{})
@@ -1376,8 +1364,7 @@ func TestStartTimesOutWhenEmulatorNeverBecomesHealthy(t *testing.T) {
 	// for inspection, and the pinned tag names it "localstack-aws-<tag>" — a name
 	// the shared cleanup() (which only removes "localstack-aws") never touches.
 	// Remove it explicitly, or it keeps holding port 4566 and breaks every later
-	// test that starts an emulator. Registered after commitNeverHealthyImage's
-	// cleanups so it runs before them (LIFO): the container goes first, then its image.
+	// test that starts an emulator.
 	t.Cleanup(func() {
 		_, _ = dockerClient.ContainerRemove(context.Background(), "localstack-aws-"+imageTag, client.ContainerRemoveOptions{Force: true})
 	})
@@ -1548,11 +1535,8 @@ func TestStartUsesLocalCustomImageWithoutPullOrLicenseCheck(t *testing.T) {
 
 	// Make the custom image present locally without a registry by tagging the
 	// lightweight test image under it.
-	reader, err := dockerClient.ImagePull(ctx, testImage, client.ImagePullOptions{})
-	require.NoError(t, err, "failed to pull test image")
-	_, _ = io.Copy(io.Discard, reader)
-	_ = reader.Close()
-	_, err = dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: testImage, Target: fullRef})
+	ensureImage(t, ctx, testImage)
+	_, err := dockerClient.ImageTag(ctx, client.ImageTagOptions{Source: testImage, Target: fullRef})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = dockerClient.ImageRemove(context.Background(), fullRef, client.ImageRemoveOptions{Force: true})


### PR DESCRIPTION
## Motivation

The integration-test stand-in helpers (`startTestContainer`, `startNamedTestContainer`, `commitNeverHealthyImage`, plus five direct sites in `start_test.go`) called `ImagePull` unconditionally on every invocation — ~100 times per suite run. Even with the image already local, each pull is a registry round trip (manifest/digest resolution, seconds each), adding minutes of pure network overhead per run.

## Solution

- New `ensureImage(t, ctx, image)` helper: `ImageInspect` first, `ImagePull` only when the image is missing. All alpine/nginx stand-in pull sites now go through it. Stand-in images only need to exist — a stale local copy is fine.
- `commitNeverHealthyImage` is now inspect-first and leaves `lstk-never-healthy:test` in place across runs (it adds no layer data on top of the alpine test image), so repeat runs skip the build entirely; the source container is removed right after the commit instead of at test cleanup, with a leftover-name pre-remove guarding interrupted runs.
- `TestStartFallsBackToLocalImageWhenPullFails` deliberately keeps pulling `localstack/localstack-pro:latest` — it starts a real emulator, so image freshness matters there.

Measured on a 42-test batch (status/stop/logs): 100.0s → 73.4s (~27%), identical results otherwise. The full suite has ~100 helper call sites versus ~35 exercised in that batch, so total savings are larger.

## Docs

<details>
<summary>Docs impact</summary>

Nothing to document — test-internal change only, no user-facing behavior.

</details>

## Review

Small, test-only, mechanical (pull sites swapped for a shared inspect-first helper); verified with vet, golangci-lint, and targeted + batch integration runs, with a stash-baseline confirming the only local failures are pre-existing environment issues. Self-merge candidate.

Co-Authored-By: Claude <noreply@anthropic.com>