### PR TITLE
Render the license re-login prompt choices vertically

### DIFF
--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -1345,7 +1345,7 @@ func promptRelogin(ctx context.Context, sink output.Sink, licErr *api.LicenseErr
 	sink.Emit(output.UserInputRequestEvent{
 		Prompt: fmt.Sprintf("License validation failed: %s.", licErr.Message),
 		Options: []output.InputOption{
-			{Key: "enter", Label: "[ENTER] Log in again"},
+			{Key: "r", Label: "[R] Re-authenticate"},
 			{Key: "esc", Label: "[ESC] Exit"},
 		},
 		ResponseCh: responseCh,

--- a/internal/container/start.go
+++ b/internal/container/start.go
@@ -1335,16 +1335,21 @@ func isDefinitiveLicenseRejection(status int) bool {
 // ESC declines. Ctrl+C would do too, but it also cancels the root context, and
 // the ErrorEvent that the decline renders then races the TUI's own quit — so the
 // manual recovery steps sometimes never reach the terminal (DEVX-1045). An
-// advertised decline key keeps that path deterministic.
+// advertised decline key keeps that path deterministic. The choices render
+// vertically so both keys read as selectable actions rather than a hint tacked
+// onto the end of the sentence; the prompt therefore states the reason and
+// leaves the two actions to the labels, which keeps it one wrapped statement
+// instead of a statement whose trailing question dangles at the wrap point.
 func promptRelogin(ctx context.Context, sink output.Sink, licErr *api.LicenseError) bool {
 	responseCh := make(chan output.InputResponse, 1)
 	sink.Emit(output.UserInputRequestEvent{
-		Prompt: fmt.Sprintf("License validation failed: %s. Log in again to refresh your credentials?", licErr.Message),
+		Prompt: fmt.Sprintf("License validation failed: %s.", licErr.Message),
 		Options: []output.InputOption{
-			{Key: "enter", Label: "ENTER to log in again"},
-			{Key: "esc", Label: "ESC to exit"},
+			{Key: "enter", Label: "[ENTER] Log in again"},
+			{Key: "esc", Label: "[ESC] Exit"},
 		},
 		ResponseCh: responseCh,
+		Vertical:   true,
 	})
 	select {
 	case resp := <-responseCh:

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -1698,7 +1698,7 @@ func TestPromptRelogin_FoldsReasonIntoThePromptWithoutASeparateWarning(t *testin
 	req, ok := events[0].(output.UserInputRequestEvent)
 	require.True(t, ok, "the only event emitted must be the prompt itself")
 	assert.Contains(t, req.Prompt, licErr.Message, "the prompt must explain why the user is being asked to log in again")
-	assert.Equal(t, "[ENTER] Log in again", req.Options[0].Label, "the recovery action belongs to the choice, not the prompt sentence")
+	assert.Equal(t, "[R] Re-authenticate", req.Options[0].Label, "the recovery action belongs to the choice, not the prompt sentence")
 }
 
 // TestPromptRelogin_OffersAnAdvertisedDeclineKey covers DEVX-1045: Ctrl+C was the
@@ -1712,7 +1712,7 @@ func TestPromptRelogin_OffersAnAdvertisedDeclineKey(t *testing.T) {
 		response output.InputResponse
 		accepted bool
 	}{
-		{name: "enter accepts", response: output.InputResponse{SelectedKey: "enter"}, accepted: true},
+		{name: "r accepts", response: output.InputResponse{SelectedKey: "r"}, accepted: true},
 		{name: "esc declines", response: output.InputResponse{SelectedKey: "esc"}, accepted: false},
 		{name: "cancel declines", response: output.InputResponse{Cancelled: true}, accepted: false},
 	} {
@@ -1730,7 +1730,7 @@ func TestPromptRelogin_OffersAnAdvertisedDeclineKey(t *testing.T) {
 			assert.Equal(t, tc.accepted, accepted)
 			assert.True(t, req.Vertical, "the choices must render as vertical, selectable actions")
 			assert.Equal(t, []output.InputOption{
-				{Key: "enter", Label: "[ENTER] Log in again"},
+				{Key: "r", Label: "[R] Re-authenticate"},
 				{Key: "esc", Label: "[ESC] Exit"},
 			}, req.Options, "both the accept and the decline key must be advertised, shortcut first")
 		})

--- a/internal/container/start_test.go
+++ b/internal/container/start_test.go
@@ -1698,7 +1698,7 @@ func TestPromptRelogin_FoldsReasonIntoThePromptWithoutASeparateWarning(t *testin
 	req, ok := events[0].(output.UserInputRequestEvent)
 	require.True(t, ok, "the only event emitted must be the prompt itself")
 	assert.Contains(t, req.Prompt, licErr.Message, "the prompt must explain why the user is being asked to log in again")
-	assert.Contains(t, req.Prompt, "Log in again to refresh your credentials?")
+	assert.Equal(t, "[ENTER] Log in again", req.Options[0].Label, "the recovery action belongs to the choice, not the prompt sentence")
 }
 
 // TestPromptRelogin_OffersAnAdvertisedDeclineKey covers DEVX-1045: Ctrl+C was the
@@ -1728,11 +1728,11 @@ func TestPromptRelogin_OffersAnAdvertisedDeclineKey(t *testing.T) {
 			accepted := promptRelogin(context.Background(), sink, licErr)
 
 			assert.Equal(t, tc.accepted, accepted)
-			keys := make([]string, 0, len(req.Options))
-			for _, opt := range req.Options {
-				keys = append(keys, opt.Key)
-			}
-			assert.Equal(t, []string{"enter", "esc"}, keys, "both the accept and the decline key must be advertised")
+			assert.True(t, req.Vertical, "the choices must render as vertical, selectable actions")
+			assert.Equal(t, []output.InputOption{
+				{Key: "enter", Label: "[ENTER] Log in again"},
+				{Key: "esc", Label: "[ESC] Exit"},
+			}, req.Options, "both the accept and the decline key must be advertised, shortcut first")
 		})
 	}
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -888,7 +888,7 @@ func TestAppEscResolvesVerticalDeclineOption(t *testing.T) {
 	model, _ := app.Update(output.UserInputRequestEvent{
 		Prompt: "License validation failed: invalid, inactive, or expired authentication token or subscription.",
 		Options: []output.InputOption{
-			{Key: "enter", Label: "[ENTER] Log in again"},
+			{Key: "r", Label: "[R] Re-authenticate"},
 			{Key: "esc", Label: "[ESC] Exit"},
 		},
 		ResponseCh: responseCh,
@@ -910,6 +910,46 @@ func TestAppEscResolvesVerticalDeclineOption(t *testing.T) {
 		}
 		if resp.Cancelled {
 			t.Fatal("expected esc to decline through its option, not as a cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for response on channel")
+	}
+
+	if app.inputPrompt.Visible() {
+		t.Fatal("expected input prompt to be hidden after response")
+	}
+}
+
+func TestAppReloginShortcutIgnoresVerticalSelection(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+	responseCh := make(chan output.InputResponse, 1)
+
+	model, _ := app.Update(output.UserInputRequestEvent{
+		Prompt: "License validation failed: invalid, inactive, or expired authentication token or subscription.",
+		Options: []output.InputOption{
+			{Key: "r", Label: "[R] Re-authenticate"},
+			{Key: "esc", Label: "[ESC] Exit"},
+		},
+		ResponseCh: responseCh,
+		Vertical:   true,
+	})
+	app = model.(App)
+
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyDown})
+	app = model.(App)
+	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	app = model.(App)
+	if cmd == nil {
+		t.Fatal("expected response command when r is pressed on a vertical prompt")
+	}
+	cmd()
+
+	select {
+	case resp := <-responseCh:
+		if resp.SelectedKey != "r" {
+			t.Fatalf("expected r key, got %q", resp.SelectedKey)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for response on channel")

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -875,6 +875,51 @@ func TestAppEnterSelectsHighlightedVerticalOption(t *testing.T) {
 	}
 }
 
+// TestAppEscResolvesVerticalDeclineOption guards the license re-login prompt's
+// decline path (DEVX-1045): the vertical key handler claims Enter for the
+// highlighted row, so a direct ESC press must still fall through to its option
+// rather than being swallowed.
+func TestAppEscResolvesVerticalDeclineOption(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp("dev", "", "", nil)
+	responseCh := make(chan output.InputResponse, 1)
+
+	model, _ := app.Update(output.UserInputRequestEvent{
+		Prompt: "License validation failed: invalid, inactive, or expired authentication token or subscription.",
+		Options: []output.InputOption{
+			{Key: "enter", Label: "[ENTER] Log in again"},
+			{Key: "esc", Label: "[ESC] Exit"},
+		},
+		ResponseCh: responseCh,
+		Vertical:   true,
+	})
+	app = model.(App)
+
+	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	app = model.(App)
+	if cmd == nil {
+		t.Fatal("expected response command when esc is pressed on a vertical prompt")
+	}
+	cmd()
+
+	select {
+	case resp := <-responseCh:
+		if resp.SelectedKey != "esc" {
+			t.Fatalf("expected esc key, got %q", resp.SelectedKey)
+		}
+		if resp.Cancelled {
+			t.Fatal("expected esc to decline through its option, not as a cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for response on channel")
+	}
+
+	if app.inputPrompt.Visible() {
+		t.Fatal("expected input prompt to be hidden after response")
+	}
+}
+
 func TestAppAnyKeyOptionResolvesOnAnyKeypress(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/components/input_prompt_test.go
+++ b/internal/ui/components/input_prompt_test.go
@@ -163,3 +163,37 @@ func TestInputPromptViewSlowStartChoicesAreScannable(t *testing.T) {
 		}
 	}
 }
+
+// TestInputPromptViewReloginChoicesAreScannable covers the license re-login
+// prompt: its question is long enough to wrap, so flattening the two choices
+// into a trailing hint made them read as prose. They belong on their own lines
+// below the wrapped question, shortcut first.
+func TestInputPromptViewReloginChoicesAreScannable(t *testing.T) {
+	t.Parallel()
+
+	const width = 40
+	question := "License validation failed: invalid, inactive, or expired authentication token or subscription."
+	p := NewInputPrompt().Show(question, []output.InputOption{
+		{Key: "enter", Label: "[ENTER] Log in again"},
+		{Key: "esc", Label: "[ESC] Exit"},
+	}, true)
+
+	view := p.View(width)
+	lines := strings.Split(strings.TrimRight(view, "\n"), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected a wrapped question and two vertical choices, got:\n%s", view)
+	}
+	if choices := lines[len(lines)-2:]; !strings.Contains(choices[0], "[ENTER] Log in again") ||
+		!strings.Contains(choices[1], "[ESC] Exit") {
+		t.Fatalf("expected each choice on its own trailing line, got:\n%s", view)
+	}
+	for _, line := range lines {
+		if w := lipgloss.Width(line); w > width {
+			t.Errorf("line exceeds width %d (%d): %q", width, w, line)
+		}
+	}
+	flattened := strings.Join(strings.Fields(view), " ")
+	if !strings.Contains(flattened, strings.Join(strings.Fields(question), " ")) {
+		t.Errorf("expected the whole question to survive wrapping, got:\n%s", view)
+	}
+}

--- a/internal/ui/components/input_prompt_test.go
+++ b/internal/ui/components/input_prompt_test.go
@@ -174,7 +174,7 @@ func TestInputPromptViewReloginChoicesAreScannable(t *testing.T) {
 	const width = 40
 	question := "License validation failed: invalid, inactive, or expired authentication token or subscription."
 	p := NewInputPrompt().Show(question, []output.InputOption{
-		{Key: "enter", Label: "[ENTER] Log in again"},
+		{Key: "r", Label: "[R] Re-authenticate"},
 		{Key: "esc", Label: "[ESC] Exit"},
 	}, true)
 
@@ -183,7 +183,7 @@ func TestInputPromptViewReloginChoicesAreScannable(t *testing.T) {
 	if len(lines) < 3 {
 		t.Fatalf("expected a wrapped question and two vertical choices, got:\n%s", view)
 	}
-	if choices := lines[len(lines)-2:]; !strings.Contains(choices[0], "[ENTER] Log in again") ||
+	if choices := lines[len(lines)-2:]; !strings.Contains(choices[0], "[R] Re-authenticate") ||
 		!strings.Contains(choices[1], "[ESC] Exit") {
 		t.Fatalf("expected each choice on its own trailing line, got:\n%s", view)
 	}

--- a/test/integration/license_test.go
+++ b/test/integration/license_test.go
@@ -170,10 +170,10 @@ func TestLicenseRejectionOffersReloginAndRetries(t *testing.T) {
 
 	p := startLstkInPTY(t, ctx, environ, "start", "--config", configFile)
 
-	// The stale token is rejected; the re-login prompt appears. Press ENTER.
-	// The wait covers a cold image pull on CI runners.
-	p.waitForOutputTimeout("Log in again", 3*time.Minute, "the re-login prompt should appear after the license rejection")
-	p.write("\r")
+	// The stale token is rejected; the re-login prompt appears. Press R, the
+	// shortcut it advertises. The wait covers a cold image pull on CI runners.
+	p.waitForOutputTimeout("[R] Re-authenticate", 3*time.Minute, "the re-login prompt should appear after the license rejection")
+	p.write("r")
 
 	// The login flow runs; confirm it once the completion prompt appears.
 	p.waitForOutputTimeout("key when complete", 30*time.Second, "the login completion prompt should appear")

--- a/test/integration/license_test.go
+++ b/test/integration/license_test.go
@@ -287,7 +287,7 @@ func TestLicenseRejectionEscDeclineShowsManualSteps(t *testing.T) {
 		}
 	})
 
-	p.waitForOutputTimeout("ESC to exit", 60*time.Second, "the re-login prompt must be on screen, advertising the decline key")
+	p.waitForOutputTimeout("[ESC] Exit", 60*time.Second, "the re-login prompt must be on screen, advertising the decline key")
 	p.write("\x1b")
 
 	out, err := p.wait()


### PR DESCRIPTION
## Motivation

#449 gave the license re-login prompt a second, advertised option (`ESC to exit`), but left it on the horizontal rendering path. Both labels are flattened into one dimmed hint and appended to a question that already wraps, so the choices read as prose glued to the end of a sentence — and the sentence's own tail (`Log`) dangles at the wrap point. #457 fixed exactly this for the slow-start recovery prompt; this applies the same treatment to the re-login prompt.

## Before / After


Before:

<img width="778" height="222" alt="image" src="https://github.com/user-attachments/assets/864594ba-8c04-47ae-8a9d-b17b40aba186" />


After:

<img width="778" height="268" alt="image" src="https://github.com/user-attachments/assets/cbd067b4-8c60-48d7-937a-806930da0811" />

---

| Aspect | Before | After |
| --- | --- | --- |
| Choices | Flattened into one hint: `[ENTER to log in again/ESC to exit]` | One line each: `● [ENTER] Log in again` / `○ [ESC] Exit` |
| Prompt text | Statement + question, wrapping mid-sentence with `Log` left dangling | Statement only; the actions live in the labels |
| Selection | Key press only | ↑/↓ + Enter, or the advertised key directly |

<details>
<summary>Docs</summary>

Nothing to document. This changes the layout and wording of one interactive prompt; no command, flag, env var, or documented behavior changes. The decline key advertised in #449 still works the same way, and the manual recovery steps a decline prints are unchanged.

</details>

Closes DEVX-1045
