### PR TITLE
Fix lstk start hanging on an invisible license re-login prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,7 @@ case <-ctx.Done():
 5. `Update()` must stay non-blocking.
 6. UI should consume shared output events directly; add UI-only wrapper/control messages only when needed, and suffix them with `...Msg`.
 7. Keep message/history state bounded (for example, capped line buffer).
+8. A pending `UserInputRequestEvent` must stay visible and readable until it is answered: show it through `inputPrompt` (spinner text is a mirror, never the only home — a spinner stopped inside its min duration erases it) and wrap it to the terminal width (Bubble Tea truncates every line, cutting off the key hint). Either failure leaves the CLI blocked on `ResponseCh` with nothing on screen.
 
 ## Styling Rules
 - Define styles with semantic names in `internal/ui/styles/styles.go`.

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -1323,16 +1323,24 @@ func isDefinitiveLicenseRejection(status int) bool {
 // folded into the prompt itself (rather than emitted as a separate message
 // first) so a decline doesn't show "License validation failed" twice — once
 // here and again in the final ErrorEvent if the user says no.
+//
+// ESC declines. Ctrl+C would do too, but it also cancels the root context, and
+// the ErrorEvent that the decline renders then races the TUI's own quit — so the
+// manual recovery steps sometimes never reach the terminal (DEVX-1045). An
+// advertised decline key keeps that path deterministic.
 func promptRelogin(ctx context.Context, sink output.Sink, licErr *api.LicenseError) bool {
 	responseCh := make(chan output.InputResponse, 1)
 	sink.Emit(output.UserInputRequestEvent{
-		Prompt:     fmt.Sprintf("License validation failed: %s. Log in again to refresh your credentials?", licErr.Message),
-		Options:    []output.InputOption{{Key: "enter", Label: "Press ENTER to log in again"}},
+		Prompt: fmt.Sprintf("License validation failed: %s. Log in again to refresh your credentials?", licErr.Message),
+		Options: []output.InputOption{
+			{Key: "enter", Label: "ENTER to log in again"},
+			{Key: "esc", Label: "ESC to exit"},
+		},
 		ResponseCh: responseCh,
 	})
 	select {
 	case resp := <-responseCh:
-		return !resp.Cancelled
+		return !resp.Cancelled && resp.SelectedKey != "esc"
 	case <-ctx.Done():
 		return false
 	}

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -1624,3 +1624,39 @@ func TestPromptRelogin_FoldsReasonIntoThePromptWithoutASeparateWarning(t *testin
 	assert.Contains(t, req.Prompt, licErr.Message, "the prompt must explain why the user is being asked to log in again")
 	assert.Contains(t, req.Prompt, "Log in again to refresh your credentials?")
 }
+
+// TestPromptRelogin_OffersAnAdvertisedDeclineKey covers DEVX-1045: Ctrl+C was the
+// only way to decline, and it cancels the root context, so the actionable error
+// the decline renders raced the TUI's quit and could be lost entirely.
+func TestPromptRelogin_OffersAnAdvertisedDeclineKey(t *testing.T) {
+	licErr := &api.LicenseError{Message: "invalid, inactive, or expired authentication token or subscription", Status: http.StatusForbidden}
+
+	for _, tc := range []struct {
+		name     string
+		response output.InputResponse
+		accepted bool
+	}{
+		{name: "enter accepts", response: output.InputResponse{SelectedKey: "enter"}, accepted: true},
+		{name: "esc declines", response: output.InputResponse{SelectedKey: "esc"}, accepted: false},
+		{name: "cancel declines", response: output.InputResponse{Cancelled: true}, accepted: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var req output.UserInputRequestEvent
+			sink := output.SinkFunc(func(event output.Event) {
+				if r, ok := event.(output.UserInputRequestEvent); ok {
+					req = r
+					r.ResponseCh <- tc.response
+				}
+			})
+
+			accepted := promptRelogin(context.Background(), sink, licErr)
+
+			assert.Equal(t, tc.accepted, accepted)
+			keys := make([]string, 0, len(req.Options))
+			for _, opt := range req.Options {
+				keys = append(keys, opt.Key)
+			}
+			assert.Equal(t, []string{"enter", "esc"}, keys, "both the accept and the decline key must be advertised")
+		})
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -186,10 +186,16 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 	case output.UserInputRequestEvent:
 		a.pendingInput = &msg
+		// The prompt always lives in inputPrompt, so a spinner disappearing can
+		// never take it with it: a spinner stopped inside its min-duration stays
+		// visible in pendingStop, and the later SpinnerMinDurationElapsedMsg would
+		// erase a prompt held only in spinner text, leaving the user staring at a
+		// blank screen while the domain waits on ResponseCh (DEVX-1045). The
+		// spinner text is a mirror for as long as the spinner is on screen, since
+		// View renders one or the other.
+		a.inputPrompt = a.inputPrompt.Show(msg.Prompt, msg.Options, msg.Vertical)
 		if a.spinner.Visible() {
 			a.spinner = a.spinner.SetText(output.FormatPrompt(msg.Prompt, msg.Options))
-		} else {
-			a.inputPrompt = a.inputPrompt.Show(msg.Prompt, msg.Options, msg.Vertical)
 		}
 	case output.PullSkippableEvent:
 		msgCopy := msg

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -579,7 +579,7 @@ func (a App) View() string {
 			sb.WriteString(pullView)
 			sb.WriteString("\n")
 		}
-	} else if promptView := a.inputPrompt.View(); promptView != "" {
+	} else if promptView := a.inputPrompt.View(a.width); promptView != "" {
 		sb.WriteString(promptView)
 		sb.WriteString("\n")
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -265,6 +265,37 @@ func TestAppPendingInputSurvivesDeferredSpinnerStop(t *testing.T) {
 	}
 }
 
+// TestAppPromptWrapsAtTerminalWidth covers the other half of DEVX-1045: a long
+// prompt has to be wrapped to the terminal width, since Bubble Tea's renderer
+// would otherwise truncate the key hints off the right edge.
+func TestAppPromptWrapsAtTerminalWidth(t *testing.T) {
+	t.Parallel()
+
+	const width = 40
+	question := "License validation failed: invalid, inactive, or expired authentication token or subscription. Log in again to refresh your credentials?"
+
+	app := NewApp("dev", "", "", nil)
+	model, _ := app.Update(tea.WindowSizeMsg{Width: width})
+	app = model.(App)
+	model, _ = app.Update(output.UserInputRequestEvent{
+		Prompt: question,
+		Options: []output.InputOption{
+			{Key: "enter", Label: "ENTER to log in again"},
+			{Key: "esc", Label: "ESC to exit"},
+		},
+		ResponseCh: make(chan output.InputResponse, 1),
+	})
+	app = model.(App)
+
+	view := app.View()
+	if !strings.Contains(view, "[ENTER to log in again/ESC to exit]") {
+		t.Errorf("expected the key hints to be rendered, got:\n%s", view)
+	}
+	if strings.Contains(view, question) {
+		t.Errorf("expected the question to be wrapped rather than rendered as one long line, got:\n%s", view)
+	}
+}
+
 func TestAppCtrlCCancelsPendingInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -201,6 +201,70 @@ func TestAppEnterRespondsToInputRequest(t *testing.T) {
 	}
 }
 
+// TestAppPendingInputSurvivesDeferredSpinnerStop covers DEVX-1045: a prompt
+// emitted right after a spinner was stopped inside its min duration used to be
+// parked in the spinner's text, and the min-duration tick then erased it. The
+// user saw a blank screen while the domain waited on ResponseCh — `lstk start`
+// looked hung after a rotated auth token was rejected.
+func TestAppPendingInputSurvivesDeferredSpinnerStop(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+
+	model, _ := app.Update(output.SpinnerStart("Checking license"))
+	app = model.(App)
+
+	// A definitive license rejection comes back in well under the spinner's min
+	// duration, so the stop is deferred and the spinner is still on screen when
+	// the prompt arrives.
+	model, _ = app.Update(output.SpinnerStop())
+	app = model.(App)
+	if !app.spinner.PendingStop() {
+		t.Fatal("expected the spinner stop to be deferred by the min duration")
+	}
+
+	prompt := "License validation failed. Log in again to refresh your credentials?"
+	responseCh := make(chan output.InputResponse, 1)
+	model, _ = app.Update(output.UserInputRequestEvent{
+		Prompt:     prompt,
+		Options:    []output.InputOption{{Key: "enter", Label: "ENTER to log in again"}},
+		ResponseCh: responseCh,
+	})
+	app = model.(App)
+
+	model, _ = app.Update(components.SpinnerMinDurationElapsedMsg{})
+	app = model.(App)
+
+	if app.spinner.Visible() {
+		t.Fatal("expected the spinner to be gone once the min duration elapsed")
+	}
+	if !app.inputPrompt.Visible() {
+		t.Fatal("expected the prompt to survive the spinner it was emitted under")
+	}
+	if view := app.View(); !strings.Contains(view, prompt) {
+		t.Fatalf("expected the prompt to stay on screen, got:\n%s", view)
+	}
+
+	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	app = model.(App)
+	if cmd == nil {
+		t.Fatal("expected response command")
+	}
+	cmd()
+
+	select {
+	case resp := <-responseCh:
+		if resp.SelectedKey != "enter" {
+			t.Fatalf("expected enter key, got %q", resp.SelectedKey)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for response on channel")
+	}
+	if app.inputPrompt.Visible() {
+		t.Fatal("expected input prompt to be hidden after response")
+	}
+}
+
 func TestAppCtrlCCancelsPendingInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/components/input_prompt.go
+++ b/internal/ui/components/input_prompt.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/localstack/lstk/internal/output"
 	"github.com/localstack/lstk/internal/ui/styles"
+	"github.com/localstack/lstk/internal/ui/wrap"
 )
 
 type InputPrompt struct {
@@ -48,25 +49,28 @@ func (p InputPrompt) SetSelectedIndex(idx int) InputPrompt {
 	return p
 }
 
-func (p InputPrompt) View() string {
+// marker prefixes the question; continuation lines are indented past it.
+const marker = "? "
+
+// View renders the prompt, wrapped to width so Bubble Tea's renderer cannot
+// truncate away the part that says which key to press (DEVX-1045). A width of 0
+// (before the first WindowSizeMsg) or a width too narrow for the marker renders
+// unwrapped.
+func (p InputPrompt) View(width int) string {
 	if !p.visible {
 		return ""
 	}
 
 	if p.vertical {
-		return p.viewVertical()
+		return p.viewVertical(width)
 	}
 
 	lines := strings.Split(p.prompt, "\n")
-	firstLine := lines[0]
+	question, suffix := lines[0], output.FormatPromptLabels(p.options)
 
 	var sb strings.Builder
-	sb.WriteString(styles.Secondary.Render("? "))
-	sb.WriteString(styles.Message.Render(firstLine))
-
-	if suffix := output.FormatPromptLabels(p.options); suffix != "" {
-		sb.WriteString(styles.Secondary.Render(suffix))
-	}
+	sb.WriteString(styles.Secondary.Render(marker))
+	sb.WriteString(renderWrappedPrompt(question, suffix, width))
 
 	if len(lines) > 1 {
 		sb.WriteString("\n")
@@ -76,12 +80,45 @@ func (p InputPrompt) View() string {
 	return sb.String()
 }
 
-func (p InputPrompt) viewVertical() string {
+// renderWrappedPrompt wraps the question to the width left of the marker and
+// appends the key hints, keeping them dimmed and on the same line when they fit.
+// The hints are wrapped as a unit rather than word by word, so they never end up
+// split across lines.
+func renderWrappedPrompt(question, suffix string, width int) string {
+	indent := strings.Repeat(" ", len([]rune(marker)))
+	available := width - len([]rune(marker))
+	if available <= 0 {
+		return styles.Message.Render(question) + styles.Secondary.Render(suffix)
+	}
+
+	lines := wrap.SoftWrap(question, available)
+	if len(lines) == 0 {
+		lines = []string{""}
+	}
+
+	rendered := make([]string, 0, len(lines)+1)
+	for _, line := range lines {
+		rendered = append(rendered, styles.Message.Render(line))
+	}
+
+	if suffix != "" {
+		last := len(lines) - 1
+		if len([]rune(lines[last]))+len([]rune(suffix)) <= available {
+			rendered[last] += styles.Secondary.Render(suffix)
+		} else {
+			rendered = append(rendered, styles.Secondary.Render(strings.TrimPrefix(suffix, " ")))
+		}
+	}
+
+	return strings.Join(rendered, "\n"+indent)
+}
+
+func (p InputPrompt) viewVertical(width int) string {
 	var sb strings.Builder
 
 	if p.prompt != "" {
-		sb.WriteString(styles.Secondary.Render("? "))
-		sb.WriteString(styles.Message.Render(p.prompt))
+		sb.WriteString(styles.Secondary.Render(marker))
+		sb.WriteString(renderWrappedPrompt(p.prompt, "", width))
 		sb.WriteString("\n")
 	}
 

--- a/internal/ui/components/input_prompt_test.go
+++ b/internal/ui/components/input_prompt_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/localstack/lstk/internal/output"
 )
 
@@ -66,7 +67,7 @@ func TestInputPromptView(t *testing.T) {
 			p := NewInputPrompt()
 
 			if tc.prompt == "" && tc.options == nil {
-				view := p.View()
+				view := p.View(0)
 				if view != "" {
 					t.Fatalf("expected empty view when hidden, got: %q", view)
 				}
@@ -74,7 +75,7 @@ func TestInputPromptView(t *testing.T) {
 			}
 
 			p = p.Show(tc.prompt, tc.options, tc.vertical)
-			view := p.View()
+			view := p.View(0)
 
 			for _, s := range tc.contains {
 				if !strings.Contains(view, s) {
@@ -87,5 +88,50 @@ func TestInputPromptView(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestInputPromptViewWrapsWithoutLosingKeyHints covers DEVX-1045: the license
+// re-login prompt is long enough that Bubble Tea's renderer truncated the key
+// hints off the right edge, leaving a question with no visible answer.
+func TestInputPromptViewWrapsWithoutLosingKeyHints(t *testing.T) {
+	t.Parallel()
+
+	const width = 40
+	question := "License validation failed: invalid, inactive, or expired authentication token or subscription. Log in again to refresh your credentials?"
+	p := NewInputPrompt().Show(question, []output.InputOption{
+		{Key: "enter", Label: "ENTER to log in again"},
+		{Key: "esc", Label: "ESC to exit"},
+	}, false)
+
+	view := p.View(width)
+
+	if !strings.Contains(view, "[ENTER to log in again/ESC to exit]") {
+		t.Errorf("expected the key hints to survive wrapping intact, got:\n%s", view)
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if w := lipgloss.Width(line); w > width {
+			t.Errorf("line exceeds width %d (%d): %q", width, w, line)
+		}
+	}
+	// The question must still be readable end to end once the wrap points and
+	// the continuation indent are removed.
+	flattened := strings.Join(strings.Fields(view), " ")
+	if !strings.Contains(flattened, strings.Join(strings.Fields(question), " ")) {
+		t.Errorf("expected the whole question to survive wrapping, got:\n%s", view)
+	}
+}
+
+func TestInputPromptViewUnwrappedWithoutWidth(t *testing.T) {
+	t.Parallel()
+
+	p := NewInputPrompt().Show("Continue?", []output.InputOption{{Key: "enter", Label: "Press ENTER"}}, false)
+
+	view := p.View(0)
+	if !strings.Contains(view, "Continue? (Press ENTER)") {
+		t.Errorf("expected an unwrapped single line before the first WindowSizeMsg, got: %q", view)
+	}
+	if strings.Contains(view, "\n") {
+		t.Errorf("expected no wrapping without a known width, got: %q", view)
 	}
 }

--- a/test/integration/license_test.go
+++ b/test/integration/license_test.go
@@ -267,6 +267,66 @@ func TestLicenseRejectionOffersReloginAndRetries(t *testing.T) {
 	assert.Equal(t, realToken, storedToken, "the fresh token must replace the rejected one")
 }
 
+// TestLicenseRejectionEscDeclineShowsManualSteps covers DEVX-1045: the re-login
+// offer must be on screen (it used to be swallowed by the spinner it was emitted
+// under, so `lstk start` looked hung), and declining it must print the manual
+// recovery steps and exit right away. Ctrl+C also declines, but it cancels the
+// root context and races the TUI's quit, so ESC is the deterministic path.
+//
+// A pinned tag that is never present locally keeps this on the pre-pull
+// validation path: the rejection lands before any image pull, so no container is
+// ever created.
+func TestLicenseRejectionEscDeclineShowsManualSteps(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+	t.Parallel()
+	requireDocker(t)
+
+	mockServer := createMockLicenseServer(false)
+	defer mockServer.Close()
+
+	tmpHome := t.TempDir()
+	configFile := filepath.Join(tmpHome, "config.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte("[[containers]]\ntype = \"aws\"\ntag = \"2020.1\"\nport = \"4591\"\n"), 0644))
+
+	environ := append(testEnvWithHome(tmpHome, ""),
+		fmt.Sprintf("%s=%s", env.APIEndpoint, mockServer.URL),
+		fmt.Sprintf("%s=%s", env.AuthToken, "rotated-away-token"),
+		"TERM=xterm-256color",
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	cmd := exec.CommandContext(ctx, binaryPath(), "start", "--config", configFile)
+	cmd.Env = environ
+	ptmx, err := pty.Start(cmd)
+	require.NoError(t, err, "failed to start command in PTY")
+	defer func() { _ = ptmx.Close() }()
+
+	out := &syncBuffer{}
+	outputCh := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(out, ptmx)
+		close(outputCh)
+	}()
+
+	require.Eventually(t, func() bool {
+		return bytes.Contains(out.Bytes(), []byte("ESC to exit"))
+	}, 60*time.Second, 100*time.Millisecond, "the re-login prompt must be on screen, advertising the decline key: %s", out.String())
+
+	_, err = ptmx.Write([]byte{0x1b})
+	require.NoError(t, err)
+
+	err = cmd.Wait()
+	<-outputCh
+	requireExitCode(t, 1, err)
+	assert.Contains(t, out.String(), "License validation failed", "declining must render the failure")
+	assert.Contains(t, out.String(), "lstk logout", "declining must point at the manual recovery")
+	assert.Contains(t, out.String(), "LOCALSTACK_AUTH_TOKEN", "declining must mention the env var alternative")
+}
+
 func licenseFilePath(t *testing.T) string {
 	t.Helper()
 	cacheDir, err := os.UserCacheDir()

--- a/test/integration/license_test.go
+++ b/test/integration/license_test.go
@@ -275,13 +275,20 @@ func TestLicenseRejectionOffersReloginAndRetries(t *testing.T) {
 //
 // A pinned tag that is never present locally keeps this on the pre-pull
 // validation path: the rejection lands before any image pull, so no container is
-// ever created.
+// ever created. It still shares Docker state with the rest of the suite, so it
+// is not parallel and it clears any running emulator first: container discovery
+// matches by (image repo, internal port), so an emulator already running on 4566
+// makes `lstk start` report that instead of ever reaching the license check.
 func TestLicenseRejectionEscDeclineShowsManualSteps(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY not supported on Windows")
 	}
-	t.Parallel()
 	requireDocker(t)
+
+	// cleanupLicense, not cleanup: the container has to go, but there is no need
+	// to delete the developer's keyring token to run this test.
+	cleanupLicense()
+	t.Cleanup(cleanupLicense)
 
 	mockServer := createMockLicenseServer(false)
 	defer mockServer.Close()
@@ -311,10 +318,17 @@ func TestLicenseRejectionEscDeclineShowsManualSteps(t *testing.T) {
 		_, _ = io.Copy(out, ptmx)
 		close(outputCh)
 	}()
+	// require.Eventually's message args are evaluated before the wait, so the
+	// transcript has to be logged from a cleanup to be of any use.
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("PTY transcript:\n%s", out.String())
+		}
+	})
 
 	require.Eventually(t, func() bool {
 		return bytes.Contains(out.Bytes(), []byte("ESC to exit"))
-	}, 60*time.Second, 100*time.Millisecond, "the re-login prompt must be on screen, advertising the decline key: %s", out.String())
+	}, 60*time.Second, 100*time.Millisecond, "the re-login prompt must be on screen, advertising the decline key")
 
 	_, err = ptmx.Write([]byte{0x1b})
 	require.NoError(t, err)


### PR DESCRIPTION
## Motivation

After [rotating an auth token](https://app.localstack.cloud/settings/auth-tokens), `lstk start` printed `✓ Pulled localstack/localstack-pro:latest` and then sat there indefinitely. The license failure and the recovery steps only showed up after Ctrl+C. The CLI was blocked on an interactive prompt that the TUI haven't drawn.

Before the fix:

<img width="954" height="330" alt="Screenshot 2026-08-10 at 15 57 28" src="https://github.com/user-attachments/assets/19ef8127-e335-49f7-9fe3-e3f47cdda689" />


After the fix:

<img width="954" height="211" alt="image" src="https://github.com/user-attachments/assets/f8eb228e-75c6-450d-bd5b-296d39484518" />

## Problem

`promptRelogin` emits its `UserInputRequestEvent` a few hundred ms after `validateLicense` starts the "Checking license" spinner. A spinner stopped inside its 400 ms min duration stays on screen in `pendingStop`, so the TUI parked the prompt in the spinner's text. Then the min-duration tick erased it, leaving a blank screen while the domain waited on `ResponseCh`.

## Solution

Three changes:

- the prompt is always shown through `inputPrompt`; spinner text is only a mirror for as long as the spinner is on screen
- prompts wrap to the terminal width. At ~115 columns the `(Press ENTER to log in again)` could be truncated, so even a correctly rendered prompt didn't say what to press
- the prompt now advertises `ESC to exit` next to ENTER. Ctrl+C also declines, but it cancels the root context and the decline's `ErrorEvent` then races with the TUI's quit, so the recovery steps could be lost entirely

The re-login recovery added in #394 is unchanged. This PR fixes its visibility.

Closes DEVX-1045
