### PR TITLE
Remove deprecated homebrew_casks.url.verified from goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,8 +61,6 @@ homebrew_casks:
     homepage: https://github.com/localstack/lstk
     description: "LocalStack CLI v2 - Start and manage LocalStack emulators"
     license: Apache-2.0
-    url:
-      verified: github.com/localstack/lstk
     completions:
       bash: completions/lstk.bash
       zsh: completions/lstk.zsh


### PR DESCRIPTION
.goreleaser.yaml had `homebrew_casks.url.verified`, a config field Homebrew and GoReleaser both deprecated. goreleaser check now fails hard on deprecated fields instead of just warning ([example](https://github.com/localstack/lstk/actions/runs/34105197383/job/101688497682)).

Removed the `url: verified:` block. It had already stopped affecting the published Cask since GoReleaser 2.18.1, so this only silences the check, it changes no release behavior.

Resolves DEVX-1111