### PR TITLE
Track test/integration go.mod in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,24 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "gomod"
+    directory: "/test/integration"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "semver: patch"
+      - "docs: skip"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot only watched the root module, so shared dependencies (moby, otel, testify) could get bumped in go.mod without test/integration's pinned versions following, breaking test-integration with "go: updates to go.mod needed" (see PR #487).

Resolves DEVX-1117