### PR TITLE
Add --json output to lstk status

### DIFF
--- a/cmd/json_envelope.go
+++ b/cmd/json_envelope.go
@@ -40,7 +40,8 @@ func jsonAwareSink(cmd *cobra.Command, cfg *env.Env, w io.Writer) output.Sink {
 }
 
 // writeEnvelope marshals envelope as compact JSON and writes it to w, followed
-// by a newline, as the single line of output a JSON-capable command produces.
+// by a newline. SetEscapeHTML(false): this is CLI output, not HTML, so & < >
+// should render literally.
 func writeEnvelope(w io.Writer, envelope output.Envelope) error {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -19,21 +19,44 @@ import (
 )
 
 func newStatusCmd(cfg *env.Env) *cobra.Command {
-	return &cobra.Command{
-		Use:     "status",
-		Short:   "Show emulator status and deployed resources",
-		Long:    "Show the status of a running emulator and its deployed resources",
-		PreRunE: initConfigDeferCreate(nil),
+	cmd := &cobra.Command{
+		Use:         "status",
+		Short:       "Show emulator status and deployed resources",
+		Long:        "Show the status of a running emulator and its deployed resources",
+		PreRunE:     initConfigDeferCreate(nil),
+		Annotations: map[string]string{jsonSupportedAnnotation: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			target, err := endpoint.Resolve(cmd.Context(), cmd)
-			if err != nil {
-				return err
-			}
+			sink := jsonAwareSink(cmd, cfg, os.Stdout)
 
 			clients := map[config.EmulatorType]emulator.Client{
 				config.EmulatorAWS:       aws.NewClient(),
 				config.EmulatorSnowflake: snowflake.NewClient(),
 				config.EmulatorAzure:     azure.NewClient(),
+			}
+
+			if cfg.JSON {
+				// Check before endpoint.Resolve, which dials the target.
+				if _, _, ok := endpoint.ResolvedSource(cmd); ok {
+					err := fmt.Errorf("status --json does not yet support --endpoint-url")
+					sink.Emit(output.ErrorEvent{Title: err.Error(), Code: output.ErrValidationError})
+					return output.NewSilentError(err)
+				}
+
+				rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
+				if err != nil {
+					return err
+				}
+				appCfg, err := config.Get()
+				if err != nil {
+					return failGetConfig(sink, cfg, err)
+				}
+				includeResources, _ := cmd.Flags().GetBool("resources")
+				return container.StatusJSON(cmd.Context(), rt, appCfg.Containers, cfg.LocalStackHost, clients, sink, includeResources)
+			}
+
+			target, err := endpoint.Resolve(cmd.Context(), cmd)
+			if err != nil {
+				return err
 			}
 
 			if target != nil {
@@ -58,4 +81,6 @@ func newStatusCmd(cfg *env.Env) *cobra.Command {
 			return container.Status(cmd.Context(), rt, appCfg.Containers, cfg.LocalStackHost, clients, output.NewPlainSink(os.Stdout))
 		},
 	}
+	cmd.Flags().Bool("resources", false, "Include deployed resource details (--json only)")
+	return cmd
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -40,7 +40,8 @@ func newStatusCmd(cfg *env.Env) *cobra.Command {
 			}
 
 			if cfg.JSON {
-				includeResources, _ := cmd.Flags().GetBool("resources")
+				noResources, _ := cmd.Flags().GetBool("no-resources")
+				includeResources := !noResources
 				if target != nil {
 					return container.StatusExternalJSON(cmd.Context(), target, clients, sink, includeResources)
 				}
@@ -78,6 +79,6 @@ func newStatusCmd(cfg *env.Env) *cobra.Command {
 			return container.Status(cmd.Context(), rt, appCfg.Containers, cfg.LocalStackHost, clients, output.NewPlainSink(os.Stdout))
 		},
 	}
-	cmd.Flags().Bool("resources", false, "Include deployed resource details (--json only)")
+	cmd.Flags().Bool("no-resources", false, "Exclude deployed resource details (--json only)")
 	return cmd
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -34,12 +34,15 @@ func newStatusCmd(cfg *env.Env) *cobra.Command {
 				config.EmulatorAzure:     azure.NewClient(),
 			}
 
+			target, err := endpoint.Resolve(cmd.Context(), cmd)
+			if err != nil {
+				return err
+			}
+
 			if cfg.JSON {
-				// Check before endpoint.Resolve, which dials the target.
-				if _, _, ok := endpoint.ResolvedSource(cmd); ok {
-					err := fmt.Errorf("status --json does not yet support --endpoint-url")
-					sink.Emit(output.ErrorEvent{Title: err.Error(), Code: output.ErrValidationError})
-					return output.NewSilentError(err)
+				includeResources, _ := cmd.Flags().GetBool("resources")
+				if target != nil {
+					return container.StatusExternalJSON(cmd.Context(), target, clients, sink, includeResources)
 				}
 
 				rt, err := runtime.NewDockerRuntime(cfg.DockerHost)
@@ -50,13 +53,7 @@ func newStatusCmd(cfg *env.Env) *cobra.Command {
 				if err != nil {
 					return failGetConfig(sink, cfg, err)
 				}
-				includeResources, _ := cmd.Flags().GetBool("resources")
 				return container.StatusJSON(cmd.Context(), rt, appCfg.Containers, cfg.LocalStackHost, clients, sink, includeResources)
-			}
-
-			target, err := endpoint.Resolve(cmd.Context(), cmd)
-			if err != nil {
-				return err
 			}
 
 			if target != nil {

--- a/docs/structured-output.md
+++ b/docs/structured-output.md
@@ -8,7 +8,7 @@ The contract described here (a shared envelope shape, a shared error-code vocabu
 
 `--json` support is being rolled out per command, not all at once. The [Command Catalog](#command-catalog) below is split into two parts:
 
-- **[Implemented in this PR](#implemented-in-this-pr)** — `stop`, `reset`, `update`. These accept `--json` today and produce exactly the shapes documented below.
+- **[Implemented](#implemented)** — `stop`, `reset`, `update`, `start`, `status`. These accept `--json` today and produce exactly the shapes documented below.
 - **[Proposed for future work](#proposed-for-future-work-draft)** — every other built-in command. Attempting `--json` on any of these today is rejected with `NOT_JSON_CAPABLE`. This part is a **first-draft proposal only** — see the warning at the top of that section before relying on any of it.
 
 ## The envelope
@@ -291,6 +291,32 @@ Codes: `NETWORK_ERROR` (GitHub API unreachable), `INTERNAL_ERROR` (archive downl
 ```
 Codes: `RUNTIME_UNAVAILABLE`, `AUTH_REQUIRED`, `LICENSE_INVALID` (bad/expired/rejected token), `LICENSE_NOT_COVERED` (valid token, plan doesn't include the requested emulator), `IMAGE_PULL_FAILED`, `EMULATOR_START_FAILED` (crash or timeout waiting for health), `EMULATOR_WRONG_TYPE` (a different emulator type is already running on the configured port), `PORT_CONFLICT`, `CONFIG_INVALID` (more than one `[[containers]]` block enabled).
 
+**`lstk status`** — one entry per configured emulator. Stops at the first not-running emulator and returns `EMULATOR_NOT_RUNNING`, same as plain text and same as `stop`/`reset`. Deployed resources (AWS only) are included by default, matching plain text; `--no-resources` drops `resourceSummary`/`resources` for a faster response, useful for a caller that polls this command repeatedly (e.g. `lstk start`'s readiness check).
+```json
+{
+  "schemaVersion": 1,
+  "command": "status",
+  "status": "ok",
+  "data": {
+    "emulators": [
+      {
+        "type": "aws", "running": true, "health": "healthy", "name": "localstack-aws",
+        "version": "3.9.0", "host": "localhost:4566", "uptimeSeconds": 1234, "persistence": false,
+        "resourceSummary": {"resources": 12, "services": 4},
+        "resources": [{"service": "s3", "name": "my-bucket", "region": "us-east-1", "account": "000000000000"}]
+      }
+    ]
+  },
+  "warnings": [],
+  "error": null
+}
+```
+`--json --endpoint-url` targets an emulator lstk didn't start, same as plain-text `status`. `endpoint.Resolve` already confirms the target is reachable before returning it, so a resolved external entry always has `"running": true` — `name`, `uptimeSeconds`, and `persistence` are omitted instead, since those are Docker facts that don't exist for it:
+```json
+{ "type": "aws", "running": true, "health": "healthy", "version": "3.9.0", "host": "https://my-remote-endpoint" }
+```
+Codes: `RUNTIME_UNAVAILABLE`, `EMULATOR_NOT_RUNNING`, `CONFIG_INVALID`, `CONFIG_NOT_FOUND` (bad or missing `--config` path).
+
 ### Proposed for future work (draft)
 
 > **This section is a first-draft proposal only, not a committed contract.** None of the commands below accept `--json` yet — every one of them is rejected with `NOT_JSON_CAPABLE` today. The shapes shown are a starting point for design discussion, included here in full so the whole intended surface can be reviewed at once rather than piecemeal across many small follow-up PRs. Expect fields, error codes, and possibly the overall approach for any of these to change based on human feedback before implementation — treat everything below as a proposal to critique, not a spec to build against.
@@ -314,29 +340,6 @@ Codes: `RUNTIME_UNAVAILABLE`, `AUTH_REQUIRED`, `LICENSE_INVALID` (bad/expired/re
 }
 ```
 Codes: `RUNTIME_UNAVAILABLE`, `AUTH_REQUIRED`, `LICENSE_INVALID`, `EMULATOR_START_FAILED`.
-
-**`lstk status`** — one entry per *configured* emulator, not just running ones: unlike today's plain-text behavior (which stops at the first non-running emulator), JSON mode reports every configured emulator's running/not-running state. Non-running entries omit the detail fields entirely rather than nulling them out.
-```json
-{
-  "schemaVersion": 1,
-  "command": "status",
-  "status": "ok",
-  "data": {
-    "emulators": [
-      {
-        "type": "aws", "running": true, "name": "localstack-aws", "version": "3.9.0",
-        "host": "localhost:4566", "uptimeSeconds": 1234, "persistence": false,
-        "resourceSummary": {"resources": 12, "services": 4},
-        "resources": [{"service": "s3", "name": "my-bucket", "region": "us-east-1", "account": "000000000000"}]
-      },
-      {"type": "snowflake", "running": false}
-    ]
-  },
-  "warnings": [],
-  "error": null
-}
-```
-Codes: `RUNTIME_UNAVAILABLE`.
 
 **`lstk logs`** (bounded) — `data.lines` is the same `{source, level, line}` shape used by the NDJSON stream variant (see "Streaming output" above).
 ```json

--- a/internal/container/status.go
+++ b/internal/container/status.go
@@ -175,6 +175,7 @@ func StatusJSON(ctx context.Context, rt runtime.Runtime, containers []config.Con
 		event := output.EmulatorStatusEvent{
 			Type:          string(c.Type),
 			Running:       true,
+			Local:         true,
 			Name:          name,
 			Host:          host,
 			UptimeSeconds: int64(uptime.Seconds()),
@@ -205,6 +206,40 @@ func StatusJSON(ctx context.Context, rt runtime.Runtime, containers []config.Con
 		sink.Emit(event)
 	}
 
+	return nil
+}
+
+// StatusExternalJSON is StatusJSON for an --endpoint-url target. Running is
+// always true: endpoint.Resolve already confirmed the target is reachable
+// before returning it.
+func StatusExternalJSON(ctx context.Context, target *endpoint.Target, clients map[config.EmulatorType]emulator.Client, sink output.Sink, includeResources bool) error {
+	event := output.EmulatorStatusEvent{
+		Type:    string(target.Type),
+		Running: true,
+		Host:    target.URL,
+	}
+
+	if client, ok := clients[target.Type]; ok {
+		if v, err := client.FetchVersion(ctx, target.URL); err != nil {
+			event.Health = "unhealthy"
+		} else {
+			event.Health = "healthy"
+			event.Version = v
+		}
+
+		if includeResources && target.Type == config.EmulatorAWS {
+			rows, err := client.FetchResources(ctx, target.URL)
+			if err != nil {
+				return err
+			}
+			event.Resources = make([]output.EmulatorStatusResource, len(rows))
+			for i, r := range rows {
+				event.Resources[i] = output.EmulatorStatusResource{Service: r.Service, Name: r.Name, Region: r.Region, Account: r.Account}
+			}
+		}
+	}
+
+	sink.Emit(event)
 	return nil
 }
 

--- a/internal/container/status.go
+++ b/internal/container/status.go
@@ -131,10 +131,11 @@ func StatusExternal(ctx context.Context, target *endpoint.Target, clients map[co
 	return nil
 }
 
-// StatusJSON reports every configured emulator's running/health state, one
-// EmulatorStatusEvent per container — unlike Status above, it doesn't stop
-// at the first non-running one. Resources are only fetched when
-// includeResources is set, since this path is also polled for readiness.
+// StatusJSON reports each configured emulator's health, one
+// EmulatorStatusEvent per container. Stops at the first not-running
+// emulator, same as Status above, returning EMULATOR_NOT_RUNNING. Resources
+// are only fetched when includeResources is set, since this path is also
+// polled for readiness.
 func StatusJSON(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, localStackHost string, clients map[config.EmulatorType]emulator.Client, sink output.Sink, includeResources bool) error {
 	if err := rt.IsHealthy(ctx); err != nil {
 		rt.EmitUnhealthyError(sink, err)
@@ -150,8 +151,11 @@ func StatusJSON(ctx context.Context, rt runtime.Runtime, containers []config.Con
 			return fmt.Errorf("checking %s running: %w", c.Name(), err)
 		}
 		if name == "" {
-			sink.Emit(output.EmulatorStatusEvent{Type: string(c.Type), Running: false})
-			continue
+			sink.Emit(output.ErrorEvent{
+				Title: fmt.Sprintf("%s is not running", c.DisplayName()),
+				Code:  output.ErrEmulatorNotRunning,
+			})
+			return output.NewSilentError(fmt.Errorf("%s is not running", c.Name()))
 		}
 
 		port := c.Port

--- a/internal/container/status.go
+++ b/internal/container/status.go
@@ -131,6 +131,83 @@ func StatusExternal(ctx context.Context, target *endpoint.Target, clients map[co
 	return nil
 }
 
+// StatusJSON reports every configured emulator's running/health state, one
+// EmulatorStatusEvent per container — unlike Status above, it doesn't stop
+// at the first non-running one. Resources are only fetched when
+// includeResources is set, since this path is also polled for readiness.
+func StatusJSON(ctx context.Context, rt runtime.Runtime, containers []config.ContainerConfig, localStackHost string, clients map[config.EmulatorType]emulator.Client, sink output.Sink, includeResources bool) error {
+	if err := rt.IsHealthy(ctx); err != nil {
+		rt.EmitUnhealthyError(sink, err)
+		return output.NewSilentError(fmt.Errorf("runtime not healthy: %w", err))
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, statusTimeout)
+	defer cancel()
+
+	for _, c := range containers {
+		name, err := ResolveRunningContainerName(ctx, rt, c)
+		if err != nil {
+			return fmt.Errorf("checking %s running: %w", c.Name(), err)
+		}
+		if name == "" {
+			sink.Emit(output.EmulatorStatusEvent{Type: string(c.Type), Running: false})
+			continue
+		}
+
+		port := c.Port
+		if containerPort, err := c.ContainerPort(); err == nil {
+			if actualPort, err := rt.GetBoundPort(ctx, name, containerPort); err == nil {
+				port = actualPort
+			}
+		}
+		host, _ := endpoint.ResolveHost(ctx, port, localStackHost)
+		if c.Type == config.EmulatorSnowflake {
+			if h := snowflake.Hostname(host); h != "" {
+				host = h
+			}
+		}
+
+		var uptime time.Duration
+		if startedAt, err := rt.ContainerStartedAt(ctx, name); err == nil {
+			uptime = time.Since(startedAt)
+		}
+
+		event := output.EmulatorStatusEvent{
+			Type:          string(c.Type),
+			Running:       true,
+			Name:          name,
+			Host:          host,
+			UptimeSeconds: int64(uptime.Seconds()),
+			Persistence:   c.Type == config.EmulatorAWS && isPersistenceEnabled(ctx, rt, name),
+		}
+
+		if client, ok := clients[c.Type]; ok {
+			baseURL := "http://" + host
+			if v, err := client.FetchVersion(ctx, baseURL); err != nil {
+				event.Health = "unhealthy"
+			} else {
+				event.Health = "healthy"
+				event.Version = v
+			}
+
+			if includeResources && c.Type == config.EmulatorAWS {
+				rows, err := client.FetchResources(ctx, baseURL)
+				if err != nil {
+					return err
+				}
+				event.Resources = make([]output.EmulatorStatusResource, len(rows))
+				for i, r := range rows {
+					event.Resources[i] = output.EmulatorStatusResource{Service: r.Service, Name: r.Name, Region: r.Region, Account: r.Account}
+				}
+			}
+		}
+
+		sink.Emit(event)
+	}
+
+	return nil
+}
+
 func emitResources(sink output.Sink, rows []emulator.Resource) {
 	if len(rows) == 0 {
 		sink.Emit(output.MessageEvent{Severity: output.SeverityNote, Text: "No resources deployed"})

--- a/internal/output/envelope_data.go
+++ b/internal/output/envelope_data.go
@@ -26,3 +26,34 @@ type JsonStoppedEmulator struct {
 }
 
 func (JsonStoppedEmulator) sealedEmulatorEntry() {}
+
+// JsonStatusEmulator is the per-emulator entry in `status`'s data.emulators.
+// Detail fields are omitted for a non-running emulator, not nulled.
+type JsonStatusEmulator struct {
+	Type            string               `json:"type"`
+	Running         bool                 `json:"running"`
+	Health          *string              `json:"health"`
+	Name            string               `json:"name,omitempty"`
+	Version         string               `json:"version,omitempty"`
+	Host            string               `json:"host,omitempty"`
+	UptimeSeconds   *int64               `json:"uptimeSeconds,omitempty"`
+	Persistence     *bool                `json:"persistence,omitempty"`
+	ResourceSummary *JsonResourceSummary `json:"resourceSummary,omitempty"`
+	Resources       []JsonStatusResource `json:"resources,omitempty"`
+}
+
+func (JsonStatusEmulator) sealedEmulatorEntry() {}
+
+// JsonResourceSummary is the resource/service counts for `status --resources`.
+type JsonResourceSummary struct {
+	Resources int `json:"resources"`
+	Services  int `json:"services"`
+}
+
+// JsonStatusResource is one deployed resource for `status --resources`.
+type JsonStatusResource struct {
+	Service string `json:"service"`
+	Name    string `json:"name"`
+	Region  string `json:"region"`
+	Account string `json:"account"`
+}

--- a/internal/output/envelope_sink.go
+++ b/internal/output/envelope_sink.go
@@ -50,6 +50,8 @@ func (s *EnvelopeSink) Emit(event Event) {
 		s.data["version"] = e.Version
 		s.data["alreadyRunning"] = e.AlreadyRunning
 		s.data["persistence"] = e.Persistence
+	case EmulatorStatusEvent:
+		s.appendEmulator(newJSONStatusEmulator(e))
 	case UpdateCheckedEvent:
 		s.data["currentVersion"] = e.CurrentVersion
 		s.data["latestVersion"] = e.LatestVersion
@@ -67,6 +69,38 @@ func (s *EnvelopeSink) Emit(event Event) {
 		s.data["method"] = e.Method
 	}
 	// Every other event type is purely presentational and intentionally dropped.
+}
+
+// newJSONStatusEmulator builds a JsonStatusEmulator from an EmulatorStatusEvent.
+func newJSONStatusEmulator(e EmulatorStatusEvent) JsonStatusEmulator {
+	entry := JsonStatusEmulator{Type: e.Type, Running: e.Running}
+	if e.Health != "" {
+		health := e.Health
+		entry.Health = &health
+	}
+	if !e.Running {
+		return entry
+	}
+
+	entry.Name = e.Name
+	entry.Version = e.Version
+	entry.Host = e.Host
+	uptime := e.UptimeSeconds
+	entry.UptimeSeconds = &uptime
+	persistence := e.Persistence
+	entry.Persistence = &persistence
+
+	if e.Resources != nil {
+		resources := make([]JsonStatusResource, len(e.Resources))
+		services := map[string]struct{}{}
+		for i, r := range e.Resources {
+			resources[i] = JsonStatusResource(r)
+			services[r.Service] = struct{}{}
+		}
+		entry.Resources = resources
+		entry.ResourceSummary = &JsonResourceSummary{Resources: len(resources), Services: len(services)}
+	}
+	return entry
 }
 
 func (s *EnvelopeSink) appendEmulator(entry JsonEmulatorEntry) {

--- a/internal/output/envelope_sink.go
+++ b/internal/output/envelope_sink.go
@@ -82,13 +82,15 @@ func newJSONStatusEmulator(e EmulatorStatusEvent) JsonStatusEmulator {
 		return entry
 	}
 
-	entry.Name = e.Name
 	entry.Version = e.Version
 	entry.Host = e.Host
-	uptime := e.UptimeSeconds
-	entry.UptimeSeconds = &uptime
-	persistence := e.Persistence
-	entry.Persistence = &persistence
+	if e.Local {
+		entry.Name = e.Name
+		uptime := e.UptimeSeconds
+		entry.UptimeSeconds = &uptime
+		persistence := e.Persistence
+		entry.Persistence = &persistence
+	}
 
 	if e.Resources != nil {
 		resources := make([]JsonStatusResource, len(e.Resources))

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -189,8 +189,7 @@ type EmulatorStatusResource struct {
 	Account string
 }
 
-// EmulatorStatusEvent reports one configured emulator's running/health
-// state, fired once per emulator including non-running ones.
+// EmulatorStatusEvent reports one running emulator's health state.
 type EmulatorStatusEvent struct {
 	Type          string
 	Running       bool

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -200,7 +200,10 @@ type EmulatorStatusEvent struct {
 	Host          string
 	UptimeSeconds int64
 	Persistence   bool
-	Resources     []EmulatorStatusResource
+	// Local is true for a Docker-managed emulator, false for an external
+	// --endpoint-url target. Name/UptimeSeconds/Persistence only apply to Local.
+	Local     bool
+	Resources []EmulatorStatusResource
 }
 
 // UpdateCheckedEvent reports the result of an update check. It always fires

--- a/internal/output/events.go
+++ b/internal/output/events.go
@@ -180,6 +180,29 @@ type EmulatorStartedEvent struct {
 	Persistence    bool
 }
 
+// EmulatorStatusResource mirrors emulator.Resource, kept local to avoid
+// internal/output importing internal/emulator.
+type EmulatorStatusResource struct {
+	Service string
+	Name    string
+	Region  string
+	Account string
+}
+
+// EmulatorStatusEvent reports one configured emulator's running/health
+// state, fired once per emulator including non-running ones.
+type EmulatorStatusEvent struct {
+	Type          string
+	Running       bool
+	Health        string
+	Name          string
+	Version       string
+	Host          string
+	UptimeSeconds int64
+	Persistence   bool
+	Resources     []EmulatorStatusResource
+}
+
 // UpdateCheckedEvent reports the result of an update check. It always fires
 // once per Check call — DevBuild, then Available, discriminate which of the
 // three possible outcomes (dev build skipped the check / already up to date /
@@ -238,6 +261,7 @@ func (SnapshotShownEvent) sealedEvent()       {}
 func (EmulatorStoppedEvent) sealedEvent()     {}
 func (EmulatorResetEvent) sealedEvent()       {}
 func (EmulatorStartedEvent) sealedEvent()     {}
+func (EmulatorStatusEvent) sealedEvent()      {}
 func (UpdateCheckedEvent) sealedEvent()       {}
 func (UpdateAppliedEvent) sealedEvent()       {}
 func (ContainerStatusEvent) sealedEvent()     {}

--- a/internal/output/plain_format.go
+++ b/internal/output/plain_format.go
@@ -70,6 +70,8 @@ func FormatEventLine(event Event) (string, bool) {
 		return formatEmulatorStopped(e), true
 	case EmulatorResetEvent:
 		return formatEmulatorReset(e), true
+	case EmulatorStatusEvent:
+		return formatEmulatorStatus(e), true
 	case UpdateCheckedEvent:
 		return formatUpdateChecked(e), true
 	case UpdateAppliedEvent:
@@ -204,6 +206,17 @@ func formatEmulatorStopped(e EmulatorStoppedEvent) string {
 
 func formatEmulatorReset(e EmulatorResetEvent) string {
 	return SuccessMarker() + " Emulator state reset"
+}
+
+func formatEmulatorStatus(e EmulatorStatusEvent) string {
+	if !e.Running {
+		return e.Type + ": not running"
+	}
+	line := e.Type + ": running"
+	if e.Health != "" {
+		line += " (" + e.Health + ")"
+	}
+	return line
 }
 
 func formatUpdateChecked(e UpdateCheckedEvent) string {

--- a/internal/output/plain_format_test.go
+++ b/internal/output/plain_format_test.go
@@ -194,6 +194,18 @@ func TestFormatEventLine(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name:   "emulator status event running healthy",
+			event:  EmulatorStatusEvent{Type: "aws", Running: true, Health: "healthy"},
+			want:   "aws: running (healthy)",
+			wantOK: true,
+		},
+		{
+			name:   "emulator status event not running",
+			event:  EmulatorStatusEvent{Type: "aws", Running: false},
+			want:   "aws: not running",
+			wantOK: true,
+		},
+		{
 			name:   "update checked event dev build",
 			event:  UpdateCheckedEvent{CurrentVersion: "dev", DevBuild: true},
 			want:   "> Note: Running a development build, skipping update check",

--- a/test/integration/__snapshots__/json_flag_test.snap
+++ b/test/integration/__snapshots__/json_flag_test.snap
@@ -215,12 +215,12 @@ Error: terraform not found in PATH
 
 [TestJSONFlagRejectsUnannotatedBuiltinCommand_1]
 {
-  "command": "status",
+  "command": "login",
   "data": null,
   "error": {
     "category": "USAGE",
     "code": "NOT_JSON_CAPABLE",
-    "message": "\"status\" is not able to provide output in JSON format",
+    "message": "\"login\" is not able to provide output in JSON format",
     "retryable": false
   },
   "schemaVersion": 1,

--- a/test/integration/json_flag_test.go
+++ b/test/integration/json_flag_test.go
@@ -18,7 +18,8 @@ import (
 
 func TestJSONFlagRejectsUnannotatedBuiltinCommand(t *testing.T) {
 	t.Parallel()
-	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "status", "--json")
+	// login never touches Docker, unlike status.
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), testEnvWithHome(t.TempDir(), ""), "login", "--json")
 	requireExitCode(t, 1, err)
 	decodeEnvelope(t, stdout)
 	snap.MatchJSON(t, []byte(stdout))

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -296,23 +296,13 @@ func TestStatusCommandJSONNotRunning(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	stdout, _, err := runLstk(t, testContext(t), "", testEnvWithHome(t.TempDir(), ""), "status", "--json")
-	require.NoError(t, err, "lstk status --json should succeed when not running")
-	requireExitCode(t, 0, err)
+	requireExitCode(t, 1, err)
 
 	envelope := decodeEnvelope(t, stdout)
-	assert.Equal(t, "ok", envelope.Status)
-	assert.Nil(t, envelope.Error)
-
-	var data struct {
-		Emulators []map[string]json.RawMessage `json:"emulators"`
-	}
-	require.NoError(t, json.Unmarshal(envelope.Data, &data))
-	require.Len(t, data.Emulators, 1)
-	e := data.Emulators[0]
-	assert.JSONEq(t, `"aws"`, string(e["type"]))
-	assert.JSONEq(t, `false`, string(e["running"]))
-	assert.JSONEq(t, `null`, string(e["health"]))
-	assert.NotContains(t, e, "name", "a non-running emulator should omit detail fields entirely")
+	assert.Equal(t, "error", envelope.Status)
+	require.NotNil(t, envelope.Error)
+	assert.Equal(t, "EMULATOR_NOT_RUNNING", envelope.Error.Code)
+	assert.Equal(t, "EMULATOR", envelope.Error.Category)
 }
 
 func TestStatusCommandJSONResourcesFlag(t *testing.T) {

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -287,7 +287,8 @@ func TestStatusCommandJSONRunning(t *testing.T) {
 	assert.Equal(t, containerName, e.Name)
 	assert.Equal(t, "4.14.1", e.Version)
 	assert.NotEmpty(t, e.Host)
-	assert.Nil(t, e.ResourceSummary, "resources should be excluded by default")
+	require.NotNil(t, e.ResourceSummary, "resources should be included by default")
+	assert.Equal(t, 0, e.ResourceSummary.Resources)
 }
 
 func TestStatusCommandJSONNotRunning(t *testing.T) {
@@ -305,7 +306,7 @@ func TestStatusCommandJSONNotRunning(t *testing.T) {
 	assert.Equal(t, "EMULATOR", envelope.Error.Category)
 }
 
-func TestStatusCommandJSONResourcesFlag(t *testing.T) {
+func TestStatusCommandJSONNoResourcesFlag(t *testing.T) {
 	requireDocker(t)
 	cleanup()
 	t.Cleanup(cleanup)
@@ -326,8 +327,8 @@ func TestStatusCommandJSONResourcesFlag(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, lsHost(server)), "status", "--json", "--resources")
-	require.NoError(t, err, "lstk status --json --resources failed: %s", stderr)
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, lsHost(server)), "status", "--json", "--no-resources")
+	require.NoError(t, err, "lstk status --json --no-resources failed: %s", stderr)
 	requireExitCode(t, 0, err)
 
 	envelope := decodeEnvelope(t, stdout)
@@ -335,15 +336,13 @@ func TestStatusCommandJSONResourcesFlag(t *testing.T) {
 		Emulators []struct {
 			ResourceSummary *struct {
 				Resources int `json:"resources"`
-				Services  int `json:"services"`
 			} `json:"resourceSummary"`
 			Resources []json.RawMessage `json:"resources"`
 		} `json:"emulators"`
 	}
 	require.NoError(t, json.Unmarshal(envelope.Data, &data))
 	require.Len(t, data.Emulators, 1)
-	require.NotNil(t, data.Emulators[0].ResourceSummary, "--resources should include a resourceSummary")
-	assert.Equal(t, 0, data.Emulators[0].ResourceSummary.Resources)
+	assert.Nil(t, data.Emulators[0].ResourceSummary, "--no-resources should exclude the resource summary")
 	assert.Empty(t, data.Emulators[0].Resources)
 }
 
@@ -396,8 +395,8 @@ func TestStatusCommandJSONExternalEndpointResources(t *testing.T) {
 	e := env.With(env.DisableEvents, "1").WithHome(t.TempDir())
 	e = append(e, unreachableDockerHost)
 
-	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "--endpoint-url", srv.URL, "status", "--json", "--resources")
-	require.NoError(t, err, "lstk status --json --resources --endpoint-url failed: %s", stderr)
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "--endpoint-url", srv.URL, "status", "--json")
+	require.NoError(t, err, "lstk status --json --endpoint-url failed: %s", stderr)
 	requireExitCode(t, 0, err)
 
 	envelope := decodeEnvelope(t, stdout)

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -357,6 +357,78 @@ func TestStatusCommandJSONResourcesFlag(t *testing.T) {
 	assert.Empty(t, data.Emulators[0].Resources)
 }
 
+func TestStatusCommandJSONExternalEndpoint(t *testing.T) {
+	t.Parallel()
+	srv := awsHealthServer(t)
+	defer srv.Close()
+
+	e := env.With(env.DisableEvents, "1").WithHome(t.TempDir())
+	e = append(e, unreachableDockerHost)
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "--endpoint-url", srv.URL, "status", "--json")
+	require.NoError(t, err, "lstk status --json --endpoint-url failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	envelope := decodeEnvelope(t, stdout)
+	assert.Equal(t, "ok", envelope.Status)
+
+	var data struct {
+		Emulators []map[string]json.RawMessage `json:"emulators"`
+	}
+	require.NoError(t, json.Unmarshal(envelope.Data, &data))
+	require.Len(t, data.Emulators, 1)
+	emu := data.Emulators[0]
+	assert.JSONEq(t, `"aws"`, string(emu["type"]))
+	assert.JSONEq(t, `true`, string(emu["running"]))
+	assert.JSONEq(t, `"healthy"`, string(emu["health"]))
+	assert.JSONEq(t, `"3.0.2"`, string(emu["version"]))
+	assert.NotContains(t, emu, "name", "an external target has no container name")
+	assert.NotContains(t, emu, "uptimeSeconds", "an external target has no known uptime")
+	assert.NotContains(t, emu, "persistence", "an external target has no known persistence setting")
+}
+
+func TestStatusCommandJSONExternalEndpointResources(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_localstack/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"version": "3.0.2", "services": {"s3": "available"}}`)
+		case "/_localstack/resources":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = fmt.Fprintln(w, `{"AWS::S3::Bucket": [{"region_name": "us-east-1", "account_id": "000000000000", "id": "my-test-bucket"}]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	e := env.With(env.DisableEvents, "1").WithHome(t.TempDir())
+	e = append(e, unreachableDockerHost)
+
+	stdout, stderr, err := runLstk(t, testContext(t), t.TempDir(), e, "--endpoint-url", srv.URL, "status", "--json", "--resources")
+	require.NoError(t, err, "lstk status --json --resources --endpoint-url failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	envelope := decodeEnvelope(t, stdout)
+	var data struct {
+		Emulators []struct {
+			ResourceSummary *struct {
+				Resources int `json:"resources"`
+			} `json:"resourceSummary"`
+			Resources []struct {
+				Name string `json:"name"`
+			} `json:"resources"`
+		} `json:"emulators"`
+	}
+	require.NoError(t, json.Unmarshal(envelope.Data, &data))
+	require.Len(t, data.Emulators, 1)
+	require.NotNil(t, data.Emulators[0].ResourceSummary)
+	assert.Equal(t, 1, data.Emulators[0].ResourceSummary.Resources)
+	require.Len(t, data.Emulators[0].Resources, 1)
+	assert.Equal(t, "my-test-bucket", data.Emulators[0].Resources[0].Name)
+}
+
 func fetchSnowflakeVersion(t *testing.T, hostPort string) string {
 	t.Helper()
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/_localstack/health", hostPort))

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -235,6 +235,128 @@ func TestStatusCommandShowsNoResourcesWhenEmpty(t *testing.T) {
 	assert.Contains(t, stdout, "No resources deployed")
 }
 
+func TestStatusCommandJSONRunning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_localstack/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"version": "4.14.1", "services": {}}`)
+		case "/_localstack/resources":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, lsHost(server)), "status", "--json")
+	require.NoError(t, err, "lstk status --json failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	envelope := decodeEnvelope(t, stdout)
+	assert.Equal(t, "ok", envelope.Status)
+	assert.Equal(t, "status", envelope.Command)
+	assert.Nil(t, envelope.Error)
+
+	var data struct {
+		Emulators []struct {
+			Type            string `json:"type"`
+			Running         bool   `json:"running"`
+			Health          string `json:"health"`
+			Name            string `json:"name"`
+			Version         string `json:"version"`
+			Host            string `json:"host"`
+			ResourceSummary *struct {
+				Resources int `json:"resources"`
+			} `json:"resourceSummary"`
+		} `json:"emulators"`
+	}
+	require.NoError(t, json.Unmarshal(envelope.Data, &data))
+	require.Len(t, data.Emulators, 1)
+	e := data.Emulators[0]
+	assert.Equal(t, "aws", e.Type)
+	assert.True(t, e.Running)
+	assert.Equal(t, "healthy", e.Health)
+	assert.Equal(t, containerName, e.Name)
+	assert.Equal(t, "4.14.1", e.Version)
+	assert.NotEmpty(t, e.Host)
+	assert.Nil(t, e.ResourceSummary, "resources should be excluded by default")
+}
+
+func TestStatusCommandJSONNotRunning(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	stdout, _, err := runLstk(t, testContext(t), "", testEnvWithHome(t.TempDir(), ""), "status", "--json")
+	require.NoError(t, err, "lstk status --json should succeed when not running")
+	requireExitCode(t, 0, err)
+
+	envelope := decodeEnvelope(t, stdout)
+	assert.Equal(t, "ok", envelope.Status)
+	assert.Nil(t, envelope.Error)
+
+	var data struct {
+		Emulators []map[string]json.RawMessage `json:"emulators"`
+	}
+	require.NoError(t, json.Unmarshal(envelope.Data, &data))
+	require.Len(t, data.Emulators, 1)
+	e := data.Emulators[0]
+	assert.JSONEq(t, `"aws"`, string(e["type"]))
+	assert.JSONEq(t, `false`, string(e["running"]))
+	assert.JSONEq(t, `null`, string(e["health"]))
+	assert.NotContains(t, e, "name", "a non-running emulator should omit detail fields entirely")
+}
+
+func TestStatusCommandJSONResourcesFlag(t *testing.T) {
+	requireDocker(t)
+	cleanup()
+	t.Cleanup(cleanup)
+
+	ctx := testContext(t)
+	startTestContainer(t, ctx)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_localstack/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"version": "4.14.1", "services": {}}`)
+		case "/_localstack/resources":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	stdout, stderr, err := runLstk(t, ctx, "", env.With(env.LocalStackHost, lsHost(server)), "status", "--json", "--resources")
+	require.NoError(t, err, "lstk status --json --resources failed: %s", stderr)
+	requireExitCode(t, 0, err)
+
+	envelope := decodeEnvelope(t, stdout)
+	var data struct {
+		Emulators []struct {
+			ResourceSummary *struct {
+				Resources int `json:"resources"`
+				Services  int `json:"services"`
+			} `json:"resourceSummary"`
+			Resources []json.RawMessage `json:"resources"`
+		} `json:"emulators"`
+	}
+	require.NoError(t, json.Unmarshal(envelope.Data, &data))
+	require.Len(t, data.Emulators, 1)
+	require.NotNil(t, data.Emulators[0].ResourceSummary, "--resources should include a resourceSummary")
+	assert.Equal(t, 0, data.Emulators[0].ResourceSummary.Resources)
+	assert.Empty(t, data.Emulators[0].Resources)
+}
+
 func fetchSnowflakeVersion(t *testing.T, hostPort string) string {
 	t.Helper()
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/_localstack/health", hostPort))


### PR DESCRIPTION
Add `--json` output to `lstk status`.
`--json` with `--endpoint-url` is also supported.

What it returns:

- Per configured emulator: type, running, health, and (when running) name, version, host, uptime, persistence.
- If the emulator is not running, returns an error (`EMULATOR_NOT_RUNNING`), same as `stop`/`reset`. Not a plain-text error, a proper envelope.

Decisions:
- `no-resource` flag added to avoid from listing resources. listing resources by default can be slow, so this is a way to opt out.
- JSON mode stops at the first not-running configured emulator, same as plain-text status (and same as stop/reset). It does not list every configured emulator.
- An external target (--endpoint-url) always has `running: true`, since resolving the target already confirms it is reachable before status runs. `name`, `uptimeSeconds`, and `persistence` are left out for it, those are Docker facts that do not exist for an emulator lstk did not start.

| scenario | output |
|----|-----|
| not running |  <img width="1144" height="54" alt="imagen" src="https://github.com/user-attachments/assets/455866bb-f6b0-4833-a28b-cf9d6de04852" /> |
| running and healthy | <img width="968" height="64" alt="imagen" src="https://github.com/user-attachments/assets/044ea763-3066-412e-8ffa-e5d4525ce9cc" /> |
| no resources flag | <img width="972" height="62" alt="imagen" src="https://github.com/user-attachments/assets/46f2becd-f143-4566-b477-8fc4de0932e5" /> | 
| endpoint URL | <img width="1135" height="60" alt="imagen" src="https://github.com/user-attachments/assets/e2cd7d8c-93a1-457a-a36a-130a9c5036d5" /> |
| not reached | <img width="1137" height="66" alt="imagen" src="https://github.com/user-attachments/assets/cdd4a3bc-0058-4cac-a8fa-4656cfd36769" /> |
| config not found | <img width="1138" height="49" alt="imagen" src="https://github.com/user-attachments/assets/8f103131-8c30-4cc7-aa22-5b8b9294f0da" /> | 
| docker daemon stopped | <img width="1137" height="77" alt="imagen" src="https://github.com/user-attachments/assets/8918b346-7be9-4074-91c1-b99698f7414e" /> |


<details>
<summary> <h2>JSON response structure</h2></summary>

```json
{
  "schemaVersion": 1,
  "command": "status",
  "status": "ok" or "error",
  "data": { ... },
  "warnings": [ ... ],
  "error": { ... }
}
```

| Field | Meaning |
|---|---|
| `schemaVersion` | A version number for this response format. Only changes if the structure itself changes later. |
| `command` | Which command this came from. Always `"status"` here. |
| `status` | `"ok"` or `"error"`, the first thing to check |
| `data` | Filled in when it works |
| `warnings` | Heads up notices, not failures |
| `error` | Filled in when it fails |

**When it works, `data` contains a list of emulators, one entry per configured type that was reached:**

| Field | Meaning |
|---|---|
| `type` | Which emulator this is: `aws`, `snowflake`, or `azure` |
| `running` | Always `true` for an entry that made it into the response. A not-running emulator is an error instead, see below |
| `health` | `"healthy"` or `"unhealthy"` |
| `name` | The container name. Only present for an lstk-managed emulator |
| `version` | The version that's running |
| `host` | The address to connect to it |
| `uptimeSeconds` | How long it has been up. Only present for an lstk-managed emulator |
| `persistence` | `true` if it keeps data between restarts. Only present for an lstk-managed emulator |
| `resourceSummary` | Counts of what's deployed inside. Only present with `--resources` |
| `resources` | The full list of what's deployed inside. Only present with `--resources` |

**When it fails, `error` contains:**

| Field | Meaning |
|---|---|
| `code` | A short, fixed label for the reason (e.g. `EMULATOR_NOT_RUNNING`) |
| `category` | A general group for that reason (see below) |
| `message` | A plain language explanation |
| `retryable` | `true` if trying again later might just work |

**Categories (`category`) seen here:**
- `RUNTIME`: Docker isn't available. Retryable
- `EMULATOR`: the emulator isn't running. Not retryable
- `CONFIG`: a bad lstk setting. Not retryable

</details>

Resolves DEVX-1053