### PR TITLE
Add peter-smith-phd to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @localstack/devx
+* @localstack/devx @peter-smith-phd


### PR DESCRIPTION
## Motivation

Peter Smith is not listed in `.github/CODEOWNERS`, so he is not auto-requested as a reviewer on lstk PRs.

## Solution

Add `@peter-smith-phd` alongside `@localstack/devx` on the catch-all `*` rule. He already has write access to the repo, so the entry is valid.

<details>
<summary>Docs</summary>

Nothing to document — repository review configuration only, no user-facing behavior, commands, flags, or env vars change.

</details>

## Review

Self-merge candidate — one-line config change, no code or user-facing behavior affected.

No Linear ticket for this one.