### PR TITLE
Trial: observe CI behavior on a fork PR (do not merge)

### DIFF
--- a/docs/container-runtimes.md
+++ b/docs/container-runtimes.md
@@ -1,6 +1,6 @@
 # Container runtimes
 
-`lstk` runs the LocalStack emulator as a container, so it needs a Docker-API-compatible runtime to talk to. It works with Docker Desktop, Rancher Desktop, Colima, OrbStack, Lima, and Podman — no extra flags needed in most cases.
+`lstk` runs the LocalStack emulator as a container, so it needs a Docker-API-compatible runtime to talk to. It works with Docker Desktop, Rancher Desktop, Colima, OrbStack, Lima, and Podman — with no extra flags needed in most cases.
 
 ## How lstk finds your runtime
 


### PR DESCRIPTION
Throwaway draft PR from a personal fork (`joe4dev/lstk`) to empirically verify how CI behaves on fork PRs after #494.

Expected, per #494's analysis: `github.repository` is the base repo on a fork PR, so the new guards do **not** fire here — the integration matrix still runs and still fails on the absent `LOCALSTACK_AUTH_TOKEN`.

Will be closed once the run is observed. The diff is a one-word doc tweak.