### PR TITLE
Ignore stale Rancher Desktop during detection

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -319,7 +319,11 @@ func detectRuntimeFlavor(
 	if configuredFlavor != flavorUnknown && configuredFlavor != flavorDockerNative {
 		return configuredFlavor
 	}
-	if _, err := statFn(filepath.Join(home, ".rd")); err == nil {
+	// Rancher Desktop leaves ~/.rd behind when the application is removed. Its
+	// rdctl executable is installed on PATH on every supported platform, and is
+	// stronger evidence that Rancher Desktop is still installed than the state
+	// directory alone.
+	if _, err := lookPath("rdctl"); err == nil {
 		return flavorRancherDesktop
 	}
 	if _, err := statFn(filepath.Join(home, ".colima")); err == nil {

--- a/internal/runtime/docker_unhealthy_test.go
+++ b/internal/runtime/docker_unhealthy_test.go
@@ -62,10 +62,30 @@ func TestEmitUnhealthyError_ConfiguredRancherSocketWinsFirstAction(t *testing.T)
 	assert.Equal(t, "rdctl start", actions[0].Value)
 }
 
-func TestEmitUnhealthyError_RancherHomeDirEvidenceWinsWithoutSocket(t *testing.T) {
+func TestEmitUnhealthyError_RancherCLIOnPathWinsWithoutSocket(t *testing.T) {
 	home := "/home/user"
 	// Daemon host is the plain default socket (unresolved), so evidence must come
-	// from the filesystem instead of the configured socket path.
+	// from PATH instead of the configured socket path.
+	rt := newUnhealthyRuntime(t, "unix:///var/run/docker.sock")
+	sink := &captureSink{}
+
+	lookPath := func(name string) (string, error) {
+		if name == "rdctl" {
+			return "/usr/local/bin/rdctl", nil
+		}
+		return "", errors.New("not found")
+	}
+
+	rt.emitUnhealthyError(sink, errors.New("boom"), home, notFound, lookPath, emptyGetenv, "linux")
+
+	actions := sink.errorEvent(t).Actions
+	require.NotEmpty(t, actions)
+	assert.Equal(t, "Start Rancher Desktop:", actions[0].Label)
+	assert.Equal(t, "rdctl start", actions[0].Value)
+}
+
+func TestEmitUnhealthyError_StaleRancherHomeDirIsIgnored(t *testing.T) {
+	home := "/home/user"
 	rt := newUnhealthyRuntime(t, "unix:///var/run/docker.sock")
 	sink := &captureSink{}
 
@@ -76,12 +96,11 @@ func TestEmitUnhealthyError_RancherHomeDirEvidenceWinsWithoutSocket(t *testing.T
 		return nil, os.ErrNotExist
 	}
 
-	rt.emitUnhealthyError(sink, errors.New("boom"), home, statFn, notOnPath, emptyGetenv, "linux")
+	rt.emitUnhealthyError(sink, errors.New("boom"), home, statFn, notOnPath, emptyGetenv, "darwin")
 
 	actions := sink.errorEvent(t).Actions
 	require.NotEmpty(t, actions)
-	assert.Equal(t, "Start Rancher Desktop:", actions[0].Label)
-	assert.Equal(t, "rdctl start", actions[0].Value)
+	assert.Equal(t, "Start Docker Desktop:", actions[0].Label)
 }
 
 func TestEmitUnhealthyError_PodmanOnPath_Darwin(t *testing.T) {


### PR DESCRIPTION
## Motivation

When Docker is unavailable, lstk treats any existing `~/.rd` directory as evidence that Rancher Desktop is installed. Rancher Desktop leaves this directory and broken CLI symlinks behind after uninstalling, which causes lstk to recommend an unusable `rdctl start` action.

Here's what I was seeing on start.

<img width="669" height="272" alt="Screenshot 2026-08-13 at 12 59 26 copy 2" src="https://github.com/user-attachments/assets/d63054f6-1e61-4dd3-8d81-c2d5b7f5f788" />

## Solution

Use a resolvable `rdctl` executable on `PATH` as fallback installation evidence instead of the Rancher state directory alone. Configured Rancher Desktop socket detection remains unchanged.

Add regression coverage for both an installed-but-stopped Rancher Desktop and stale `~/.rd` state after uninstalling.

<details>
<summary>Docs</summary>

No documentation changes are needed. This corrects a runtime detection false-positive without changing the documented container-runtime workflow.

</details>

## Review

Self-merge candidate: this is a small, focused detection fix with regression coverage and no new user-facing behavior. A human review is optional unless the team wants to revisit the existing cross-platform assumption that Rancher Desktop installs `rdctl` on `PATH`.

Closes PRO-374

Co-Authored-By: Claude <noreply@anthropic.com>
