### PR TITLE
Enable major version release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,8 +314,8 @@ jobs:
 
       - name: Validate version tag
         run: |
-          if [[ ! "${GITHUB_REF_NAME}" =~ ^v0\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Tag '${GITHUB_REF_NAME}' does not match version format v0.minor.patch"
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag '${GITHUB_REF_NAME}' does not match version format vmajor.minor.patch"
             exit 1
           fi
 


### PR DESCRIPTION
Widen ci.yml's release-tag check from v0.x.y-only to any vX.Y.Z, so a v1.0.0 tag can actually publish.

This enables today's v1.0.0 release 📦 
Towards DEVX-1105