### PR TITLE
Skip release and integration workflows in forks

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -18,6 +18,9 @@ concurrency:
 jobs:
   check-changes:
     name: Check for changes since last release
+    # Root of the release graph: every other job needs it, so one guard keeps a
+    # fork's scheduled or dispatched run from tagging or releasing.
+    if: github.repository == 'localstack/lstk'
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,10 @@ jobs:
 
   test-integration:
     name: Integration Tests (${{ matrix.os }}${{ matrix.shard && format(' shard {0}/{1}', matrix.shard, matrix.shard_total) || '' }})
+    # A fork has no LOCALSTACK_AUTH_TOKEN, so the suite can only fail there.
+    # Not the fork-PR guard the SARIF uploads use: skipping a matrix job may
+    # never report the per-OS check runs that branch protection requires.
+    if: github.repository == 'localstack/lstk'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -262,7 +266,7 @@ jobs:
     name: Integration Tests (ubuntu-latest)
     runs-on: ubuntu-latest
     needs: test-integration
-    if: always()
+    if: always() && github.repository == 'localstack/lstk'
     timeout-minutes: 5
     steps:
       - name: Verify integration matrix succeeded
@@ -289,7 +293,10 @@ jobs:
 
   release:
     name: Build and Publish Release
-    if: startsWith(github.ref, 'refs/tags/')
+    # `needs: test-integration` already blocks a fork today, but a fork with its
+    # own auth token would cut a real release -- goreleaser uploads it before the
+    # cask push fails on the empty tap token.
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'localstack/lstk'
     needs:
       - lint
       - goreleaser-check

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -25,6 +25,8 @@ concurrency:
 jobs:
   create-tag:
     name: Create next tag
+    # Pushes a tag, which triggers the publishing workflows.
+    if: github.repository == 'localstack/lstk'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   linear-release:
     name: Create Linear release
+    # Same tag trigger as ci.yml's release job: never run for a fork's own tags.
+    if: github.repository == 'localstack/lstk'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,8 @@ When `DOCKER_HOST` isn't set, `DockerRuntime` resolves the daemon endpoint in or
 
 Releases are automated: a weekly workflow (`.github/workflows/automated-release.yml` → `create-release-tag.yml`) tags and publishes via goreleaser, deriving the version bump from merged PRs' `semver:` labels. See `docs/RELEASING.md`.
 
+Every workflow that tags or publishes (`ci.yml`'s `release`, `linear-release.yml`, `automated-release.yml`, `create-release-tag.yml`) carries `if: github.repository == 'localstack/lstk'`. A fork's `GITHUB_TOKEN` is populated, so a fork supplying its own auth token could otherwise cut a real release from a `v*.*.*` tag (without one, `ci.yml`'s `needs: test-integration` is what blocks it). Add the guard to any new workflow that tags or publishes.
+
 # Logging
 
 lstk always writes diagnostic logs to `$CONFIG_DIR/lstk.log` (appends across runs, cleared at 1 MB). Two log levels: `Info` and `Error`.


### PR DESCRIPTION
## Motivation

A fork with Actions enabled runs our tag and release workflows against its own repository. They fail on empty secrets — but a `v*.*.*` tag pushed in a fork gets far enough for goreleaser to cut a real GitHub release there, since a fork's `GITHUB_TOKEN` is populated and only the Homebrew tap push fails. The integration suite can likewise only ever fail in a fork, because `LOCALSTACK_AUTH_TOKEN` is never present.

## Solution

`if: github.repository == 'localstack/lstk'` on the five jobs that tag, publish, or run the integration suite. The guard is constant-true in this repo on every trigger — including the `workflow_call` from `automated-release.yml` — so upstream CI is unchanged; only a fork's own runs skip.

Repository-scoped rather than the `head.repo.fork` guard the SARIF (Static Analysis Results Interchange Format) uploads use: `test-integration`'s per-OS job names are required status checks, and skipping a matrix job may never report them, which would leave a fork PR unmergeable rather than merely red. Fork PRs into this repo are unaffected — `github.repository` is the base repo there, so the suite still runs and still fails on the missing token.

<details>
<summary>Docs</summary>

Nothing user-facing — CI configuration only. One paragraph added to CLAUDE.md's Release Process section so a future tag/publish workflow picks up the guard.

</details>

## Review

Human review advised — touches four release-pipeline workflows. Verified by inspection and `actionlint`; not exercised against a real fork (requires merging into main first).

## Related

Resolves DEVX-1100
