### PR TITLE
Improve slow-start prompt behavior

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -1528,6 +1528,12 @@ func (m *startupMonitor) await(ctx context.Context, containerID, healthURL strin
 	defer deadline.Stop()
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
+	var responseCh chan output.InputResponse
+	defer func() {
+		if responseCh != nil {
+			m.sink.Emit(output.UserInputDismissEvent{ResponseCh: responseCh})
+		}
+	}()
 
 	check := func() (ready bool, err error) {
 		running, err := m.rt.IsRunning(ctx, containerID)
@@ -1574,6 +1580,29 @@ func (m *startupMonitor) await(ctx context.Context, containerID, healthURL strin
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case resp := <-responseCh:
+			// The TUI has already hidden a prompt once it sends a response.
+			responseCh = nil
+			if resp.Cancelled {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				return context.Canceled
+			}
+			if resp.SelectedKey == "s" {
+				// Readiness may have changed between the last poll and the keypress.
+				// Never stop an emulator that became ready while the prompt was open.
+				if ready, err := check(); err != nil || ready {
+					return err
+				}
+				m.sink.Emit(output.SpinnerStart("Stopping LocalStack..."))
+				// Best-effort stop; the timeout error is authoritative either way.
+				_ = m.rt.Stop(ctx, containerID)
+				return &startupTimeoutError{timeout: m.timeout, stopped: true}
+			}
+
+			deadline.Reset(m.timeout)
+			m.sink.Emit(output.SpinnerStart("Starting LocalStack"))
 		case res := <-exitCh:
 			if res.Err != nil {
 				// The wait itself failed (e.g. an exit+removal race before the
@@ -1584,66 +1613,31 @@ func (m *startupMonitor) await(ctx context.Context, containerID, healthURL strin
 			}
 			return &containerExitedError{exitCode: res.ExitCode}
 		case <-deadline.C:
-			surface, stopped, err := m.handleTimeout(ctx, containerID)
-			if err != nil {
+			// Avoid surfacing a stale timeout if readiness changed since the last
+			// poll, especially when the ticker and deadline become ready together.
+			if ready, err := check(); err != nil || ready {
 				return err
 			}
-			if surface {
-				return &startupTimeoutError{timeout: m.timeout, stopped: stopped}
+			if !m.interactive {
+				return &startupTimeoutError{timeout: m.timeout}
 			}
-			// Keep waiting: re-arm the deadline and restore the spinner.
-			deadline.Reset(m.timeout)
-			m.sink.Emit(output.SpinnerStart("Starting LocalStack"))
+
+			m.sink.Emit(output.SpinnerStop())
+			responseCh = make(chan output.InputResponse, 1)
+			m.sink.Emit(output.UserInputRequestEvent{
+				Prompt: "LocalStack is still starting. Check progress with 'lstk logs'.",
+				Options: []output.InputOption{
+					{Key: "w", Label: "[W] Keep waiting"},
+					{Key: "s", Label: "[S] Stop and exit"},
+				},
+				ResponseCh: responseCh,
+				Vertical:   true,
+			})
 		case <-ticker.C:
 			if ready, err := check(); err != nil || ready {
 				return err
 			}
 		}
-	}
-}
-
-// handleTimeout decides what to do when the startup deadline elapses. In
-// non-interactive mode it always surfaces the timeout, leaving the container
-// running so the user can inspect it. In interactive mode it prompts the user to
-// keep waiting or stop; "keep waiting" returns surface=false so the caller
-// re-arms the deadline. stopped reports whether the container was stopped (the
-// user chose "stop"), so the timeout error can describe its actual state.
-func (m *startupMonitor) handleTimeout(ctx context.Context, containerID string) (surface, stopped bool, err error) {
-	if !m.interactive {
-		return true, false, nil
-	}
-
-	m.sink.Emit(output.SpinnerStop())
-	responseCh := make(chan output.InputResponse, 1)
-	m.sink.Emit(output.UserInputRequestEvent{
-		Prompt: "LocalStack is taking longer than expected to start. Check logs with 'lstk logs'",
-		Options: []output.InputOption{
-			{Key: "w", Label: "Keep waiting [W]"},
-			{Key: "s", Label: "Stop LocalStack and exit [S]"},
-		},
-		ResponseCh: responseCh,
-	})
-
-	select {
-	case resp := <-responseCh:
-		if resp.Cancelled {
-			// Ctrl+C: leave the container running (it is detached).
-			if ctx.Err() != nil {
-				return false, false, ctx.Err()
-			}
-			return false, false, context.Canceled
-		}
-		if resp.SelectedKey == "s" {
-			// Stopping takes a few seconds; show progress so the CLI does not
-			// look hung after the keypress. The caller's SpinnerStop closes it.
-			m.sink.Emit(output.SpinnerStart("Stopping LocalStack..."))
-			// Best-effort stop; the timeout error is authoritative either way.
-			_ = m.rt.Stop(ctx, containerID)
-			return true, true, nil
-		}
-		return false, false, nil
-	case <-ctx.Done():
-		return false, false, ctx.Err()
 	}
 }
 

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -821,9 +821,11 @@ func TestStartupMonitorAwait_InteractivePromptKeepWaitingThenStop(t *testing.T) 
 	mockRT.EXPECT().Stop(gomock.Any(), "cid").Return(nil)
 
 	prompts := make(chan output.UserInputRequestEvent, 2)
+	seenPrompts := make(chan output.UserInputRequestEvent, 2)
 	sink := output.SinkFunc(func(event output.Event) {
 		if req, ok := event.(output.UserInputRequestEvent); ok {
 			prompts <- req
+			seenPrompts <- req
 		}
 	})
 
@@ -846,6 +848,80 @@ func TestStartupMonitorAwait_InteractivePromptKeepWaitingThenStop(t *testing.T) 
 	var timeoutErr *startupTimeoutError
 	require.ErrorAs(t, err, &timeoutErr)
 	assert.True(t, timeoutErr.stopped, "choosing stop at the prompt must be recorded on the error")
+
+	firstPrompt := <-seenPrompts
+	assert.Equal(t, "LocalStack is still starting. Check progress with 'lstk logs'.", firstPrompt.Prompt)
+	assert.True(t, firstPrompt.Vertical)
+	assert.Equal(t, []output.InputOption{
+		{Key: "w", Label: "[W] Keep waiting"},
+		{Key: "s", Label: "[S] Stop and exit"},
+	}, firstPrompt.Options)
+}
+
+func TestStartupMonitorAwait_DismissesPromptWhenEmulatorBecomesReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsRunning(gomock.Any(), "cid").Return(true, nil).AnyTimes()
+
+	var ready atomic.Bool
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if ready.Load() {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer healthServer.Close()
+
+	prompts := make(chan output.UserInputRequestEvent, 1)
+	dismissals := make(chan output.UserInputDismissEvent, 1)
+	sink := output.SinkFunc(func(event output.Event) {
+		switch event := event.(type) {
+		case output.UserInputRequestEvent:
+			prompts <- event
+			ready.Store(true)
+		case output.UserInputDismissEvent:
+			dismissals <- event
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	monitor := newStartupMonitor(mockRT, sink, nil, 25*time.Millisecond, true)
+	err := monitor.await(ctx, "cid", healthServer.URL, make(chan runtime.ExitResult))
+
+	require.NoError(t, err)
+	prompt := <-prompts
+	dismissal := <-dismissals
+	assert.Equal(t, prompt.ResponseCh, dismissal.ResponseCh)
+}
+
+func TestStartupMonitorAwait_DoesNotStopEmulatorThatBecameReadyBeforeSelection(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := runtime.NewMockRuntime(ctrl)
+	mockRT.EXPECT().IsRunning(gomock.Any(), "cid").Return(true, nil).AnyTimes()
+
+	var ready atomic.Bool
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if ready.Load() {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer healthServer.Close()
+
+	sink := output.SinkFunc(func(event output.Event) {
+		if prompt, ok := event.(output.UserInputRequestEvent); ok {
+			ready.Store(true)
+			prompt.ResponseCh <- output.InputResponse{SelectedKey: "s"}
+		}
+	})
+
+	monitor := newStartupMonitor(mockRT, sink, nil, 25*time.Millisecond, true)
+	err := monitor.await(context.Background(), "cid", healthServer.URL, make(chan runtime.ExitResult))
+
+	require.NoError(t, err)
 }
 
 func TestStartupMonitorAwait_ReturnsExitCodeFromExitCh(t *testing.T) {

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -245,6 +245,7 @@ func (MultipleInstallsEvent) sealedEvent()    {}
 func (ContainerStatusEvent) sealedEvent()     {}
 func (ProgressEvent) sealedEvent()            {}
 func (UserInputRequestEvent) sealedEvent()    {}
+func (UserInputDismissEvent) sealedEvent()    {}
 func (PullSkippableEvent) sealedEvent()       {}
 func (LogLineEvent) sealedEvent()             {}
 
@@ -290,6 +291,13 @@ type UserInputRequestEvent struct {
 	Options    []InputOption
 	ResponseCh chan<- InputResponse
 	Vertical   bool
+}
+
+// UserInputDismissEvent removes a pending prompt when the condition that
+// required input resolves on its own. ResponseCh identifies the exact request
+// so a late dismissal cannot hide a newer prompt.
+type UserInputDismissEvent struct {
+	ResponseCh chan<- InputResponse
 }
 
 // PullSkippableEvent signals that an in-flight image pull can be abandoned in

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -34,6 +34,8 @@ func FormatEventLine(event Event) (string, bool) {
 		return "", false
 	case UserInputRequestEvent:
 		return formatUserInputRequest(e), true
+	case UserInputDismissEvent:
+		return "", false
 	case PullSkippableEvent:
 		// Interactive-only affordance with no plain-text rendering: non-interactive
 		// pulls never emit it, and PlainSink cannot bind the ESC key.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -197,6 +197,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.spinner.Visible() {
 			a.spinner = a.spinner.SetText(output.FormatPrompt(msg.Prompt, msg.Options))
 		}
+	case output.UserInputDismissEvent:
+		if a.pendingInput == nil || a.pendingInput.ResponseCh != msg.ResponseCh {
+			return a, nil
+		}
+		a.pendingInput = nil
+		a.inputPrompt = a.inputPrompt.Hide()
+		a.spinner = a.spinner.SetText("")
+		return a, nil
 	case output.PullSkippableEvent:
 		msgCopy := msg
 		a.pullSkip = &msgCopy

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -201,6 +201,38 @@ func TestAppEnterRespondsToInputRequest(t *testing.T) {
 	}
 }
 
+func TestAppDismissesOnlyTheMatchingPendingInput(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+	model, _ := app.Update(output.SpinnerStart("Starting LocalStack"))
+	app = model.(App)
+
+	responseCh := make(chan output.InputResponse, 1)
+	prompt := "LocalStack is still starting."
+	model, _ = app.Update(output.UserInputRequestEvent{
+		Prompt:     prompt,
+		Options:    []output.InputOption{{Key: "w", Label: "[W] Keep waiting"}},
+		ResponseCh: responseCh,
+	})
+	app = model.(App)
+
+	model, _ = app.Update(output.UserInputDismissEvent{ResponseCh: make(chan output.InputResponse, 1)})
+	app = model.(App)
+	if !app.inputPrompt.Visible() {
+		t.Fatal("expected an unrelated dismissal to leave the prompt visible")
+	}
+
+	model, _ = app.Update(output.UserInputDismissEvent{ResponseCh: responseCh})
+	app = model.(App)
+	if app.pendingInput != nil || app.inputPrompt.Visible() {
+		t.Fatal("expected the matching prompt to be dismissed")
+	}
+	if view := app.View(); strings.Contains(view, prompt) {
+		t.Fatalf("expected the spinner's prompt mirror to be cleared, got:\n%s", view)
+	}
+}
+
 // TestAppPendingInputSurvivesDeferredSpinnerStop covers DEVX-1045: a prompt
 // emitted right after a spinner was stopped inside its min duration used to be
 // parked in the spinner's text, and the min-duration tick then erased it. The

--- a/internal/ui/components/input_prompt_test.go
+++ b/internal/ui/components/input_prompt_test.go
@@ -135,3 +135,31 @@ func TestInputPromptViewUnwrappedWithoutWidth(t *testing.T) {
 		t.Errorf("expected no wrapping without a known width, got: %q", view)
 	}
 }
+
+func TestInputPromptViewSlowStartChoicesAreScannable(t *testing.T) {
+	t.Parallel()
+
+	const width = 80
+	question := "LocalStack is still starting. Check progress with 'lstk logs'."
+	p := NewInputPrompt().Show(question, []output.InputOption{
+		{Key: "w", Label: "[W] Keep waiting"},
+		{Key: "s", Label: "[S] Stop and exit"},
+	}, true)
+
+	view := p.View(width)
+	lines := strings.Split(view, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected a question and two vertical choices, got:\n%s", view)
+	}
+	if !strings.Contains(lines[0], question) {
+		t.Fatalf("expected the question and log command on one line, got:\n%s", view)
+	}
+	if !strings.Contains(lines[1], "[W] Keep waiting") || !strings.Contains(lines[2], "[S] Stop and exit") {
+		t.Fatalf("expected prefixed shortcuts on separate lines, got:\n%s", view)
+	}
+	for _, line := range lines {
+		if lipgloss.Width(line) > width {
+			t.Fatalf("line exceeds width %d: %q", width, line)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

When LocalStack takes longer than the interactive startup timeout, the recovery prompt wraps awkwardly and hides its shortcut keys. More importantly, startup health checks pause while the prompt is open, so it can remain stuck after the emulator is ready and a stale Stop selection can stop a healthy emulator.

## Solution

- Render the slow-start actions as vertical, shortcut-first choices.
- Continue monitoring readiness and container exit while the prompt is visible.
- Dismiss only the matching prompt when startup resolves automatically.
- Recheck readiness before stopping to protect an emulator that became healthy during the prompt.
- Add regression tests for layout, automatic dismissal, and readiness/Stop races.

## BEFORE / AFTER

| Aspect | Before | After |
| --- | --- | --- |
| Prompt layout | Question and actions form one long line and wrap awkwardly | Question and actions render on separate lines |
| Shortcuts | `Keep waiting [W]` / `Stop LocalStack and exit [S]` | `[W] Keep waiting` / `[S] Stop and exit` |
| Successful startup | Prompt remains stuck until a key is pressed | Prompt closes automatically and the success sequence appears |
| Stop action | A stale prompt can stop an emulator that has become ready | Readiness is checked again before stopping |
| Monitoring | Health checks pause while awaiting input | Health and exit monitoring continue behind the prompt |

| BEFORE | AFTER |
|--------|--------|
| <img width="669" height="315" alt="Screenshot 2026-08-13 at 13 36 25" src="https://github.com/user-attachments/assets/c509aec6-94cc-4a84-a1e1-85ce95e4fc6b" /> | <img width="669" height="315" alt="Screenshot 2026-08-13 at 13 58 06" src="https://github.com/user-attachments/assets/9957a9d9-fb17-4d77-8e2b-790010a14178" /> | 

## Docs

<details>
<summary>Docs assessment</summary>

No documentation changes are needed. This refines existing interactive startup behavior and keeps the recovery command visible in the prompt.

</details>

## Review

Self-merge candidate: this is a small, already-discussed UX fix with focused unit and race regression coverage.

## Validation

- `go test -race ./internal/container -run 'TestStartupMonitorAwait_(InteractivePromptKeepWaitingThenStop|DismissesPromptWhenEmulatorBecomesReady|DoesNotStopEmulatorThatBecameReadyBeforeSelection)$' -count=1`
- `go test ./internal/ui/... ./internal/output/... -count=1`
- `make build`
- `git diff --check`

Closes DEVX-1051

Co-Authored-By: Claude <noreply@anthropic.com>
