### PR TITLE
Document external contributions policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,22 @@
 # Contributing to lstk
 
-lstk is developed by the LocalStack team and is not currently accepting external pull requests — pull request creation is restricted to repository collaborators.
+lstk is developed by the LocalStack team. You can read the source, build it, and fork it freely.
 
-Your input still matters: open an [issue](https://github.com/localstack/lstk/issues) for bugs and feature requests. This is the channel we act on.
+**We do not accept pull requests from outside collaborators.**
+
+**The way to participate is to open a well-formed issue.** A reproducible bug report or a clearly explained feature request gives us the context we need to act.
+
+## Filing an issue
+
+[Open a new issue](https://github.com/localstack/lstk/issues/new) for a bug report or feature request.
+
+For **bug reports**, include enough information for someone else to reproduce the problem without a follow-up.
+
+For **feature requests**, lead with the problem rather than only a proposed implementation.
+
+## Why we don't accept outside pull requests
+
+lstk's architecture and roadmap move quickly, and reviewing outside patches requires context and coordination we cannot currently offer fairly. An issue lets us validate the problem and decide on an approach before anyone spends time implementing it.
 
 ## Development Setup
 
@@ -100,7 +114,9 @@ This scaffolds a new Bubble Tea TUI component.
 - Unit tests for isolated logic where integration is impractical
 - When fixing a bug, always add an integration test that reproduces the scenario
 
-## Pull Requests
+## Pull Requests for Collaborators
+
+These steps are for authorized repository collaborators:
 
 1. Create a feature branch from `main`
 2. Run `make lint` and `make test` before submitting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to lstk
 
-Thanks for contributing to lstk! This document covers contribution guidelines for the lstk CLI.
+lstk is developed by the LocalStack team and is not currently accepting external pull requests — pull request creation is restricted to repository collaborators.
+
+Your input still matters: open an [issue](https://github.com/localstack/lstk/issues) for bugs and feature requests. This is the channel we act on.
 
 ## Development Setup
 
@@ -100,11 +102,10 @@ This scaffolds a new Bubble Tea TUI component.
 
 ## Pull Requests
 
-1. Fork the repository
-2. Create a feature branch from `main`
-3. Run `make lint` and `make test` before submitting
-4. Review your own PR first — run `/review-pr <number>`
-5. Open a PR against `main`
+1. Create a feature branch from `main`
+2. Run `make lint` and `make test` before submitting
+3. Review your own PR first — run `/review-pr <number>`
+4. Open a PR against `main`
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,8 @@ Running `lstk` will automatically handle authentication, configuration, and cont
 
 For the full command reference, configuration options, environment variables, and troubleshooting, see the **[lstk documentation](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/)**.
 
-## Contributing
+## Feedback and contributing
 
-See [CONTRIBUTING.md](https://github.com/localstack/lstk/blob/main/CONTRIBUTING.md) for development setup, architecture, and pull request guidelines.
+lstk is developed by the LocalStack team and is not currently accepting external pull requests. Feedback is very welcome though — use the [issue tracker](https://github.com/localstack/lstk/issues) for bug reports and feature requests.
 
-## Reporting bugs
-
-Feedback is welcome! Use the [repository issue tracker](https://github.com/localstack/lstk/issues) for bug reports or feature requests.
+Development setup and architecture live in [CONTRIBUTING.md](https://github.com/localstack/lstk/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Running `lstk` will automatically handle authentication, configuration, and cont
 
 For the full command reference, configuration options, environment variables, and troubleshooting, see the **[lstk documentation](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/)**.
 
-## Feedback and contributing
+## Participating
 
-lstk is developed by the LocalStack team and is not currently accepting external pull requests. Feedback is very welcome though — use the [issue tracker](https://github.com/localstack/lstk/issues) for bug reports and feature requests.
+lstk is developed by the LocalStack team. You can read the source, build it, and fork it freely — but we don't accept pull requests from outside collaborators.
 
-Development setup and architecture live in [CONTRIBUTING.md](https://github.com/localstack/lstk/blob/main/CONTRIBUTING.md).
+The best way to participate is to open a well-formed issue. A bug report we can reproduce is worth more to us than a patch, because it captures the part we can't discover ourselves. [CONTRIBUTING.md](CONTRIBUTING.md) explains what to include in bug reports and feature requests.


### PR DESCRIPTION
## Motivation

The repository restricted pull request creation to collaborators, but its contribution guide still told external contributors to fork the repository and open a PR. That directed people toward a workflow they could not complete and did not clearly explain how they could participate instead.

## Solution

Clarifies the contribution policy in README and CONTRIBUTING:

- States that outside pull requests are not accepted
- Directs external participation toward well-formed issues
- Asks for reproducible bug reports and problem-focused feature requests
- Explains why outside patches are not currently accepted
- Restricts the pull request instructions to authorized collaborators
- Removes the stale instruction to fork the repository

This PR does not add issue forms or templates. The existing issue-submission flow remains unchanged.

The following related work remains out of scope:

- Establishing a private security-reporting path
- Cleaning up unused contribution labels

<details>
<summary>Docs</summary>

Nothing to document elsewhere. This PR updates the repository README and CONTRIBUTING guide; the lstk documentation site has no contribution section.

</details>

## Review

Human review advised: this changes the user-facing participation policy presented on the repository's front door.

Towards PRO-260

Co-Authored-By: Claude <noreply@anthropic.com>
