### PR TITLE
Fix TestUpdateNPMInstall timing out on a cold npm cache

### DIFF
--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -94,7 +94,25 @@ func TestUpdateNPMInstall(t *testing.T) {
 		t.Skipf("lstk already installed at %s, would conflict with npm install -g", path)
 	}
 
-	ctx := testContext(t)
+	// Not testContext: nearly all of this test's time goes into the registry
+	// install below, and that cost is set by the registry, not by anything here.
+	// Green runs on windows-latest land at 19-81s, but on a slow day the install
+	// alone has stretched past two minutes (one run's npm reported ~3m), so the
+	// shared 2-minute budget turned a slow registry into a red build on both
+	// Linux and Windows with no code change. Five minutes clears the observed
+	// worst case several times over; what follows the install is cheap by
+	// comparison (a `go build`, then `lstk update`'s own `npm install -g`, which
+	// reuses the cache the first install just filled: ~1s each measured warm).
+	//
+	// The platforms report this timeout very differently, which is worth
+	// knowing when reading a failure. Linux is honest: "signal: killed", with
+	// the test duration pinned at exactly the deadline. Windows is not: npm
+	// there is a .cmd wrapper around node, so killing it leaves the node
+	// grandchild to finish and write its success summary into the still-open
+	// pipe, and the failure reads "exit status 1" beside output claiming the
+	// install succeeded.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
 
 	// Set up a fake local npm project so we get a binary inside node_modules.
 	// On Windows, t.TempDir() may return a short 8.3 path (e.g. RUNNER~1)
@@ -107,11 +125,20 @@ func TestUpdateNPMInstall(t *testing.T) {
 		0o644,
 	))
 
-	// Install @localstack/lstk locally so the node_modules structure exists
-	npmInstall := exec.CommandContext(ctx, "npm", "install", "@localstack/lstk")
+	// Install @localstack/lstk locally so the node_modules structure exists.
+	// --no-audit/--no-fund skip an audit round trip this test has no use for;
+	// small next to the cold-download time, but free. WaitDelay matters because
+	// npm is a wrapper (npm.cmd on Windows) around node: killing it on a
+	// deadline leaves the node grandchild holding the output pipe, and
+	// CombinedOutput would block for that grandchild's full lifetime (the
+	// DEVX-846 lesson).
+	npmInstall := exec.CommandContext(ctx, "npm", "install", "--no-audit", "--no-fund", "@localstack/lstk")
 	npmInstall.Dir = projectDir
+	npmInstall.WaitDelay = 10 * time.Second
 	out, err := npmInstall.CombinedOutput()
-	require.NoError(t, err, "npm install failed: %s", string(out))
+	// Report ctx.Err() alongside the output: npm prints its success summary even
+	// when it is killed part-way, so the output alone is actively misleading.
+	require.NoError(t, err, "npm install failed (ctx err: %v): %s", ctx.Err(), string(out))
 
 	// Build a fake old version binary and replace the one in node_modules
 	platformPkg := npmPlatformPackage()
@@ -141,10 +168,12 @@ func TestUpdateNPMInstall(t *testing.T) {
 	// The update should always use `npm install -g` regardless of local/global context.
 	cmd := exec.CommandContext(ctx, nmBinaryPath, "update", "--non-interactive")
 	cmd.Dir = projectDir
+	// Same grandchild reasoning as the install above: this shells out to npm.
+	cmd.WaitDelay = 10 * time.Second
 	stdout, err := cmd.CombinedOutput()
 	stdoutStr := string(stdout)
 
-	require.NoError(t, err, "lstk update failed: %s", stdoutStr)
+	require.NoError(t, err, "lstk update failed (ctx err: %v): %s", ctx.Err(), stdoutStr)
 	requireExitCode(t, 0, err)
 	assert.Contains(t, stdoutStr, "npm install -g", "should always use global install")
 	assert.Contains(t, stdoutStr, "Updated to", "should complete the update")


### PR DESCRIPTION
## Motivation

`TestUpdateNPMInstall` is failing on `main`, on **both** the Windows and the ubuntu runners. The two report it very differently, which is what made it look like a registry problem.

Windows — npm claims success, process exits 1:

```
=== FAIL: . TestUpdateNPMInstall (168.29s)
    Messages: npm install failed:
              added 2 packages, and audited 3 packages in 2m
              found 0 vulnerabilities
```

Ubuntu — the smoking gun, killed at exactly the deadline with no output:

```
=== FAIL: . TestUpdateNPMInstall (120.01s)
    Error: signal: killed
    Messages: npm install failed:
```

It is a timeout, not an npm error. The test runs on the shared `testContext(t)` — **2 minutes** — and nearly all of that goes into the `npm install` from the registry, a cost set by the registry rather than by the test.

How long it takes when it passes (`windows-latest`, last six green `main` runs):

| run | duration |
|---|---|
| 33663720068 | 19.18s |
| 33661716590 | **81.30s** |
| 33659332647 | 21.38s |
| 33636690396 | 21.62s |
| 33608951873 | 35.86s |
| 33382161264 | 62.11s |

So normally 19-81s — but on a slow day the install alone stretches past two minutes (one failing run's npm reported `in 3m`), and the 2-minute budget turns that into a red build. Ubuntu's `120.01s` duration is exactly the context deadline, which is the clearest confirmation available.

The Windows signature is misleading for a specific reason: `npm` there is a `.cmd` wrapper around `node`, so `exec.CommandContext` kills the wrapper while the `node` grandchild keeps going, finishes, and writes its success summary into the still-open pipe. On Linux `npm` is a real exec, so the kill surfaces honestly as `signal: killed`.

## Solution

- Give the test its own **5-minute** context instead of `testContext`, following the existing precedent in `sam_e2e_test.go` and `license_test.go` (both opt out with a comment for the same class of reason). That is ~3.7x the slowest observed passing run and still clears the ~3m slow-registry outlier, so the budget stops being the thing that fails without letting a genuinely hung install sit for ages.
- `--no-audit --no-fund` on the local install — small next to the download, but free.
- Set `cmd.WaitDelay` on both npm-spawning execs, so a deadline kill can't leave `CombinedOutput` blocked on a grandchild holding the pipe (the DEVX-846 lesson, already documented in CLAUDE.md).
- Include `ctx.Err()` in both failure messages, so the next timeout says "context deadline exceeded" instead of impersonating an npm failure. This is what made the original diagnosis slow.

Test-only change; no production code touched.

## Manual testing

The test skips when `lstk` is on `PATH` (`npm install -g` would collide), and forcing it to run installs `@localstack/lstk` globally, so I did not run it end to end locally. Sizing came from the CI durations above instead. Locally I timed the individual phases in throwaway dirs (global install into a temp `--prefix`) to confirm which one dominates:

```bash
npm install @localstack/lstk                             # slow path: the download
npm install --no-audit --no-fund @localstack/lstk        # 1s once cached
npm install -g --prefix "$(mktemp -d)" @localstack/lstk  # 1s — reuses that cache
```

The last line is the useful one: the `npm install -g` inside `lstk update` is **not** a second slow install, it reuses the cache the first one filled. Only one phase is expensive.

CI on this PR is the real verification — the `Integration Tests (windows-latest)` and `Integration Tests (ubuntu-latest)` jobs, both of which fail on `main` today.

<details>
<summary>Docs</summary>

Nothing to document — test-infrastructure only. No user-facing command, flag, env var, or behavior changes.

</details>

## Review

Human review advised — the diagnosis is worth a second pair of eyes even though the change is test-only, since the 5-minute budget is a judgement call.

Closes DEVX-1108
