### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -23,7 +23,7 @@ jobs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0
@@ -61,7 +61,7 @@ jobs:
       bump: ${{ steps.bump.outputs.bump }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version-file: .tool-versions
 
@@ -53,14 +53,14 @@ jobs:
       security-events: write # upload SARIF to code scanning
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # SARIF report for the Security tab; never fails the job (gate steps
       # below own pass/fail). repo-checkout: false everywhere: the action's
       # default checkout (with git clean) would delete a prior step's *.sarif
       # file before the upload step can read it.
       - name: Run govulncheck (root module, SARIF report)
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
           repo-checkout: false
           go-version-file: go.mod
@@ -68,7 +68,7 @@ jobs:
           output-file: govulncheck-root.sarif
 
       - name: Run govulncheck (test/integration module, SARIF report)
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
           repo-checkout: false
           work-dir: test/integration
@@ -80,14 +80,14 @@ jobs:
       # (the scan + gate still run).
       - name: Upload SARIF (root module)
         if: always() && github.event.pull_request.head.repo.fork != true
-        uses: github/codeql-action/upload-sarif@v4.37.9
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: govulncheck-root.sarif
           category: govulncheck-root
 
       - name: Upload SARIF (test/integration module)
         if: always() && github.event.pull_request.head.repo.fork != true
-        uses: github/codeql-action/upload-sarif@v4.37.9
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: govulncheck-integration.sarif
           category: govulncheck-integration
@@ -95,13 +95,13 @@ jobs:
       # The blocking gate: fails on any known vulnerability reachable from the
       # repo's own code.
       - name: Run govulncheck (root module, gate)
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
           repo-checkout: false
           go-version-file: go.mod
 
       - name: Run govulncheck (test/integration module, gate)
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
           repo-checkout: false
           work-dir: test/integration
@@ -113,10 +113,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run GoReleaser check
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -128,10 +128,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -142,14 +142,14 @@ jobs:
           CREATE_JUNIT_REPORT: "true"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: unit-test-results
           path: test-results.xml
 
       - name: Test report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()
         with:
           name: Unit Test Results
@@ -180,10 +180,10 @@ jobs:
           - os: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: |
@@ -201,13 +201,13 @@ jobs:
       # skip automatically wherever the binaries are absent (macOS/Windows).
       - name: Install Terraform
         if: matrix.os == 'ubuntu-latest'
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
 
       - name: Install OpenTofu
         if: matrix.os == 'ubuntu-latest'
-        uses: opentofu/setup-opentofu@v2
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
         with:
           tofu_wrapper: false
 
@@ -227,7 +227,7 @@ jobs:
       # SAM >= 1.95.0; the latest release satisfies that.
       - name: Install AWS SAM CLI
         if: matrix.os == 'ubuntu-latest'
-        uses: aws-actions/setup-sam@v3
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
 
@@ -242,14 +242,14 @@ jobs:
           SHARD_TOTAL: ${{ matrix.shard_total }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: integration-test-results-${{ matrix.os }}${{ matrix.shard && format('-{0}', matrix.shard) || '' }}
           path: test-integration-results.xml
 
       - name: Test report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()
         with:
           name: Integration Test Results (${{ matrix.os }}${{ matrix.shard && format(' shard {0}/{1}', matrix.shard, matrix.shard_total) || '' }})
@@ -277,10 +277,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
 
@@ -302,12 +302,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -320,7 +320,7 @@ jobs:
           fi
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -330,7 +330,7 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.release_ref }}
           fetch-depth: 0

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Create Linear release
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@53ad0f863963e7f8e270fba18426bbb55ef55384 # v0.17.2
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   sync-labels:
-    uses: localstack/meta/.github/workflows/sync-labels.yml@83b4ff2ee4169d58eeb35bfa6dcddf9f35388212 # main
+    uses: localstack/meta/.github/workflows/sync-labels.yml@83b4ff2ee4169d58eeb35bfa6dcddf9f35388212 # main @ 2026-04-22
     with:
       categories: docs
     secrets:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,13 +33,13 @@ jobs:
       security-events: write # upload SARIF to code scanning
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # SARIF report for the Security tab covers all severities and never fails
       # the job (the gate below owns pass/fail). trivy-action ignores severity
       # filters when format is sarif, so this cannot double as the gate.
       - name: Run Trivy (SARIF report)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: vuln
@@ -50,13 +50,13 @@ jobs:
       # (the scan + gate still run).
       - name: Upload SARIF to code scanning
         if: always() && github.event.pull_request.head.repo.fork != true
-        uses: github/codeql-action/upload-sarif@v4.37.9
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: trivy-results.sarif
 
       # The blocking gate: fail only on fixable CRITICAL/HIGH vulnerabilities.
       - name: Run Trivy (fixable CRITICAL/HIGH gate)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: vuln
@@ -79,10 +79,10 @@ jobs:
       security-events: write # upload SARIF to code scanning
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run Trivy (all severities)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: vuln
@@ -90,6 +90,6 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@v4.37.9
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/weekly-go-upgrade.yml
+++ b/.github/workflows/weekly-go-upgrade.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
           check-latest: true
@@ -32,7 +32,7 @@ jobs:
           go mod tidy
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/weekly-go-upgrade
           author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"


### PR DESCRIPTION
## Motivation

Mutable tags (`@v7`, `@v1`) let an upstream retag change what runs in CI — including the workflows holding `PRO_ACCESS_TOKEN`, `NPM_AUTH_TOKEN`, and the release path. `enforce-labels.yml` and `sync-labels.yml` were already pinned (#307); this finishes the rest.

## Solution

All 45 external `uses:` refs across 6 workflows pinned to full commit SHAs with a `# vX.Y.Z` comment.

Each SHA is the commit the tag pointed at when this branch was cut (`gh api repos/<owner>/<repo>/commits/<tag>`), so nothing upstream is adopted here — no behavior change. `aws-actions/setup-sam` publishes only major tags, hence its bare `# v3`. Dependabot bumps SHA and comment together. The 3 local `./.github/...` refs stay unpinned.

Also corrects one misleading pre-existing comment: `sync-labels.yml`'s pin read `# main`, which claims to track a branch that has since moved 8 commits ahead. `localstack/meta` publishes no tags, so it now reads `# main @ 2026-04-22` — the branch and the date it was pinned from. The commit is unchanged, and the reusable workflow we consume hasn't changed since.

## Verification

`git diff -U0` shows only `uses:` lines changed; no external ref lacks a 40-char SHA; all workflows still parse. CI on this PR is the real check.

## Docs

<details>
<summary>Nothing to document.</summary>

CI-only change — no user-facing behavior, flags, config, or output.
</details>

## Review

Self-merge candidate. Every line is a tag-to-SHA swap a reviewer can verify with `gh api repos/<owner>/<repo>/commits/<tag>`.

Closes DEVX-978

Co-Authored-By: Claude <noreply@anthropic.com>
